### PR TITLE
Downcase HTTP_UPGRADE header for comparison

### DIFF
--- a/pakyow-realtime/lib/pakyow/realtime/hooks.rb
+++ b/pakyow-realtime/lib/pakyow/realtime/hooks.rb
@@ -1,7 +1,7 @@
 Pakyow::App.before :route do
   # we want to hijack websocket requests
   #
-  if req.env['HTTP_UPGRADE'] == 'websocket'
+  if req.env['HTTP_UPGRADE'].to_s.downcase == 'websocket'
     if Pakyow::Config.realtime.enabled
       socket_connection_id = params[:socket_connection_id]
       socket_digest = socket_digest(socket_connection_id)

--- a/pakyow-realtime/lib/pakyow/realtime/hooks.rb
+++ b/pakyow-realtime/lib/pakyow/realtime/hooks.rb
@@ -1,7 +1,7 @@
 Pakyow::App.before :route do
   # we want to hijack websocket requests
   #
-  if req.env['HTTP_UPGRADE'].to_s.downcase == 'websocket'
+  if req.env['HTTP_UPGRADE'] && req.env['HTTP_UPGRADE'].casecmp('websocket') == 0
     if Pakyow::Config.realtime.enabled
       socket_connection_id = params[:socket_connection_id]
       socket_digest = socket_digest(socket_connection_id)


### PR DESCRIPTION
Downcases the HTTP_UPGRADE value provided by the browser when checking for "websocket". This fixes websockets in IE11, which sends the HTTP_UPGRADE value as “Websocket” (for some reason).