### PR TITLE
Ignore routes in prototype mode

### DIFF
--- a/pakyow-core/lib/core/app.rb
+++ b/pakyow-core/lib/core/app.rb
@@ -226,15 +226,13 @@ module Pakyow
 
       @found = false
       catch(:halt) {
-        unless config.app.ignore_routes
-          call_stack(:before, :route)
+        call_stack(:before, :route)
 
-          @found = @router.perform(@request, self) {
-            call_stack(:after, :match)
-          }
+        @found = @router.perform(@request, self) {
+          call_stack(:after, :match)
+        }
 
-          call_stack(:after, :route)
-        end
+        call_stack(:after, :route)
 
         unless found?
           handle(404, false) 
@@ -409,7 +407,7 @@ module Pakyow
       @router = Router.instance.reset
       self.class.routes.each_pair {|set_name, block|
         @router.set(set_name, &block)
-      }
+      } unless config.app.ignore_routes
     end
 
     def set_cookies


### PR DESCRIPTION
Prototype mode currently returns only 404s because the path is never given an opportunity to match.  Since `pakyow server` works as a prototype mode until the back-end is supplied, prototype mode can be achieved by simply ignoring routes when they are loaded.
