### PR TITLE
Config group attributes

### DIFF
--- a/pakyow-support/lib/pakyow/support/configurable/config_group.rb
+++ b/pakyow-support/lib/pakyow/support/configurable/config_group.rb
@@ -35,9 +35,9 @@ module Pakyow
         def defaults(env, &block)
           env = env.to_sym
           if block_given?
-            @defaults[env] = block
+            @_defaults[env] = block
           else
-            @defaults[env]
+            @_defaults[env]
           end
         end
 

--- a/pakyow-support/lib/pakyow/support/configurable/config_group.rb
+++ b/pakyow-support/lib/pakyow/support/configurable/config_group.rb
@@ -6,15 +6,15 @@ module Pakyow
     module Configurable
       class ConfigGroup
         using DeepDup
-        attr_reader :name, :options, :parent, :settings
+        attr_reader :_name, :_options, :_parent, :_settings
 
         def initialize(name, options, parent, &block)
-          @name = name
-          @options = options
-          @parent = parent
-          @settings = {}
-          @initial_settings = {}
-          @defaults = {}
+          @_name = name
+          @_options = options
+          @_parent = parent
+          @_settings = {}
+          @_initial_settings = {}
+          @_defaults = {}
 
           instance_eval(&block)
           @initialized = true
@@ -26,10 +26,10 @@ module Pakyow
 
           unless instance_variable_defined?(:@initialized)
             # keep up with the initial values so we can reset
-            @initial_settings[name] = option
+            @_initial_settings[name] = option
           end
 
-          @settings[name] = option
+          @_settings[name] = option
         end
 
         def defaults(env, &block)
@@ -44,7 +44,7 @@ module Pakyow
         def method_missing(name, value = nil)
           if name[-1] == "="
             name = name[0..-2].to_sym
-            @settings.fetch(name) {
+            @_settings.fetch(name) {
               if extendable?
                 setting(name)
               else
@@ -52,20 +52,20 @@ module Pakyow
               end
             }.value = value
           else
-            @settings.fetch(name) {
+            @_settings.fetch(name) {
               return nil
-            }.value(@parent)
+            }.value(@_parent)
           end
         end
 
         def extendable?
-          @options[:extendable] == true
+          @_options[:extendable] == true
         end
 
         def reset
-          @settings = @initial_settings.deep_dup
+          @_settings = @_initial_settings.deep_dup
 
-          @settings.each do |_, settings|
+          @_settings.each do |_, settings|
             settings.reset
           end
         end


### PR DESCRIPTION
Use underscore prefix to avoid name conflicts for settings.