### PR TITLE
Fix bug causing data subscriptions to not expire for a web socket

### DIFF
--- a/pakyow-realtime/CHANGELOG.md
+++ b/pakyow-realtime/CHANGELOG.md
@@ -1,5 +1,7 @@
 # UNRELEASED
 
+  * [fixed] Issue causing data subscriptions to never be expired for a web socket connection
+
 # 1.0
 
   * Hello, Web

--- a/pakyow-realtime/lib/pakyow/realtime/server.rb
+++ b/pakyow-realtime/lib/pakyow/realtime/server.rb
@@ -2,7 +2,7 @@
 
 require "concurrent/array"
 require "concurrent/timer_task"
-require "concurrent/executor/thread_pool_executor"
+require "concurrent/executor/single_thread_executor"
 
 require "pakyow/support/message_verifier"
 
@@ -20,11 +20,8 @@ module Pakyow
         @adapter = Adapters.const_get(adapter.to_s.capitalize).new(self, adapter_config)
         @sockets = Concurrent::Array.new
         @timeout_config = timeout_config
-        @executor = Concurrent::ThreadPoolExecutor.new(
-          auto_terminate: false,
-          min_threads: 1,
-          max_threads: 10,
-          max_queue: 0
+        @executor = Concurrent::SingleThreadExecutor.new(
+          auto_terminate: false
         )
 
         connect

--- a/pakyow-realtime/spec/spec_helper.rb
+++ b/pakyow-realtime/spec/spec_helper.rb
@@ -14,7 +14,7 @@ require_relative "../../spec/helpers/mock_handler"
 
 RSpec.configure do |spec_config|
   spec_config.before do |example|
-    allow_any_instance_of(Concurrent::ThreadPoolExecutor).to receive(:<<) do |_, block|
+    allow_any_instance_of(Concurrent::SingleThreadExecutor).to receive(:<<) do |_, block|
       block.call
     end
   end

--- a/pakyow-ui/CHANGELOG.md
+++ b/pakyow-ui/CHANGELOG.md
@@ -1,5 +1,7 @@
 # UNRELEASED
 
+  * [fixed] Issue causing data subscriptions to never be expired for a web socket connection
+
 # 1.0
 
   * Hello, Web

--- a/pakyow-ui/lib/pakyow/application/behavior/ui/rendering.rb
+++ b/pakyow-ui/lib/pakyow/application/behavior/ui/rendering.rb
@@ -86,7 +86,12 @@ module Pakyow
 
                     # Expire subscriptions if the connection is never established.
                     #
-                    context.app.data.expire(context.socket_client_id, context.app.config.realtime.timeouts.initial)
+                    # We only do this at the top level render and not in sub renders (e.g.) components
+                    # because the same socket client id applies for every render.
+                    #
+                    if @composer.class == Pakyow::Presenter::Composers::View
+                      context.app.data.expire(context.socket_client_id, context.app.config.realtime.timeouts.initial)
+                    end
                   end
                 end
               end

--- a/pakyow-ui/lib/pakyow/ui/framework.rb
+++ b/pakyow-ui/lib/pakyow/ui/framework.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "concurrent/executor/thread_pool_executor"
+require "concurrent/executor/single_thread_executor"
 
 require "pakyow/framework"
 
@@ -76,11 +76,8 @@ module Pakyow
           unfreezable :ui_executor
 
           after "initialize" do
-            @ui_executor = Concurrent::ThreadPoolExecutor.new(
+            @ui_executor = Concurrent::SingleThreadExecutor.new(
               auto_terminate: false,
-              min_threads: 1,
-              max_threads: 10,
-              max_queue: 0
             )
           end
         end

--- a/pakyow-ui/spec/integration/behavior/timeouts_spec.rb
+++ b/pakyow-ui/spec/integration/behavior/timeouts_spec.rb
@@ -62,11 +62,13 @@ RSpec.describe "ui state timeout behavior" do
     end
 
     let :view_renderer do
+      composer_instance = composer.new
+      allow(composer_instance).to receive(:class).and_return(Pakyow::Presenter::Composers::View)
       Pakyow.app(:test).isolated(:Renderer).new(
         app: Pakyow.app(:test),
         presentables: connection.values.merge(post: Pakyow.app(:test).data.posts.all),
         presenter_class: Pakyow.app(:test).isolated(:Presenter),
-        composer: composer.new
+        composer: composer_instance
       )
     end
 
@@ -85,7 +87,7 @@ RSpec.describe "ui state timeout behavior" do
     before do
       allow(Marshal).to receive(:dump).and_return("dumped")
 
-      allow_any_instance_of(Concurrent::ThreadPoolExecutor).to receive(:post) do |_, *args, &block|
+      allow_any_instance_of(Concurrent::SingleThreadExecutor).to receive(:post) do |_, *args, &block|
         block.call(*args)
       end
     end


### PR DESCRIPTION
Using thread pools larger than 1 thread can cause changes to be applied out of order from time to time. While the executor guarantees that tasks are executed in order, it doesn't guarantee that one finished before another. This was causing odd and unpredictable behavior that was resolved by dropping down to a single thread executor.

The change to the after render hook guarantees reduces calls to the data adapter when multiple renders happen for a single request (e.g. component renders). This is safe since all renders are for the same socket id.

Unfortunately this is extremely difficult to verify reliably with a test. Fortunately this code doesn't have reason to change in the near future.