### PR TITLE
Add ensure_or_deny method to attrs

### DIFF
--- a/pakyow-presenter/lib/pakyow/presenter/attributes.rb
+++ b/pakyow-presenter/lib/pakyow/presenter/attributes.rb
@@ -43,6 +43,17 @@ module Pakyow
         update_value
       end
 
+      # calls `ensure` or `deny` based on result of block
+      def ensure_or_deny(value, &block)
+        raise ArgumentError, 'Expected a block' unless block_given?
+
+        if block.call
+          self.ensure(value)
+        else
+          self.deny(value)
+        end
+     end
+
       def include?(attribute)
         @doc.has_attribute?(attribute)
       end

--- a/pakyow-presenter/spec/integration/support/mixins/attr_specs.rb
+++ b/pakyow-presenter/spec/integration/support/mixins/attr_specs.rb
@@ -60,6 +60,23 @@ shared_examples :attr_specs do
         expect(node.attrs.title.to_s).to eq('')
       end
 
+      it 'ensures when block returns truthy' do
+        value = 'foo'
+        node.attrs.title.ensure_or_deny(value) { true }
+        expect(node.attrs.title.to_s).to eq(value)
+
+        # do it again
+        node.attrs.title.ensure_or_deny(value) { true }
+        expect(node.attrs.title.to_s).to eq(value)
+      end
+
+      it 'denies when block returns falsey' do
+        value = 'foo'
+        node.attrs.title = value
+        node.attrs.title.ensure_or_deny(value) { false }
+        expect(node.attrs.title.to_s).to eq('')
+      end
+
       it 'deletes the value' do
         value = 'foobar'
         node.attrs.title = value


### PR DESCRIPTION
Adds a new `ensure_or_deny` method that simplifies being explicit about the attrs you modify.

For example, we often do something like this to make sure a class is added/removed under the appropriate conditions:

```ruby
binding :status do
  {
    class: lambda { |klass|
      # old way using if/else + `ensure` and `deny`
      if bindable.active?
        klass.ensure('active')
      else
        klass.deny('active')
      end
    }
  }
end
```

But now we can just do this:

```ruby
binding :status do
  {
    class: lambda { |klass|
      # new way using `ensure_or_deny`
      klass.ensure_or_deny('active') { bindable.active? }
    }
  }
end
```
