### PR TITLE
Middleware Refactor

### DIFF
--- a/lib/generators/pakyow/app/templates/app/setup.rb
+++ b/lib/generators/pakyow/app/templates/app/setup.rb
@@ -2,7 +2,7 @@ require 'bundler/setup'
 require 'pakyow'
 
 Pakyow::App.define do
-  configure :global do
+  configure do
     Bundler.require :default, Pakyow::Config.env
 
     if defined?(Dotenv)
@@ -11,24 +11,14 @@ Pakyow::App.define do
       Dotenv.load
     end
 
-    # put global config here and they'll be available across environments
     app.name = '<%= app_name %>'
   end
 
   configure :development do
-    # put development config here
-  end
-
-  configure :prototype do
-    # an environment for running the front-end prototype with no backend
-    app.ignore_routes = true
+    # development config goes here
   end
 
   configure :production do
-    # put your production config here
-  end
-
-  middleware do |builder|
-    Dir.glob('middleware/*.rb').each { |r| require File.join('.', r) }
+    # production config goes here
   end
 end

--- a/lib/generators/pakyow/app/templates/middleware/logger.rb
+++ b/lib/generators/pakyow/app/templates/middleware/logger.rb
@@ -1,1 +1,0 @@
-Pakyow::App.builder.use Pakyow::Middleware::Logger if Pakyow::Config.logger.enabled

--- a/lib/generators/pakyow/app/templates/middleware/override.rb
+++ b/lib/generators/pakyow/app/templates/middleware/override.rb
@@ -1,1 +1,0 @@
-Pakyow::App.builder.use Rack::MethodOverride

--- a/lib/generators/pakyow/app/templates/middleware/reloader.rb
+++ b/lib/generators/pakyow/app/templates/middleware/reloader.rb
@@ -1,1 +1,0 @@
-Pakyow::App.builder.use Pakyow::Middleware::Reloader if Pakyow::Config.reloader.enabled

--- a/lib/generators/pakyow/app/templates/middleware/req_path_normalizer.rb
+++ b/lib/generators/pakyow/app/templates/middleware/req_path_normalizer.rb
@@ -1,1 +1,0 @@
-Pakyow::App.builder.use Pakyow::Middleware::ReqPathNormalizer

--- a/lib/generators/pakyow/app/templates/middleware/session.rb
+++ b/lib/generators/pakyow/app/templates/middleware/session.rb
@@ -1,1 +1,0 @@
-Pakyow::App.builder.use Rack::Session::Cookie, key: "#{Pakyow::Config.app.name}.session", secret: ENV['SESSION_SECRET']

--- a/lib/generators/pakyow/app/templates/middleware/static.rb
+++ b/lib/generators/pakyow/app/templates/middleware/static.rb
@@ -1,1 +1,0 @@
-Pakyow::App.builder.use Pakyow::Middleware::Static if Pakyow::Config.app.static

--- a/pakyow-core/lib/core/base.rb
+++ b/pakyow-core/lib/core/base.rb
@@ -15,17 +15,21 @@ require 'core/route_template_defaults'
 require 'core/route_lookup'
 require 'core/app'
 require 'core/errors'
+
 require 'core/config'
 require 'core/config/reloader'
 require 'core/config/app'
 require 'core/config/server'
 require 'core/config/cookies'
 require 'core/config/logger'
+require 'core/config/session'
 
-# middlewares
-require 'core/middleware/logger'
-require 'core/middleware/static'
+require 'core/middleware/override'
 require 'core/middleware/reloader'
+require 'core/middleware/req_path_normalizer'
+require 'core/middleware/session'
+require 'core/middleware/static'
+require 'core/middleware/logger'
 
 module Pakyow
   class << self

--- a/pakyow-core/lib/core/config/app.rb
+++ b/pakyow-core/lib/core/config/app.rb
@@ -1,5 +1,7 @@
 Pakyow::Config.register :app do |config|
 
+  config.opt :name, 'pakyow'
+
   # if true, errors are displayed in the browser
   config.opt :errors_in_browser
 

--- a/pakyow-core/lib/core/config/session.rb
+++ b/pakyow-core/lib/core/config/session.rb
@@ -1,0 +1,13 @@
+Pakyow::Config.register :session do |config|
+  # whether or not to use sessions
+  config.opt :enabled, true
+
+  # the session object
+  config.opt :object, Rack::Session::Cookie
+
+  # the session key
+  config.opt :key, -> { "#{Pakyow::Config.app.name}.session" }
+
+  # the session secret
+  config.opt :secret, -> { ENV['SESSION_SECRET'] }
+end

--- a/pakyow-core/lib/core/config/session.rb
+++ b/pakyow-core/lib/core/config/session.rb
@@ -5,9 +5,37 @@ Pakyow::Config.register :session do |config|
   # the session object
   config.opt :object, Rack::Session::Cookie
 
+  # session middleware config options
+  config.opt :options, -> {
+    opts = {
+      key: Pakyow::Config.session.key,
+      secret: Pakyow::Config.session.secret
+    }
+
+    # set optional options if available
+    %i(domain path expire_after old_secret).each do |opt|
+      value = Pakyow::Config.session.send(opt)
+      opts[opt] = value if value
+    end
+
+    opts
+  }
+
   # the session key
   config.opt :key, -> { "#{Pakyow::Config.app.name}.session" }
 
   # the session secret
   config.opt :secret, -> { ENV['SESSION_SECRET'] }
+
+  # the old session secret (used for rotation)
+  config.opt :old_secret
+
+  # session expiration, in seconds
+  config.opt :expire_after
+
+  # session cookie path
+  config.opt :path
+
+  # session cookie domain
+  config.opt :domain
 end

--- a/pakyow-core/lib/core/middleware/logger.rb
+++ b/pakyow-core/lib/core/middleware/logger.rb
@@ -99,6 +99,12 @@ end
 
 module Pakyow
   module Middleware
+    Pakyow::App.middleware do |builder|
+      if Pakyow::Config.logger.enabled
+        builder.use Pakyow::Middleware::Logger
+      end
+    end
+
     class Logger
       # handles logging after an error occurs
       Pakyow::App.after(:error) {

--- a/pakyow-core/lib/core/middleware/override.rb
+++ b/pakyow-core/lib/core/middleware/override.rb
@@ -1,0 +1,3 @@
+Pakyow::App.middleware do |builder|
+  builder.use Rack::MethodOverride
+end

--- a/pakyow-core/lib/core/middleware/reloader.rb
+++ b/pakyow-core/lib/core/middleware/reloader.rb
@@ -1,5 +1,11 @@
 module Pakyow
   module Middleware
+    Pakyow::App.middleware do |builder|
+      if Pakyow::Config.reloader.enabled
+        builder.use Pakyow::Middleware::Reloader
+      end
+    end
+
     # Rack compatible middleware that tells app to reload on each request.
     #
     # @api public

--- a/pakyow-core/lib/core/middleware/req_path_normalizer.rb
+++ b/pakyow-core/lib/core/middleware/req_path_normalizer.rb
@@ -2,6 +2,10 @@ require 'core/call_context'
 
 module Pakyow
   module Middleware
+    Pakyow::App.middleware do |builder|
+      builder.use Pakyow::Middleware::ReqPathNormalizer
+    end
+
     # Rack compatible middleware that normalize the path if contains '//',
     # it replace '//' with '/' and issue a 301 redirect to the new path.
     #

--- a/pakyow-core/lib/core/middleware/session.rb
+++ b/pakyow-core/lib/core/middleware/session.rb
@@ -1,0 +1,5 @@
+Pakyow::App.middleware do |builder|
+  if Pakyow::Config.session.enabled
+    builder.use Pakyow::Config.session.object, key: Pakyow::Config.session.key, secret: Pakyow::Config.session.secret
+  end
+end

--- a/pakyow-core/lib/core/middleware/session.rb
+++ b/pakyow-core/lib/core/middleware/session.rb
@@ -1,5 +1,5 @@
 Pakyow::App.middleware do |builder|
   if Pakyow::Config.session.enabled
-    builder.use Pakyow::Config.session.object, key: Pakyow::Config.session.key, secret: Pakyow::Config.session.secret
+    builder.use Pakyow::Config.session.object, Pakyow::Config.session.options
   end
 end

--- a/pakyow-core/lib/core/middleware/static.rb
+++ b/pakyow-core/lib/core/middleware/static.rb
@@ -17,6 +17,12 @@ module Pakyow
     #
     # @api public
     class Static
+      Pakyow::App.middleware do |builder|
+        if Pakyow::Config.app.static
+          builder.use Pakyow::Middleware::Static
+        end
+      end
+
       def initialize(app)
         @app = app
       end

--- a/pakyow-core/spec/unit/config/session_config_spec.rb
+++ b/pakyow-core/spec/unit/config/session_config_spec.rb
@@ -1,0 +1,54 @@
+require_relative '../../spec_helper'
+require 'core/config/session'
+
+describe 'config.session' do
+  it 'registers session config' do
+    expect(Pakyow::Config.session).to be_a(Pakyow::Config)
+  end
+
+  describe 'options' do
+    let :opts do
+      Pakyow::Config.session
+        .instance_variable_get(:@defaults)
+        .instance_variable_get(:@opts)
+        .keys
+    end
+
+    describe 'enabled' do
+      it 'is defined' do
+        expect(opts).to include(:enabled)
+      end
+
+      it 'defaults to true' do
+        expect(Pakyow::Config.session.enabled).to eq(true)
+      end
+    end
+
+    describe 'object' do
+      it 'is defined' do
+        expect(opts).to include(:object)
+      end
+
+      it 'defaults to cookie' do
+        expect(Pakyow::Config.session.object).to eq(Rack::Session::Cookie)
+      end
+    end
+
+    describe 'key' do
+      it 'is defined' do
+        expect(opts).to include(:key)
+      end
+    end
+
+    describe 'secret' do
+      it 'is defined' do
+        expect(opts).to include(:secret)
+      end
+
+      it 'defaults to ENV[SESSION_SECRET]' do
+        ENV['SESSION_SECRET'] = rand.to_s
+        expect(Pakyow::Config.session.secret).to eq(ENV['SESSION_SECRET'])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Defining middleware in the generated app felt wrong.

The approach in this commit registers default middleware and allows non-critical middleware to be disabled via config options. It also adds config options for configuring sessions so that the session middleware can be handled in a consistent way.