### PR TITLE
Explicitly require version feature for CLI

### DIFF
--- a/lib/pakyow/command_line_interface.rb
+++ b/lib/pakyow/command_line_interface.rb
@@ -72,6 +72,7 @@ ERR
 
     desc "version", "Display the installed Pakyow version"
     def version
+      require "pakyow/version"
       puts "Pakyow #{Pakyow::VERSION}"
     end
   end


### PR DESCRIPTION
When running the version command in the project, the feature is required
by the gemspec. However when the gem is built and installed, the feature
is never required so referencing Pakyow::VERSION fails.