### PR TITLE
Load global config first

### DIFF
--- a/pakyow-core/lib/core/helpers/configuring.rb
+++ b/pakyow-core/lib/core/helpers/configuring.rb
@@ -110,11 +110,11 @@ module Pakyow
           config.app.loaded_envs = envs
           config.env = envs.first
 
+          load_env(:global)
+
           envs.each do |env|
             load_env(env)
           end
-
-          load_env(:global)
 
           Pakyow.configure_logger
         end

--- a/pakyow-core/spec/cases/application_spec.rb
+++ b/pakyow-core/spec/cases/application_spec.rb
@@ -48,8 +48,8 @@ describe 'Application' do
     expect($global_config_was_executed).to eq true
   end
 
-  it 'global configuration supercedes env' do
-    expect($env_overwrites_global_config).to eq false
+  it 'loads global configuration first' do
+    expect($env_overwrites_global_config).to eq true
   end
 
   it 'configuration loaded before middleware' do


### PR DESCRIPTION
It intentionally worked in a different way, but those edges went away when we started using dotenv for specific config values. This makes more sense now. Fixes #152.