### PR TITLE
Move heartbeat from the server to the individual websocket instance

### DIFF
--- a/pakyow-realtime/CHANGELOG.md
+++ b/pakyow-realtime/CHANGELOG.md
@@ -1,6 +1,9 @@
 # UNRELEASED
 
   * [fixed] Issue causing data subscriptions to never be expired for a web socket connection
+  * [changed] Let websocket instances manage their own heartbeats, rather than the websocket server
+  * [changed] Send heartbeats every second from websocket instances
+    * This and the change prior seem to resolve intermittent timeouts on production
 
 # 1.0
 

--- a/pakyow-realtime/spec/unit/websocket_spec.rb
+++ b/pakyow-realtime/spec/unit/websocket_spec.rb
@@ -1,0 +1,91 @@
+RSpec.describe Pakyow::Realtime::WebSocket do
+  let :instance do
+    described_class.new(id, connection)
+  end
+
+  let :id do
+    "42"
+  end
+
+  let :connection do
+    double(
+      :connection,
+      app: application,
+      request: nil,
+      __getobj__: underlying_connection
+    )
+  end
+
+  let :underlying_connection do
+    double(
+      :underlying_connection
+    )
+  end
+
+  let :logger do
+    double(
+      :logger,
+      info: nil
+    )
+  end
+
+  let :application do
+    double(
+      :application,
+      websocket_server: websocket_server,
+      hooks: [],
+      config: config
+    )
+  end
+
+  let :websocket_server do
+    double(
+      :websocket_server,
+      socket_connect: nil,
+      socket_disconnect: nil
+    )
+  end
+
+  let :socket do
+    double(
+      :socket,
+      close: nil,
+      write: nil,
+      flush: nil,
+      read: nil
+    )
+  end
+
+  let :config do
+    double(
+      :config,
+      version: "123"
+    )
+  end
+
+  before do
+    allow(Pakyow::Logger).to receive(:new).and_return(logger)
+    allow(Async::WebSocket::Adapters::Native).to receive(:open) do |&block|
+      Async do
+        block.call(socket)
+      end
+    end
+  end
+
+  describe "heartbeat" do
+    it "has a heartbeat after connecting" do
+      allow(socket).to receive(:read) do
+        Async::Task.current.sleep 3
+      end
+
+      Async {
+        expect(instance).to receive(:beat).at_least(:twice)
+      }.wait
+    end
+
+    it "does not have a heartbeat after disconnecting" do
+      expect(instance).not_to receive(:beat)
+      sleep 3
+    end
+  end
+end

--- a/pakyow-ui/spec/spec_helper.rb
+++ b/pakyow-ui/spec/spec_helper.rb
@@ -18,7 +18,6 @@ RSpec.configure do |spec_config|
   spec_config.before do |example|
     @excluded_frameworks = [:reflection]
 
-    allow_any_instance_of(Pakyow::Realtime::Server).to receive(:start_heartbeat)
     allow_any_instance_of(Pakyow::Data::Subscribers).to receive(:expire)
 
     if $booted


### PR DESCRIPTION
I've been running this in production the last couple days and it appears to resolve the intermittent connection timeouts I was seeing. It also just feels like a better approach overall.