### PR TITLE
fix requiring 'config/application' at template

### DIFF
--- a/pakyow-core/lib/generators/pakyow/app/templates/config.ru
+++ b/pakyow-core/lib/generators/pakyow/app/templates/config.ru
@@ -1,4 +1,4 @@
-require 'config/application'
+require File.expand_path('../config/application', __FILE__)
 PakyowApplication::Application.stage(:development)
 
 app = Rack::Builder.new do

--- a/pakyow-core/lib/generators/pakyow/app/templates/rakefile
+++ b/pakyow-core/lib/generators/pakyow/app/templates/rakefile
@@ -1,5 +1,5 @@
 env = ARGV[1] || 'development'
 env = env.split('=')[1] || env
 
-require 'config/application'
+require File.expand_path('../config/application', __FILE__)
 PakyowApplication::Application.stage(env.to_sym)


### PR DESCRIPTION
I created an application by 'pakyow new' and run by rackup:

```
$ pakyow new myapp
$ cd myapp
$ rackup config.ru
```

Then the error occurred:

```
in `require': no such file to load -- config/application (LoadError)
```

I fixed it by this patch.
