### PR TITLE
Improve output clarity for failed server and console commands

### DIFF
--- a/lib/pakyow/command_line_interface.rb
+++ b/lib/pakyow/command_line_interface.rb
@@ -35,6 +35,11 @@ DESC
       Pakyow::Commands::Console
         .new(environment: environment)
         .run
+    rescue LoadError => e
+      raise Thor::Error, <<ERR
+Error: #{e.message}
+You must run the `pakyow console` command in a Pakyow application's root directory.
+ERR
     end
 
     desc "server ENVIRONMENT", <<DESC
@@ -58,6 +63,11 @@ DESC
       Pakyow::Commands::Server
         .new(environment: environment, port: options[:port])
         .run
+    rescue LoadError => e
+      raise Thor::Error, <<ERR
+Error: #{e.message}
+You must run the `pakyow server` command in a Pakyow application's root directory.
+ERR
     end
 
     desc "version", "Display the installed Pakyow version"

--- a/lib/pakyow/commands/server.rb
+++ b/lib/pakyow/commands/server.rb
@@ -3,7 +3,7 @@ module Pakyow
     class Server
       attr_reader :environment, :port
 
-      def initialize(environment: :development, port:)
+      def initialize(environment: :development, port: 3000)
         @environment = environment
         @port = port
       end

--- a/spec/features/command_line_interface_spec.rb
+++ b/spec/features/command_line_interface_spec.rb
@@ -20,6 +20,26 @@ RSpec.describe "command line interface" do
     end
   end
 
+  describe "console" do
+    context "current directly is not a pakyow app" do
+      it "kindly notifies the user" do
+        output = `bin/pakyow server 2>&1`.chomp
+
+        expect(output).to match("must run.*server")
+      end
+    end
+  end
+
+  describe "server" do
+    context "current directly is not a pakyow app" do
+      it "kindly notifies the user" do
+        output = `bin/pakyow console 2>&1`.chomp
+
+        expect(output).to match("must run.*console")
+      end
+    end
+  end
+
   describe "version" do
     it "outputs current Pakyow version" do
       output = `bin/pakyow version`.chomp

--- a/spec/features/command_line_interface_spec.rb
+++ b/spec/features/command_line_interface_spec.rb
@@ -21,21 +21,21 @@ RSpec.describe "command line interface" do
   end
 
   describe "console" do
-    context "current directly is not a pakyow app" do
+    context "current directory is not a pakyow app" do
       it "kindly notifies the user" do
-        output = `bin/pakyow server 2>&1`.chomp
+        output = `bin/pakyow console 2>&1`.chomp
 
-        expect(output).to match("must run.*server")
+        expect(output).to match("must run.*console")
       end
     end
   end
 
   describe "server" do
-    context "current directly is not a pakyow app" do
+    context "current directory is not a pakyow app" do
       it "kindly notifies the user" do
-        output = `bin/pakyow console 2>&1`.chomp
+        output = `bin/pakyow server 2>&1`.chomp
 
-        expect(output).to match("must run.*console")
+        expect(output).to match("must run.*server")
       end
     end
   end


### PR DESCRIPTION
* The backtrace produced by the LoadError really wasn't beneficial to a
  user. This at least hints to the user that they may be running the
  command in the wrong directly.

Now it looks like:

```sh
$ bin/pakyow server
Error: cannot load such file -- app/setup
You must run the `pakyow server` command in a Pakyow application's root directory.
```
See #131 