### PR TITLE
Fix require in app generator

### DIFF
--- a/lib/generators/pakyow/app/app_generator.rb
+++ b/lib/generators/pakyow/app/app_generator.rb
@@ -1,7 +1,7 @@
 require 'erb'
 require 'fileutils'
 require 'securerandom'
-require_relative '../../../version.rb'
+require 'pakyow/version.rb'
 
 module Pakyow
   module Generators


### PR DESCRIPTION
The relative path was broken when we moved code into the pakyow
namespace. Actually this is a really great illustration of why to avoid
require_relative.