### PR TITLE
HTTP Server Shutdown on Interrupt and Terminate Signals

### DIFF
--- a/pakyow-core/lib/core/application.rb
+++ b/pakyow-core/lib/core/application.rb
@@ -23,6 +23,7 @@ module Pakyow
         self.builder.run(self.prepare(args))
         detect_handler.run(builder, :Host => Pakyow::Configuration::Base.server.host, :Port => Pakyow::Configuration::Base.server.port) do |server|
           trap(:INT) { stop(server) }
+          trap(:TERM) { stop(server) }
         end
       end
 
@@ -137,8 +138,8 @@ module Pakyow
       end
 
       def stop(server)
-        if server.respond_to?('shutdown')
-          server.shutdown
+        if server.respond_to?('stop!')
+          server.stop!
         elsif server.respond_to?('stop')
           server.stop
         else


### PR DESCRIPTION
I added a method to shut down the HTTP server gracefully when a Ctrl+C is received after calling 'pakyow server'. This removes the need for having to use 'kill -9 {pid}' while developing.

I manually tested it with thin, mongrel, and WEBrick, but there is also a case for future (unknown) server types.

Handles both :INT and :TERM.

This is a reissue of pull request #41 to the release branch.
