### PR TITLE
Configuration blocks mistakenly gobble up KeyErrors

### DIFF
--- a/pakyow-core/lib/pakyow/core/helpers/configuring.rb
+++ b/pakyow-core/lib/pakyow/core/helpers/configuring.rb
@@ -131,8 +131,11 @@ module Pakyow
       end
 
       def load_env(env)
-        config.app_config(&env_config.fetch(env))
-      rescue KeyError
+        config.app_config(&config_for(env))
+      end
+
+      def config_for(env)
+        env_config.fetch(env) { proc{} }
       end
     end
   end


### PR DESCRIPTION
## Problem

Since `KeyError` is rescued when invoking a configuration block, an error of this type raised in a user's configuration block is lost, leading to head-scratching as to why things aren't working (or blowing up).

## Solution

Since the error is not used, substitute and innocent noop proc for missing configuration blocks. This avoids needing to handle errors et al.

cc @bryanp 