### PR TITLE
Prevent generator from overwriting occupied directories

### DIFF
--- a/pakyow-core/lib/generators/pakyow/app/app_generator.rb
+++ b/pakyow-core/lib/generators/pakyow/app/app_generator.rb
@@ -20,7 +20,16 @@ module Pakyow
       end
       
       def build(dest)
-        FileUtils.cp_r(@src, dest)
+        if !File.directory?(dest) || (Dir.entries(dest) - ['.', '..']).empty?
+          FileUtils.cp_r(@src, dest)
+        else
+          ARGV.clear
+          print "The folder '#{dest}' is in use. Would you like to populate it anyway? [Yn] "
+
+          if gets.chomp! == 'Y'
+            FileUtils.cp_r(@src, dest)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
In its current state, the generator can end up overwriting an entire project. I worked around this by checking if the directory exists or is occupied. Also, running `pakyow new` without any arguments displays the usage for that option rather than raising a TypeError.
