### PR TITLE
Fix test help params

### DIFF
--- a/pakyow-test/lib/test_help/ext/request.rb
+++ b/pakyow-test/lib/test_help/ext/request.rb
@@ -1,9 +1,11 @@
 module Pakyow
-  class Request
-    old_params = instance_method(:params)
-
-    define_method :params do
-      env.fetch('pakyow.params', old_params.bind(self).())
+  module ParamsOverride
+    def params
+      env.fetch('pakyow.params') { super }
     end
+  end
+
+  class Request
+    prepend ParamsOverride
   end
 end

--- a/pakyow-test/lib/test_help/ext/request.rb
+++ b/pakyow-test/lib/test_help/ext/request.rb
@@ -1,7 +1,9 @@
 module Pakyow
   class Request
-    def params
-      env['pakyow.params']
+    old_params = instance_method(:params)
+
+    define_method :params do
+      env.fetch('pakyow.params', old_params.bind(self).())
     end
   end
 end

--- a/pakyow-test/spec/unit/ext/request_spec.rb
+++ b/pakyow-test/spec/unit/ext/request_spec.rb
@@ -1,0 +1,34 @@
+require_relative '../support/unit_helper'
+require_relative '../../../lib/test_help/ext/request'
+
+describe Pakyow::Request do
+  describe 'params' do
+    let :req do
+      Pakyow::Request.new(env)
+    end
+
+    let :data do
+      { 'foo' => 'bar' }
+    end
+
+    context 'when env contains pakyow.params' do
+      let :env do
+        Rack::MockRequest.env_for('/', 'pakyow.params' => data)
+      end
+
+      it 'returns pakyow.params' do
+        expect(req.params).to be(data)
+      end
+    end
+
+    context 'when env does not contain pakyow.params' do
+      let :env do
+        Rack::MockRequest.env_for('/', params: data)
+      end
+
+      it 'returns the results of the original params method' do
+        expect(req.params).to eq(data)
+      end
+    end
+  end
+end


### PR DESCRIPTION
It now returns the original param values if pakyow.params is nil. See #151.