### PR TITLE
Issue #73 Possible Bug in Reloading

### DIFF
--- a/pakyow-core/lib/core/app.rb
+++ b/pakyow-core/lib/core/app.rb
@@ -411,7 +411,7 @@ module Pakyow
       call_stack(:before, :load)
 
       # load src files
-      @loader = Loader.new
+      @loader ||= Loader.new
       @loader.load_from_path(config.app.src_dir)
 
       # load the routes


### PR DESCRIPTION
Use current loader or new loader
This fix allows for intended use of loader to only load files that have
been changed since the last time they were loaded.