### PR TITLE
Ability to set env params on simulated requests

### DIFF
--- a/pakyow-test/lib/test_help/helpers.rb
+++ b/pakyow-test/lib/test_help/helpers.rb
@@ -3,13 +3,14 @@ require_relative 'simulator'
 module Pakyow
   module TestHelp
     module Helpers
-      def simulate(name_or_path, method: :get, with: {}, session: {}, cookies: {}, &block)
+      def simulate(name_or_path, method: :get, with: {}, session: {}, cookies: {}, env: {}, &block)
         sim = Pakyow::TestHelp::Simulator.new(
           name_or_path,
           method: method,
           params: with,
           session: session,
-          cookies: cookies
+          cookies: cookies,
+          env: env
         )
 
         sim.run(&block)

--- a/pakyow-test/lib/test_help/simulator.rb
+++ b/pakyow-test/lib/test_help/simulator.rb
@@ -5,7 +5,7 @@ module Pakyow
     class Simulator
       attr_reader :env, :path, :method, :params
 
-      def initialize(name_or_path, method: :get, params: {}, session: {}, cookies: {})
+      def initialize(name_or_path, method: :get, params: {}, session: {}, cookies: {}, env: {})
         @path   = router.path(name_or_path, params)
         @method = method
         @params = params
@@ -18,7 +18,7 @@ module Pakyow
           'rack.request.cookie_hash'  => cookies,
           'rack.input'                => StringIO.new,
           'pakyow.params'             => @params
-        }
+        }.merge(Hash[env.map{ |k,v| [k.to_s, v] }])
       end
 
       def run(&block)

--- a/pakyow-test/spec/integration/routing_spec.rb
+++ b/pakyow-test/spec/integration/routing_spec.rb
@@ -108,4 +108,12 @@ context 'when testing a route' do
       end
     end
   end
+
+  context 'with env params', :env do
+    it 'recognizes the env params' do
+      get :default, env: { foo: 'bar' } do |sim|
+        expect(sim.req.env['foo']).to eq('bar')
+      end
+    end
+  end
 end

--- a/pakyow-test/spec/unit/helpers_spec.rb
+++ b/pakyow-test/spec/unit/helpers_spec.rb
@@ -35,7 +35,11 @@ describe Pakyow::TestHelp::Helpers do
       { user: 2 }
     end
 
-    it 'creates and runs the simulator with name, method, params, session, and cookies' do
+    let :env do
+      { bar: 'foo' }
+    end
+
+    it 'creates and runs the simulator with name, method, params, session, cookies, and env' do
       expect(simulation).to receive(:run)
 
       expect(Pakyow::TestHelp::Simulator).to receive(:new).with(
@@ -43,7 +47,8 @@ describe Pakyow::TestHelp::Helpers do
         method: method,
         params: with,
         session: session,
-        cookies: cookies
+        cookies: cookies,
+        env: env
       ).and_return(simulation)
 
       instance.simulate(
@@ -51,7 +56,8 @@ describe Pakyow::TestHelp::Helpers do
         method: method,
         with: with,
         session: session,
-        cookies: cookies
+        cookies: cookies,
+        env: env
       )
     end
   end

--- a/pakyow-test/spec/unit/simulator_spec.rb
+++ b/pakyow-test/spec/unit/simulator_spec.rb
@@ -8,7 +8,8 @@ describe Pakyow::TestHelp::Simulator do
       method: method,
       params: params,
       session: session,
-      cookies: cookies
+      cookies: cookies,
+      env: env
     )
   end
 
@@ -30,6 +31,10 @@ describe Pakyow::TestHelp::Simulator do
 
   let :cookies do
     { user: 2 }
+  end
+
+  let :env do
+    { bar: 'foo' }
   end
 
   describe 'initialization' do
@@ -60,6 +65,10 @@ describe Pakyow::TestHelp::Simulator do
 
       it 'contains rack.request.cookie_hash' do
         expect(simulator.env['rack.request.cookie_hash']).to eq(cookies)
+      end
+
+      it 'contains rack.request.env' do
+        expect(simulator.env['bar']).to eq('foo')
       end
 
       it 'contains rack.input' do


### PR DESCRIPTION
Adds the ability to specify the `env` configs you want to include in your simulated requests. It follows the same pattern as `params`, `cookies`, etc...

```
get '/', env: { foo: 'bar' } do |sim|
  puts sim.req.env['foo'] # => 'bar'
end
```

Tests are included.