### PR TITLE
hot fix: dup msg passed to Logger#<< (#write)

### DIFF
--- a/pakyow-core/lib/pakyow/core/middleware/logger.rb
+++ b/pakyow-core/lib/pakyow/core/middleware/logger.rb
@@ -41,7 +41,7 @@ module Pakyow
 
     def <<(msg = nil, severity = :unknown)
       return if @log.nil?
-      (msg || "") << "\n"
+      msg = (msg || "").dup << "\n"
 
       msg = format(msg, severity) if @format
       @mutex.synchronize do


### PR DESCRIPTION
This fix is to handle the case for logging where a frozen string is passed to the logger, which is the case for Sequel.