### PR TITLE
improves app generator bundle install

### DIFF
--- a/lib/generators/pakyow/app/app_generator.rb
+++ b/lib/generators/pakyow/app/app_generator.rb
@@ -38,7 +38,7 @@ module Pakyow
         end
 
         exec
-        puts "Done!"
+        puts "Done! Run `cd #{@dest}; pakyow server` to get started!"
       end
 
       protected
@@ -50,8 +50,10 @@ module Pakyow
 
       # performs and other setup (e.g. bundle install)
       def exec
-        puts "Running `bundle install`"
-        `cd #{@dest} && bundle install`
+        FileUtils.cd(@dest) do
+          puts "Running `bundle install` in #{Dir.pwd}"
+          system("bundle install")
+        end
       end
     end
   end


### PR DESCRIPTION
Using backticks doesn't send the output of `bundle install` to the current standard out, so using `system` instead. I like seeing what `bundle install` is doing, and guess others do too. Also, `FileUtils.cd` with a block will cd to the directory to run the commands in the block, then return to original directory.

Also, friendlier done message with hint to next step.
