### PR TITLE
App Refactor

### DIFF
--- a/pakyow-core/lib/core/helpers/configuring.rb
+++ b/pakyow-core/lib/core/helpers/configuring.rb
@@ -1,0 +1,87 @@
+module Pakyow
+  module Helpers
+    # Methods for configuring an app.
+    #
+    # @api public
+    module Configuring
+      # Absolute path to the file containing the app definition.
+      #
+      # @api private
+      attr_reader :path
+
+      # Defines an app
+      #
+      # @api public
+      def define(&block)
+        raise ArgumentError, 'Expected a block' unless block_given?
+
+        # Sets the path to the file containiner the app definition for later reloading.
+        @path = String.parse_path_from_caller(caller[0])
+
+        instance_eval(&block)
+        self
+      end
+
+      # Defines a route set.
+      #
+      # @api public
+      def routes(set_name = :main, &block)
+        return @routes ||= {} unless block_given?
+        routes[set_name] = block
+      end
+
+      # Accepts block to be added to middleware stack.
+      #
+      # @api public
+      def middleware(&block)
+        return @middleware ||= [] unless block_given?
+        middleware << block
+      end
+
+      # Creates an environment.
+      #
+      # @api public
+      def configure(env, &block)
+        raise ArgumentError, 'Expected a block' unless block_given?
+        env_config[env] = block
+      end
+
+      # Configures the app for one or more environment.
+      #
+      # @api private
+      def load_config(*env_or_envs)
+        hook_around :configure do
+          envs = build_envs(env_or_envs)
+
+          config.app.loaded_envs = envs
+          config.env = envs.first
+
+          envs.each do |env|
+            load_env(env)
+          end
+
+          load_env(:global)
+
+          Pakyow.configure_logger
+        end
+      end
+
+      protected
+
+      def env_config
+        @config ||= {}
+      end
+
+      def build_envs(env_or_envs)
+        envs = Array.ensure(env_or_envs)
+        envs = (envs.empty? || envs.first.nil?) ? [config.app.default_environment] : envs
+        envs.map!(&:to_sym)
+      end
+
+      def load_env(env)
+        config.app_config(&env_config.fetch(env))
+      rescue KeyError
+      end
+    end
+  end
+end

--- a/pakyow-core/lib/core/helpers/hooks.rb
+++ b/pakyow-core/lib/core/helpers/hooks.rb
@@ -1,0 +1,61 @@
+module Pakyow
+  module Helpers
+    # Methods to register and call hooks before and after particular triggers.
+    #
+    # @api public
+    module Hooks
+      TRIGGERS = %i(init load process route match error configure)
+
+      # Registers a before hook for a particular trigger.
+      #
+      # @api public
+      def before(trigger, &block)
+        hooks[:before][trigger.to_sym] << block
+      end
+
+      # Registers an after hook for a particular trigger.
+      #
+      # @api public
+      def after(trigger, &block)
+        hooks[:after][trigger.to_sym] << block
+      end
+
+      # Fetches a hook by type (before | after) and trigger.
+      #
+      # @api private
+      def hook(type, trigger)
+        hooks[type.to_sym][trigger.to_sym]
+      end
+
+      protected
+
+      def hooks
+        return @hooks unless @hooks.nil?
+
+        @hooks = {
+          before: {},
+          after: {}
+        }
+
+        TRIGGERS.each do |name|
+          @hooks[:before][name.to_sym] = []
+          @hooks[:after][name.to_sym] = []
+        end
+
+        @hooks
+      end
+
+      def hook_around(trigger)
+        call_hooks :before, trigger
+        yield
+        call_hooks :after, trigger
+      end
+
+      def call_hooks(type, trigger)
+        hook(type, trigger).each do |block|
+          instance_exec(&block)
+        end
+      end
+    end
+  end
+end

--- a/pakyow-core/lib/core/helpers/running.rb
+++ b/pakyow-core/lib/core/helpers/running.rb
@@ -1,15 +1,22 @@
+require 'rack/builder'
+require 'rack/handler'
+
 module Pakyow
   module Helpers
     # Methods run running an app.
     #
     # @api public
     module Running
+      STOP_METHODS = ['stop!', 'stop']
+      HANDLERS = ['puma', 'thin', 'mongrel', 'webrick']
+      SIGNALS = [:INT, :TERM]
+
       # Prepares the app for being staged in one or more environments by
       # loading config(s), middleware, and setting the load path.
       #
       # @api public
       def prepare(*env_or_envs)
-        return if prepared?
+        return true if prepared?
 
         # load config for one or more environments
         load_config(*env_or_envs)
@@ -33,29 +40,30 @@ module Pakyow
       #
       # @api public
       def run(*env_or_envs)
-        return if running?
-
-        @running = true
+        return true if running?
 
         builder.run(stage(*env_or_envs))
         detect_handler.run(builder, Host: config.server.host, Port: config.server.port) do |server|
-          trap(:INT)  { stop(server) }
-          trap(:TERM) { stop(server) }
+          SIGNALS.each do |signal|
+            trap(signal) { stop(server) }
+          end
         end
+
+        @running = true
       end
 
       # Returns true if the application is prepared.
       #
       # @api public
       def prepared?
-        @prepared
+        @prepared == true
       end
 
       # Returns true if the application is running.
       #
       # @api public
       def running?
-        @running
+        @running == true
       end
 
       # Returns true if the application is staged.
@@ -65,34 +73,44 @@ module Pakyow
         !Pakyow.app.nil?
       end
 
-      protected
-
+      # Returns a rack builder instance.
+      #
+      # @api public
       def builder
         @builder ||= Rack::Builder.new
       end
 
+      # Returns an instance of the rack handler.
+      #
+      # @api private
       def detect_handler
-        handlers = ['puma', 'thin', 'mongrel', 'webrick']
-        handlers.unshift(config.server.handler) if config.server.handler
+        if config.server.handler
+          HANDLERS.unshift(config.server.handler).uniq!
+        end
 
-        handlers.each do |handler|
+        HANDLERS.each do |handler_name|
           begin
-            return Rack::Handler.get(handler)
+            handler = Rack::Handler.get(handler_name)
+            return handler unless handler.nil?
           rescue LoadError
           rescue NameError
           end
         end
+
+        raise 'No handler found'
       end
 
+      protected
+
       def stop(server)
-        if server.respond_to?('stop!')
-          server.stop!
-        elsif server.respond_to?('stop')
-          server.stop
-        else
-          # exit ungracefully if necessary...
-          Process.exit!
+        STOP_METHODS.each do |method|
+          if server.respond_to?(method)
+            return server.send(method)
+          end
         end
+
+        # exit ungracefully
+        Process.exit!
       end
 
       def load_middleware

--- a/pakyow-core/lib/core/helpers/running.rb
+++ b/pakyow-core/lib/core/helpers/running.rb
@@ -1,0 +1,105 @@
+module Pakyow
+  module Helpers
+    # Methods run running an app.
+    #
+    # @api public
+    module Running
+      # Prepares the app for being staged in one or more environments by
+      # loading config(s), middleware, and setting the load path.
+      #
+      # @api public
+      def prepare(*env_or_envs)
+        return if prepared?
+
+        # load config for one or more environments
+        load_config(*env_or_envs)
+
+        # load each block from middleware stack
+        load_middleware
+
+        @prepared = true
+      end
+
+      # Stages the app by preparing and returning an instance. This is
+      # essentially everything short of running it.
+      #
+      # @api public
+      def stage(*env_or_envs)
+        prepare(*env_or_envs)
+        self.new
+      end
+
+      # Runs the staged app.
+      #
+      # @api public
+      def run(*env_or_envs)
+        return if running?
+
+        @running = true
+
+        builder.run(stage(*env_or_envs))
+        detect_handler.run(builder, Host: config.server.host, Port: config.server.port) do |server|
+          trap(:INT)  { stop(server) }
+          trap(:TERM) { stop(server) }
+        end
+      end
+
+      # Returns true if the application is prepared.
+      #
+      # @api public
+      def prepared?
+        @prepared
+      end
+
+      # Returns true if the application is running.
+      #
+      # @api public
+      def running?
+        @running
+      end
+
+      # Returns true if the application is staged.
+      #
+      # @api public
+      def staged?
+        !Pakyow.app.nil?
+      end
+
+      protected
+
+      def builder
+        @builder ||= Rack::Builder.new
+      end
+
+      def detect_handler
+        handlers = ['puma', 'thin', 'mongrel', 'webrick']
+        handlers.unshift(config.server.handler) if config.server.handler
+
+        handlers.each do |handler|
+          begin
+            return Rack::Handler.get(handler)
+          rescue LoadError
+          rescue NameError
+          end
+        end
+      end
+
+      def stop(server)
+        if server.respond_to?('stop!')
+          server.stop!
+        elsif server.respond_to?('stop')
+          server.stop
+        else
+          # exit ungracefully if necessary...
+          Process.exit!
+        end
+      end
+
+      def load_middleware
+        middleware.each do |block|
+          instance_exec(builder, &block)
+        end
+      end
+    end
+  end
+end

--- a/pakyow-core/spec/unit/helpers/configuring_spec.rb
+++ b/pakyow-core/spec/unit/helpers/configuring_spec.rb
@@ -1,0 +1,161 @@
+require 'pakyow-support'
+require 'core/helpers/configuring'
+
+module Spec
+  class ConfiguringAppMock
+    extend Pakyow::Helpers::Configuring
+  end
+end
+
+describe Pakyow::Helpers::Configuring do
+  let :mock do
+    Spec::ConfiguringAppMock
+  end
+
+  after do
+    mock.instance_variables.each do |ivar|
+      mock.remove_instance_variable(ivar)
+    end
+  end
+
+  describe '#define' do
+    context 'called with a block' do
+      before do
+        @result = mock.define do
+          @foo = :bar
+        end
+      end
+
+      it 'sets the path to the file defining the app' do
+        expect(mock.path).to eq(__FILE__)
+      end
+
+      it 'evals the block' do
+        expect(mock.instance_variable_get(:@foo)).to eq(:bar)
+      end
+
+      it 'returns the app' do
+        expect(@result).to eq(mock)
+      end
+    end
+
+    context 'called without a block' do
+      it 'raises an argument error' do
+        expect { mock.define }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
+  describe '#routes' do
+    let :block do
+      -> {}
+    end
+
+    context 'called with a name and a block' do
+      let :name do
+        :foo
+      end
+
+      before do
+        mock.routes(name, &block)
+      end
+
+      it 'registers the routes' do
+        expect(mock.routes[name]).to eq(block)
+      end
+    end
+
+    context 'called without a name' do
+      before do
+        mock.routes(&block)
+      end
+
+      it 'assumes the name' do
+        expect(mock.routes.values.last).to eq(block)
+      end
+    end
+
+    context 'called without a block' do
+      before do
+        mock.routes(&block)
+      end
+
+      let :routes do
+        mock.routes
+      end
+
+      it 'returns the registered routes' do
+        expect(routes).to be_instance_of(Hash)
+        expect(routes.keys.first).to eq(:main)
+        expect(routes.values.first).to eq(block)
+      end
+    end
+  end
+
+  describe '#middleware' do
+    let :block do
+      -> {}
+    end
+
+    before do
+      mock.middleware(&block)
+    end
+
+    context 'called with a block' do
+      it 'registers the middleware' do
+        expect(mock.middleware).to include(block)
+      end
+    end
+
+    context 'called without a block' do
+      let :middleware do
+        mock.middleware
+      end
+
+      it 'returns the registered middleware' do
+        expect(middleware).to be_instance_of(Array)
+        expect(middleware.first).to eq(block)
+      end
+    end
+  end
+
+  describe '#configure' do
+    let :config do
+      mock.instance_variable_get(:@config)
+    end
+
+    let :env do
+      :dev
+    end
+
+    let :block do
+      -> {}
+    end
+
+    context 'called with an env name and a block' do
+      before do
+        mock.configure(env, &block)
+      end
+
+      it 'registers the configuration' do
+        expect(config[env]).to eq(block)
+      end
+    end
+
+    context 'called without an env name' do
+      it 'raises an argument error' do
+        expect { mock.configure(&block) }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'called without a block' do
+      it 'raises an argument error' do
+        expect { mock.configure(env) }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
+  describe '#load_config' do
+    # TODO: test this once that part of Pakyow::App is refactored
+  end
+end

--- a/pakyow-core/spec/unit/helpers/configuring_spec.rb
+++ b/pakyow-core/spec/unit/helpers/configuring_spec.rb
@@ -18,7 +18,7 @@ describe Pakyow::Helpers::Configuring do
     end
   end
 
-  describe '#define' do
+  describe '::define' do
     context 'called with a block' do
       before do
         @result = mock.define do
@@ -46,7 +46,7 @@ describe Pakyow::Helpers::Configuring do
     end
   end
 
-  describe '#routes' do
+  describe '::routes' do
     let :block do
       -> {}
     end
@@ -92,7 +92,7 @@ describe Pakyow::Helpers::Configuring do
     end
   end
 
-  describe '#middleware' do
+  describe '::middleware' do
     let :block do
       -> {}
     end
@@ -119,7 +119,7 @@ describe Pakyow::Helpers::Configuring do
     end
   end
 
-  describe '#configure' do
+  describe '::configure' do
     let :config do
       mock.instance_variable_get(:@config)
     end
@@ -155,7 +155,7 @@ describe Pakyow::Helpers::Configuring do
     end
   end
 
-  describe '#load_config' do
+  describe '::load_config' do
     # TODO: test this once that part of Pakyow::App is refactored
   end
 end

--- a/pakyow-core/spec/unit/helpers/hooks_spec.rb
+++ b/pakyow-core/spec/unit/helpers/hooks_spec.rb
@@ -1,3 +1,145 @@
 require 'core/helpers/hooks'
 
-# TODO: write these
+module Spec
+  class HooksAppMock
+    extend Pakyow::Helpers::Hooks
+  end
+end
+
+describe Pakyow::Helpers::Hooks do
+  let :mock do
+    Spec::HooksAppMock
+  end
+
+  let :trigger do
+    Pakyow::Helpers::Hooks::TRIGGERS.first
+  end
+
+  after do
+    mock.instance_variables.each do |ivar|
+      mock.remove_instance_variable(ivar)
+    end
+  end
+
+  describe '::TRIGGERS' do
+    it 'includes `init`' do
+      expect(Pakyow::Helpers::Hooks::TRIGGERS).to include(:init)
+    end
+
+    it 'includes `load`' do
+      expect(Pakyow::Helpers::Hooks::TRIGGERS).to include(:load)
+    end
+
+    it 'includes `process`' do
+      expect(Pakyow::Helpers::Hooks::TRIGGERS).to include(:process)
+    end
+
+    it 'includes `route`' do
+      expect(Pakyow::Helpers::Hooks::TRIGGERS).to include(:route)
+    end
+
+    it 'includes `match`' do
+      expect(Pakyow::Helpers::Hooks::TRIGGERS).to include(:match)
+    end
+
+    it 'includes `error`' do
+      expect(Pakyow::Helpers::Hooks::TRIGGERS).to include(:error)
+    end
+
+    it 'includes `configure`' do
+      expect(Pakyow::Helpers::Hooks::TRIGGERS).to include(:configure)
+    end
+  end
+
+  describe '::before' do
+    context 'called with a valid trigger and block' do
+      let :block do
+        -> {}
+      end
+
+      before do
+        mock.before(trigger, &block)
+      end
+
+      it 'registers the block for trigger' do
+        expect(mock.hook(:before, trigger).first).to be(block)
+      end
+    end
+
+    context 'called with a non-existent trigger and block' do
+      it 'raises an ArgumentError' do
+        expect { mock.before(:foo) {} }.to raise_exception(ArgumentError)
+      end
+    end
+
+    context 'called without a block' do
+      it 'raises an ArgumentError' do
+        expect { mock.before(trigger) }.to raise_exception(ArgumentError)
+      end
+    end
+  end
+
+  describe '::after' do
+    context 'called with a valid trigger and block' do
+      let :block do
+        -> {}
+      end
+
+      before do
+        mock.after(trigger, &block)
+      end
+
+      it 'registers the block for trigger' do
+        expect(mock.hook(:after, trigger).first).to be(block)
+      end
+    end
+
+    context 'called with an invalid trigger and block' do
+      it 'raises an ArgumentError' do
+        expect { mock.after(:foo) {} }.to raise_exception(ArgumentError)
+      end
+    end
+
+    context 'called without a block' do
+      it 'raises an ArgumentError' do
+        expect { mock.after(trigger) }.to raise_exception(ArgumentError)
+      end
+    end
+  end
+
+  describe '::hook' do
+    context 'called with a valid type and trigger' do
+      context 'and a hook is registered' do
+        let :block do
+          -> {}
+        end
+
+        before do
+          mock.before(trigger, &block)
+        end
+
+        it 'returns an Array containing the hook' do
+          expect(mock.hook(:before, trigger)).to eq([block])
+        end
+      end
+
+      context 'and a hook is not registered' do
+        it 'returns an empty Array' do
+          expect(mock.hook(:before, trigger)).to eq([])
+        end
+      end
+    end
+
+    context 'called with an invalid type' do
+      it 'raises an ArgumentError' do
+        expect { mock.hook(:foo, trigger) }.to raise_exception(ArgumentError)
+      end
+    end
+
+    context 'called with an invalid trigger' do
+      it 'raises an ArgumentError' do
+        expect { mock.hook(:before, :foo) }.to raise_exception(ArgumentError)
+      end
+    end
+  end
+end

--- a/pakyow-core/spec/unit/helpers/hooks_spec.rb
+++ b/pakyow-core/spec/unit/helpers/hooks_spec.rb
@@ -1,0 +1,3 @@
+require 'core/helpers/hooks'
+
+# TODO: write these

--- a/pakyow-core/spec/unit/helpers/running_spec.rb
+++ b/pakyow-core/spec/unit/helpers/running_spec.rb
@@ -1,3 +1,367 @@
 require 'core/helpers/running'
 
-# TODO: write these
+module Spec
+  class RunningAppMock
+    extend Pakyow::Helpers::Running
+
+    Struct.new('Config', :server)
+    Struct.new('ServerConfig', :handler, :host, :port)
+
+    MIDDLEWARE = []
+
+    class << self
+      attr_accessor :app
+
+      def handler
+        'mock'
+      end
+
+      def host
+        'localhost'
+      end
+
+      def port
+        4242
+      end
+    end
+
+    def initialize
+      self.class.app = true
+    end
+
+    # FIXME: revisit this after refactoring `load_config`
+    def self.load_config(*); end
+
+    def self.middleware(*)
+      MIDDLEWARE
+    end
+
+    def self.config
+      Struct::Config.new(Struct::ServerConfig.new(handler, host, port))
+    end
+  end
+
+  class HandlerMock
+    def self.run(*)
+    end
+  end
+
+  Rack::Handler.register('mock', HandlerMock)
+end
+
+describe Pakyow::Helpers::Running do
+  let :mock do
+    Spec::RunningAppMock
+  end
+
+  let :env do
+    :mock
+  end
+
+  let :envs do
+    [env, env]
+  end
+
+  before do
+    allow(Pakyow).to receive(:app) { mock.app }
+  end
+
+  after do
+    mock.instance_variables.each do |ivar|
+      mock.remove_instance_variable(ivar)
+    end
+  end
+
+  describe '::STOP_METHODS' do
+    it 'includes `stop!`' do
+      expect(Pakyow::Helpers::Running::STOP_METHODS).to include('stop!')
+    end
+
+    it 'includes `stop`' do
+      expect(Pakyow::Helpers::Running::STOP_METHODS).to include('stop')
+    end
+  end
+
+  describe '::SIGNALS' do
+    it 'includes `INT`' do
+      expect(Pakyow::Helpers::Running::SIGNALS).to include(:INT)
+    end
+
+    it 'includes `TERM`' do
+      expect(Pakyow::Helpers::Running::SIGNALS).to include(:TERM)
+    end
+  end
+
+  describe '::HANDLERS' do
+    it 'includes `puma`' do
+      expect(Pakyow::Helpers::Running::HANDLERS).to include('puma')
+    end
+
+    it 'includes `thin`' do
+      expect(Pakyow::Helpers::Running::HANDLERS).to include('thin')
+    end
+
+    it 'includes `mongrel`' do
+      expect(Pakyow::Helpers::Running::HANDLERS).to include('mongrel')
+    end
+
+    it 'includes `webrick`' do
+      expect(Pakyow::Helpers::Running::HANDLERS).to include('webrick')
+    end
+  end
+
+  describe '::prepare' do
+    it 'calls `load_config` with envs' do
+      expect(mock).to receive(:load_config).with(*envs)
+      mock.prepare(*envs)
+    end
+
+    it 'appears to be prepared' do
+      mock.prepare(*envs)
+      expect(mock.prepared?).to be(true)
+    end
+
+    it 'calls each middleware block in context of `builder`' do
+      block = -> (builder) {}
+      mock::MIDDLEWARE << block
+
+      expect(mock).to receive(:instance_exec).with(mock.builder, &block)
+      mock.prepare(*envs)
+    end
+
+    context 'called when already prepared' do
+      before do
+        allow(mock).to receive(:prepared?).and_return(true)
+      end
+
+      it 'does not call `load_config`' do
+        expect(mock).not_to receive(:load_config)
+        mock.prepare(*envs)
+      end
+
+      it 'does not load middleware' do
+        expect(mock).not_to receive(:load_middleware)
+        mock.prepare(*envs)
+      end
+
+      it 'returns true' do
+        expect(mock.prepare(*envs)).to eq(true)
+      end
+    end
+  end
+
+  describe '::stage' do
+    context 'passed a single env' do
+      it 'prepares with env' do
+        expect(mock).to receive(:prepare).with(env)
+        mock.stage(env)
+      end
+    end
+
+    context 'passed multiple envs' do
+      let :args do
+        [env, env]
+      end
+
+      it 'prepares with envs' do
+        expect(mock).to receive(:prepare).with(*args)
+        mock.stage(*args)
+      end
+    end
+
+    it 'returns instance' do
+      expect(mock.stage).to be_instance_of(mock)
+    end
+  end
+
+  describe '::run' do
+    it 'stages with envs' do
+      expect(mock).to receive(:stage).with(*envs)
+      mock.run(*envs)
+    end
+
+    it 'runs the builder with staged instance' do
+      expect(mock.builder).to receive(:run).with(instance_of(mock))
+      mock.run(*envs)
+    end
+
+    it 'appears to be running' do
+      mock.run(*envs)
+      expect(mock.running?).to be(true)
+    end
+
+    describe 'running the detected handler' do
+      let :handler do
+        double(Rack::Handler)
+      end
+
+      before do
+        allow(mock).to receive(:detect_handler).and_return(handler)
+      end
+
+      after do
+        mock.run(*envs)
+      end
+
+      it 'uses the builder' do
+        expect(handler).to receive(:run).with(mock.builder, anything)
+      end
+
+      it 'sets the Host and Port' do
+        expect(handler).to receive(:run).with(anything, {
+          Host: mock.host,
+          Port: mock.port
+        })
+      end
+
+      it 'traps each signal' do
+        expect(handler).to receive(:run) { |&block|
+          block.call
+        }
+
+        expect(mock).to receive(:trap).with(Pakyow::Helpers::Running::SIGNALS[0])
+        expect(mock).to receive(:trap).with(Pakyow::Helpers::Running::SIGNALS[1])
+      end
+    end
+
+    context 'called when already running' do
+      before do
+        allow(mock).to receive(:running?).and_return(true)
+      end
+
+      it 'does not run builder' do
+        expect(mock.builder).not_to receive(:run)
+        mock.run(*envs)
+      end
+
+      it 'does not try to detect handler' do
+        expect(mock).not_to receive(:detect_handler)
+        mock.run(*envs)
+      end
+
+      it 'returns true' do
+        expect(mock.run(*envs)).to be(true)
+      end
+    end
+  end
+
+  describe '::prepared?' do
+    context 'before `prepare` is called' do
+      it 'returns false' do
+        expect(mock.prepared?).to eq(false)
+      end
+    end
+
+    context 'after `prepare` is called' do
+      before do
+        mock.prepare(env)
+      end
+
+      it 'returns true' do
+        expect(mock.prepared?).to eq(true)
+      end
+    end
+  end
+
+  describe '::running?' do
+    context 'before `run` is called' do
+      it 'returns false' do
+        expect(mock.running?).to eq(false)
+      end
+    end
+
+    context 'after `run` is called' do
+      before do
+        mock.run(env)
+      end
+
+      it 'returns true' do
+        expect(mock.running?).to eq(true)
+      end
+    end
+  end
+
+  describe '::staged?' do
+    context 'before `stage` is called' do
+      it 'returns false' do
+        expect(mock.staged?).to eq(false)
+      end
+    end
+
+    context 'after `stage` is called' do
+      before do
+        mock.stage(env)
+      end
+
+      it 'returns true' do
+        expect(mock.staged?).to eq(true)
+      end
+    end
+  end
+
+  describe '::builder' do
+    it 'returns a rack builder' do
+      expect(mock.builder).to be_instance_of(Rack::Builder)
+    end
+
+    context 'called again' do
+      before do
+        @builder = mock.builder
+      end
+
+      it 'returns the same builder' do
+        expect(mock.builder).to be(@builder)
+      end
+    end
+  end
+
+  describe '::detect_handler' do
+    context 'when there\'s a configured handler' do
+      it 'prepends the configured handler to the list' do
+        mock.detect_handler
+        expect(Pakyow::Helpers::Running::HANDLERS).to include(mock.handler)
+      end
+
+      it 'only adds the configured handler once' do
+        mock.detect_handler
+        mock.detect_handler
+        expect(Pakyow::Helpers::Running::HANDLERS.count(mock.handler)).to eq(1)
+      end
+    end
+
+    it 'tries to get each handler' do
+      Pakyow::Helpers::Running::HANDLERS.each do |handler|
+        expect(Rack::Handler).to receive(:get).with(handler)
+      end
+
+      # we want to clear out all registered handlers
+      Rack::Handler.instance_variable_set(:@handlers, {})
+
+      begin
+        mock.detect_handler
+        # rescue the no handler exception
+      rescue
+      end
+    end
+
+    context 'when a handler exists' do
+      before do
+        Rack::Handler.register('mock', Spec::HandlerMock)
+      end
+
+      it 'returns the handler' do
+        expect(mock.detect_handler).to be(Spec::HandlerMock)
+      end
+    end
+
+    context 'when no handler exists' do
+      before do
+        Rack::Handler.instance_variable_set(:@handlers, {})
+      end
+
+      it 'raises an exception' do
+        expect { mock.detect_handler }.to raise_exception(RuntimeError)
+      end
+    end
+  end
+end

--- a/pakyow-core/spec/unit/helpers/running_spec.rb
+++ b/pakyow-core/spec/unit/helpers/running_spec.rb
@@ -1,0 +1,3 @@
+require 'core/helpers/running'
+
+# TODO: write these

--- a/pakyow-core/spec/unit/helpers/running_spec.rb
+++ b/pakyow-core/spec/unit/helpers/running_spec.rb
@@ -318,13 +318,21 @@ describe Pakyow::Helpers::Running do
   describe '::detect_handler' do
     context 'when there\'s a configured handler' do
       it 'prepends the configured handler to the list' do
-        mock.detect_handler
+        begin
+          mock.detect_handler
+        rescue
+        end
+
         expect(Pakyow::Helpers::Running::HANDLERS).to include(mock.handler)
       end
 
       it 'only adds the configured handler once' do
-        mock.detect_handler
-        mock.detect_handler
+        begin
+          mock.detect_handler
+          mock.detect_handler
+        rescue
+        end
+
         expect(Pakyow::Helpers::Running::HANDLERS.count(mock.handler)).to eq(1)
       end
     end


### PR DESCRIPTION
Pakyow::App has been notoriously hard to test and overly complex from the beginning. This commit is the first step towards improving this part of the codebase.

The decision to move methods out of Pakyow::App into their own modules was driven out of a desire to make the code a) more testable and b) easier to understand. Each concern of the app is now contained in its own module (e.g. configuring).

Everything a developer needs to know is available right there in the module. Because there are no dependencies, the methods around a particular concern can be tested in true isolation.

Because of the scope of this refactor I wanted to open a PR and get input from others.

Next steps include:

- Writing unit tests for `Pakyow::Helpers::Running` and `Pakyow::Helpers::Hooks`
- Removing the need to `dup` when handling a request
- Making `load_config` a private instance method rather than a public class method
- Cleaning up error handling / error presentation

Thanks in advance for your input!