### PR TITLE
Don't prints styles into text emails

### DIFF
--- a/pakyow-mailer/lib/mailer/mailer.rb
+++ b/pakyow-mailer/lib/mailer/mailer.rb
@@ -55,8 +55,8 @@ module Pakyow
             Pakyow.logger.warn "#{w[:message]} (#{w[:level]}) may not render properly in #{w[:clients]}"
           end
 
-          @processed_content[:html] = @premailer.to_inline_css
           @processed_content[:text] = @content || @premailer.to_plain_text
+          @processed_content[:html] = @premailer.to_inline_css
         else
           @processed_content[:text] = @content
         end


### PR DESCRIPTION
This is related to the following issue in premailer:

https://github.com/premailer/premailer/issues/201

I noticed this was happening in a project I was working on.  It turns out the fix is pretty simple, you just need to render the plain text version first.  

Before change:
![screenshot 2015-04-10 16 10 55](https://cloud.githubusercontent.com/assets/41271/7097568/7137d984-df9c-11e4-8d83-505e79f63f79.png)

After change:
![screenshot 2015-04-10 16 11 39](https://cloud.githubusercontent.com/assets/41271/7097572/775c6dfc-df9c-11e4-98aa-ee3bb44eaff1.png)

Go Pakyow!