### PR TITLE
fix requiring to use File.expand_path

### DIFF
--- a/pakyow-presenter/test/helper.rb
+++ b/pakyow-presenter/test/helper.rb
@@ -3,5 +3,5 @@ require 'test/unit'
 require 'pp'
 require 'shoulda'
 
-require '../pakyow-core/lib/pakyow-core'
+require File.expand_path('../../../pakyow-core/lib/pakyow-core', __FILE__)
 require 'pakyow-presenter'


### PR DESCRIPTION
I have changed to use absolute path instead relative path for require.
