### PR TITLE
Inferred Naming

### DIFF
--- a/pakyow-core/lib/pakyow/core/app.rb
+++ b/pakyow-core/lib/pakyow/core/app.rb
@@ -371,7 +371,7 @@ module Pakyow
       # TODO: add File.join(config.app.src, "lib") to load path
 
       # TODO: these should be defined somewhere, so that things like presenter can extend
-      load_app_state(File.join(config.app.src, "routes"), "routing")
+      load_app_state(File.join(config.app.src, "routing"), "routing")
     end
 
     def load_app_state(state_path, state_ident, load_target = self.class)

--- a/pakyow-core/lib/pakyow/core/app.rb
+++ b/pakyow-core/lib/pakyow/core/app.rb
@@ -380,7 +380,7 @@ module Pakyow
     using Support::RecursiveRequire
 
     def load_app
-      # TODO: add File.join(config.app.src, "lib") to load path
+      $LOAD_PATH.unshift File.join(config.app.src, "lib")
 
       App.concerns.each do |concern|
         load_app_concern(File.join(config.app.src, concern), concern)

--- a/pakyow-core/lib/pakyow/core/loader.rb
+++ b/pakyow-core/lib/pakyow/core/loader.rb
@@ -5,7 +5,7 @@ module Pakyow
     end
 
     def call(eval_binding = binding)
-      eval(File.read(@path), eval_binding)
+      eval(File.read(@path), eval_binding, @path)
     end
 
     def method_missing(name, *args, &block)

--- a/pakyow-core/lib/pakyow/core/loader.rb
+++ b/pakyow-core/lib/pakyow/core/loader.rb
@@ -1,16 +1,17 @@
 module Pakyow
   class Loader
-    def initialize(target, name, path)
-      @target, @name, @path = target, name.to_sym, path
+    def initialize(target, prefix, path)
+      @target, @prefix, @path = target, prefix.to_sym, path
     end
 
     def call(eval_binding = binding)
       eval(File.read(@path), eval_binding, @path)
     end
 
-    def method_missing(name, *args, &block)
-      args.unshift(@name) unless args[0].is_a?(Symbol)
-      @target.public_send(name, *args, &block)
+    def method_missing(name, *args, **kargs, &block)
+      # prefix the given name with the known prefix
+      args[0] = :"#{@prefix}__#{args[0]}" if args[0].is_a?(Symbol)
+      @target.public_send(name, *args, **kargs, &block)
     end
   end
 end

--- a/pakyow-core/lib/pakyow/core/loader.rb
+++ b/pakyow-core/lib/pakyow/core/loader.rb
@@ -1,0 +1,16 @@
+module Pakyow
+  class Loader
+    def initialize(target, name, path)
+      @target, @name, @path = target, name.to_sym, path
+    end
+
+    def call(eval_binding = binding)
+      eval(File.read(@path), eval_binding)
+    end
+
+    def method_missing(name, *args, &block)
+      args.unshift(@name) unless args[0].is_a?(Symbol)
+      @target.public_send(name, *args, &block)
+    end
+  end
+end

--- a/pakyow-core/lib/pakyow/core/router.rb
+++ b/pakyow-core/lib/pakyow/core/router.rb
@@ -139,9 +139,7 @@ module Pakyow
     include Helpers
     using Support::DeepDup
     extend Routing::HookMerger
-
     extend Support::ClassMaker
-    CLASS_MAKER_BASE = "Router".freeze
 
     router = self
     Pakyow.singleton_class.class_eval do

--- a/pakyow-core/spec/features/loading_spec.rb
+++ b/pakyow-core/spec/features/loading_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe "loading the app" do
+  it "loads routes from src/routes"
+
+  context "when using inferred_naming" do
+    it "automatically names unnamed routers"
+    it "respects the given name for named routers"
+    it "still allows for fully defined routers"
+
+    describe "an automatically inferred router" do
+      it "is properly namespaced"
+    end
+  end
+
+  context "when not using inferred naming" do
+    it "requires routers to be fully defined"
+  end
+end

--- a/pakyow-core/spec/features/loading_spec.rb
+++ b/pakyow-core/spec/features/loading_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe "loading the app" do
   it "loads routes from src/routes"
+  it "adds src/lib to the load path"
 
   context "when using inferred_naming" do
     it "automatically names unnamed routers"

--- a/pakyow-core/spec/features/loading_spec.rb
+++ b/pakyow-core/spec/features/loading_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "loading the app" do
   it "loads routes from src/routes"
   it "adds src/lib to the load path"
 
-  context "when using inferred_naming" do
+  context "when using definition dsl" do
     it "automatically names unnamed routers"
     it "respects the given name for named routers"
     it "still allows for fully defined routers"

--- a/pakyow-core/spec/unit/app_spec.rb
+++ b/pakyow-core/spec/unit/app_spec.rb
@@ -56,9 +56,9 @@ RSpec.describe Pakyow::App do
       end
     end
 
-    describe "app.inferred_naming" do
+    describe "app.dsl" do
       it "has a default value" do
-        expect(Pakyow::App.config.app.inferred_naming).to eq(true)
+        expect(Pakyow::App.config.app.dsl).to eq(true)
       end
     end
 

--- a/pakyow-core/spec/unit/app_spec.rb
+++ b/pakyow-core/spec/unit/app_spec.rb
@@ -56,6 +56,12 @@ RSpec.describe Pakyow::App do
       end
     end
 
+    describe "app.inferred_naming" do
+      it "has a default value" do
+        expect(Pakyow::App.config.app.inferred_naming).to eq(true)
+      end
+    end
+
     describe "routing.enabled" do
       it "has a default value" do
         expect(Pakyow::App.config.routing.enabled).to eq(true)

--- a/pakyow-presenter/lib/pakyow/presenter/binder.rb
+++ b/pakyow-presenter/lib/pakyow/presenter/binder.rb
@@ -4,7 +4,6 @@ module Pakyow
   module Presenter
     class Binder
       extend Support::ClassMaker
-      CLASS_MAKER_BASE = "Binder".freeze
 
       attr_reader :object
 

--- a/pakyow-presenter/lib/pakyow/presenter/extensions/app.rb
+++ b/pakyow-presenter/lib/pakyow/presenter/extensions/app.rb
@@ -12,5 +12,8 @@ module Pakyow
 
       setting :require_route, false
     end
+
+    concern :views
+    concern :binders
   end
 end

--- a/pakyow-presenter/lib/pakyow/presenter/presenters/view.rb
+++ b/pakyow-presenter/lib/pakyow/presenter/presenters/view.rb
@@ -8,10 +8,9 @@ module Pakyow
       class << self
         attr_reader :path, :block
 
-        def make(name, path, state: nil, &block)
-          puts "make view #{name.inspect} #{path.inspect}"
+        def make(path, state: nil, &block)
           path = String.normalize_path(path)
-          super(name, state: state, path: path, block: block) {}
+          super(name_from_path(path), state: state, path: path, block: block) {}
         end
 
         def name_from_path(path)

--- a/pakyow-presenter/lib/pakyow/presenter/presenters/view.rb
+++ b/pakyow-presenter/lib/pakyow/presenter/presenters/view.rb
@@ -4,7 +4,6 @@ module Pakyow
   module Presenter
     class ViewPresenter < Presenter
       extend Support::ClassMaker
-      CLASS_MAKER_BASE = "ViewPresenter".freeze
 
       class << self
         attr_reader :path, :block

--- a/pakyow-presenter/lib/pakyow/presenter/presenters/view.rb
+++ b/pakyow-presenter/lib/pakyow/presenter/presenters/view.rb
@@ -8,17 +8,10 @@ module Pakyow
       class << self
         attr_reader :path, :block
 
-        def make(path, state: nil, &block)
-          klass = class_const_for_name(Class.new(self), name_from_path(path))
-
-          klass.class_eval do
-            @name = name
-            @state = state
-            @path = String.normalize_path(path)
-            @block = block
-          end
-
-          klass
+        def make(name, path, state: nil, &block)
+          puts "make view #{name.inspect} #{path.inspect}"
+          path = String.normalize_path(path)
+          super(name, state: state, path: path, block: block) {}
         end
 
         def name_from_path(path)

--- a/pakyow-presenter/lib/pakyow/presenter/processor.rb
+++ b/pakyow-presenter/lib/pakyow/presenter/processor.rb
@@ -39,7 +39,6 @@ module Pakyow
 
     class Processor
       extend Support::ClassMaker
-      CLASS_MAKER_BASE = "Processor".freeze
 
       class << self
         attr_reader :name, :extensions, :block

--- a/pakyow-presenter/lib/pakyow/presenter/processor.rb
+++ b/pakyow-presenter/lib/pakyow/presenter/processor.rb
@@ -44,19 +44,9 @@ module Pakyow
         attr_reader :name, :extensions, :block
 
         def make(name, *extensions, state: nil, &block)
-          klass = class_const_for_name(Class.new(self), name)
-
           # name is expected to also be an extension
           extensions.unshift(name).map!(&:to_sym)
-
-          klass.class_eval do
-            @name = name
-            @extensions = extensions
-            @state = state
-            @block = block
-          end
-
-          klass
+          super(name, state: state, extensions: extensions, block: block) {}
         end
 
         def process(content)

--- a/pakyow-support/spec/unit/class_maker_spec.rb
+++ b/pakyow-support/spec/unit/class_maker_spec.rb
@@ -1,0 +1,104 @@
+require "pakyow/support/class_maker"
+
+RSpec.describe Pakyow::Support::ClassMaker do
+  let :object do
+    Class.new do
+      extend Pakyow::Support::ClassMaker
+    end
+  end
+
+  describe ".make" do
+    after do
+      Object.send(:remove_const, :Foo)
+    end
+
+    it "sets the name on the class" do
+      expect(object.make(:foo).name).to eq(:foo)
+    end
+
+    it "sets the state on the class" do
+      expect(object.make(:foo, state: [0, 1, 2]).state).to eq([0, 1, 2])
+    end
+
+    it "evals the block on the class" do
+      expect(object.make(:foo) { @foo = :bar }.instance_variable_get(:@foo)).to eq(:bar)
+    end
+
+    it "returns the new class" do
+      expect(object.make(:foo)).to eq(Foo)
+    end
+
+    context "passing arbitrary args" do
+      it "sets each arg as a class ivar" do
+        expect(object.make(:foo, bar: :baz).instance_variable_get(:@bar)).to eq(:baz)
+      end
+    end
+  end
+
+  describe "the defined class" do
+    context "given name has an underscore" do
+      after do
+        Object.send(:remove_const, :FooBar)
+      end
+
+      it "is camelcased" do
+        expect(object.make(:foo_bar)).to eq(FooBar)
+      end
+    end
+
+    context "given name has more than one underscore" do
+      after do
+        Object.send(:remove_const, :FooBarBaz)
+      end
+
+      it "is camelcased" do
+        expect(object.make(:foo_bar_baz)).to eq(FooBarBaz)
+      end
+    end
+
+    context "given name has a double underscore" do
+      after do
+        Foo.send(:remove_const, :Bar)
+        Object.send(:remove_const, :Foo)
+      end
+
+      it "is namespaced" do
+        expect(object.make(:foo__bar)).to eq(Foo::Bar)
+      end
+    end
+
+    context "given name has more than one double underscore" do
+      after do
+        Foo::Bar.send(:remove_const, :Baz)
+        Foo.send(:remove_const, :Bar)
+        Object.send(:remove_const, :Foo)
+      end
+
+      it "is namespaced" do
+        expect(object.make(:foo__bar__baz)).to eq(Foo::Bar::Baz)
+      end
+    end
+
+    context "given name has a double underscore followed by a single underscore" do
+      after do
+        Foo.send(:remove_const, :BarBaz)
+        Object.send(:remove_const, :Foo)
+      end
+
+      it "is namespaced" do
+        expect(object.make(:foo__bar_baz)).to eq(Foo::BarBaz)
+      end
+    end
+
+    context "given name has a single underscore followed by a double underscore" do
+      after do
+        FooBar.send(:remove_const, :Baz)
+        Object.send(:remove_const, :FooBar)
+      end
+
+      it "camelcases the namespace" do
+        expect(object.make(:foo_bar__baz)).to eq(FooBar::Baz)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Pakyow will now automatically infer names for application state (e.g. routers). The goal is to make it easier to follow a good and consistent naming convention throughout an application.

You can see a real-world, bootable example over at [pakyow/design](https://github.com/pakyow/design).

**Work that's left:**

- [x] Make this universal instead of only available to routers

**Further explanation:**

Given this router defined at `./backend/routing/home.rb`:

```ruby
router "/" do
  get :foo, "/foo" do; end
end
```

Pakyow infers the name to be `home`. The router is available for path building as expected:

```ruby
path(:home_foo)
# => /foo
```

Pakyow also gives the router a nice class name. Given an app name of `example`, the assigned class name for the above router is `Example::Routing::Home`. It's identical to defining it longhand:

```ruby
Example::App.router << Example::Routing::Home < Pakyow::Router("/")
  get :foo, "/foo" do; end
end
```

Pakyow's inferred naming also handles more complex cases, such as nested routers. For example, given this router defined at `./backend/routing/admin.rb`:

```ruby
router "/admin, before: [:require_admin] do
end
```

Any routers defined within an `admin` folder are created within the `admin` router, effectively using it as a namespace. Nested routers inherit the parent's path and hooks. So, the following router named `./backend/routing/admin/post.rb` would be created within the `Example::Routing::Admin` router, inherit the `/admin` path, as well as the `require_admin` hook:

```ruby
resource "/posts" do
  list do; end
end
```