### PR TITLE
Implementation of the at_path method for View

### DIFF
--- a/pakyow-presenter/lib/presenter/view_lookup_store.rb
+++ b/pakyow-presenter/lib/presenter/view_lookup_store.rb
@@ -169,6 +169,10 @@ module Pakyow
       def real_path(abstract_path)
         @view_store[:abstract_paths][abstract_path][:real_path] if @view_store[:abstract_paths][abstract_path]
       end
+
+      def root_path(abstract_path)
+        @view_store[:view_dirs][abstract_path][:root_view] if @view_store[:view_dirs][abstract_path]
+      end
       
       private
 


### PR DESCRIPTION
It takes an abstract path and compiles the view for that path.

Also includes a root_path convenience method on view_lookup_store to make it easier to get the root view of an abstract path.
