### PR TITLE
add rack-protection to default middleware stack

### DIFF
--- a/lib/pakyow/environment.rb
+++ b/lib/pakyow/environment.rb
@@ -1,5 +1,6 @@
 require "irb"
 require "rack"
+require "rack-protection"
 require "logger"
 
 require "pakyow/support/hookable"
@@ -83,6 +84,7 @@ require "pakyow/middleware"
 # - Rack::ContentLength
 # - Rack::Head
 # - Rack::MethodOverride
+# - Rack::Protection
 # - {Middleware::JSONBody}
 # - {Middleware::ReqPathNormalizer}
 # - {Middleware::Logger}
@@ -158,6 +160,15 @@ module Pakyow
     use Rack::ContentLength
     use Rack::Head
     use Rack::MethodOverride
+
+    app = Pakyow::App.config
+    if app.session.enabled
+      use app.session.object, app.session.opts
+      use Rack::Protection
+    else
+      use Rack::Protection, without_session: true
+    end
+
     use Middleware::JSONBody
     use Middleware::Normalizer
     use Middleware::Logger

--- a/pakyow-core/lib/pakyow/core/config/app.rb
+++ b/pakyow-core/lib/pakyow/core/config/app.rb
@@ -63,7 +63,7 @@ module Pakyow
       setting :path
       setting :domain
 
-      setting :options do
+      setting :opts do
         opts = {
           key: config.session.key,
           secret: config.session.secret

--- a/pakyow.gemspec
+++ b/pakyow.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency("pakyow-test",      Pakyow::VERSION)
   spec.add_dependency("bundler",          "~> 1.13")
   spec.add_dependency("thor",             "~> 0.19")
+  spec.add_dependency("rack-protection",  "~> 1.5")
 
   spec.add_development_dependency("rspec", "~> 3.5")
   spec.add_development_dependency("pry", "~> 0.10")


### PR DESCRIPTION
Not sure if getting the config from Pakyow::App this way is acceptable. (Also not working on environment branch, but this seems like an issue in pakyow-core, that is probably already dealt with in the routing-refactor branch)

Side note: Changed the config.session.options to config.session.opts (this is because ConfigGroup has a options attribute, which is in conflict)

In regard to: https://github.com/pakyow/pakyow/issues/241