### PR TITLE
Issue 76

### DIFF
--- a/pakyow-core/lib/core/router.rb
+++ b/pakyow-core/lib/core/router.rb
@@ -116,8 +116,8 @@ module Pakyow
       method = request.method
 
       match, data = nil
-      @sets.each { |set|
-        match, data = set[1].match(path, method)
+      @sets.values.each { |set|
+        match, data = set.match(path, method)
         break if match
       }
 

--- a/pakyow-core/lib/core/router.rb
+++ b/pakyow-core/lib/core/router.rb
@@ -116,8 +116,8 @@ module Pakyow
       method = request.method
 
       match, data = nil
-      @sets.values.each { |set|
-        match, data = set.match(path, method)
+      @sets.each { |set|
+        match, data = set[1].match(path, method)
         break if match
       }
 

--- a/pakyow-ui/README.md
+++ b/pakyow-ui/README.md
@@ -151,6 +151,16 @@ Notice that we're mutating with the data from our mutable user. Pakyow will
 fetch the data using the `all` query and pass it to the `list` mutation where
 the view is rendered.
 
+***NOTE:*** One important cavaeat here is that the individual data passed to the mutate method needs to respond to the `to_hash` method, which should return a hash of all relevant attributes. E.g. For ActiveRecord models could define `to_hash` like this:
+
+```
+class User < ActiveRecord::Base
+  def to_hash
+    attributes
+  end
+end
+```
+
 At this point we've effectively turned view rendering into a declarative thing
 from the route's point of view. We only have to describe what happens and Pakyow
 takes care of the rest.

--- a/pakyow-ui/lib/pakyow-ui/mutable.rb
+++ b/pakyow-ui/lib/pakyow-ui/mutable.rb
@@ -34,10 +34,11 @@ module Pakyow
 
       def method_missing(method, *args)
         if action = @actions[method]
-          action[:block].call(*args)
+          result = action[:block].call(*args)
           if action[:mutation]
             @context.ui.mutated(@scope)
           end
+          result
         elsif query = @queries[method]
           MutableData.new(query, method, args, @scope)
         else

--- a/pakyow-ui/lib/pakyow-ui/ui_view.rb
+++ b/pakyow-ui/lib/pakyow-ui/ui_view.rb
@@ -206,9 +206,10 @@ module Pakyow
       private
 
       def mixin_bindings(data, bindings = {})
-        data.map { |datum|
+        data.map { |bindable|
+          datum = bindable.to_hash
           Binder.instance.bindings_for_scope(scoped_as, bindings).keys.each do |key|
-            datum[key] = Binder.instance.value_for_scoped_prop(scoped_as, key, datum, bindings, self)
+            datum[key] = Binder.instance.value_for_scoped_prop(scoped_as, key, bindable, bindings, self)
           end
 
           datum


### PR DESCRIPTION
To address the two points in issue 76:

1. mixin_bindings calls `to_hash` on data, but continues to send the original object to the binder.
2. Result of the mutable action block is returned from method_missing when an action is called.

Also added a short note about the expectation for data to respond to `to_hash` in the Readme.