### PR TITLE
Corrected syntax in help message for "server" command.

### DIFF
--- a/lib/pakyow/cli.rb
+++ b/lib/pakyow/cli.rb
@@ -33,7 +33,7 @@ module Pakyow
         "You must run the `pakyow console` command in the root directory of a Pakyow project."
     end
 
-    desc "server [ENVIRONMENT]", "Start a Pakyow application"
+    desc "server [ENVIRONMENT] [options]", "Start a Pakyow application"
     long_desc <<-DESC
       The `pakyow server` command starts the server for the current Pakyow project.
 


### PR DESCRIPTION
This is still a WIP at this point... The tweak here was dead simple, but I'm not really sure how to correct the display of the options as discussed [here](https://github.com/pakyow/pakyow/issues/217).