### PR TITLE
use to_hash instead of to_h

### DIFF
--- a/pakyow-ui/lib/pakyow/ui/mutation_store.rb
+++ b/pakyow-ui/lib/pakyow/ui/mutation_store.rb
@@ -20,7 +20,7 @@ module Pakyow
           qualifications: qualifications,
           query_name: mutable_data.query_name,
           query_args: mutable_data.query_args,
-          session: session.to_h,
+          session: session.to_hash,
           socket_key: mutate_context.view.context.socket_digest(mutate_context.view.context.socket_connection_id)
         )
       end


### PR DESCRIPTION
Rack::Session::Abstract::SessionHash implements a to_hash method instead of a to_h method.