### PR TITLE
Present context-aware messages for commands run in the wrong context

### DIFF
--- a/pakyow-core/lib/pakyow/errors.rb
+++ b/pakyow-core/lib/pakyow/errors.rb
@@ -37,7 +37,9 @@ module Pakyow
 
   class UnknownCommand < Error
     class_state :messages, default: {
-      default: "`{command}' is not a known command"
+      default: "`{command}' is not a known command",
+      not_in_project_context: "Cannot run command `{command}' outside of a pakyow project",
+      not_in_global_context: "Cannot run command `{command}' within a pakyow project"
     }.freeze
   end
 

--- a/pakyow-core/spec/features/cli_spec.rb
+++ b/pakyow-core/spec/features/cli_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe "command line interface" do
   before do
     define_apps
 
-    allow_any_instance_of(Pakyow::CLI).to receive(:project_context?).and_return(true)
+    allow_any_instance_of(Pakyow::CLI).to receive(:project_context?).and_return(project_context)
 
     # Set the working directory to the supporting app.
     #
@@ -249,6 +249,10 @@ RSpec.describe "command line interface" do
 
   let :argv do
     []
+  end
+
+  let :project_context do
+    true
   end
 
   def define_apps
@@ -399,5 +403,31 @@ RSpec.describe "command line interface" do
     end
 
     include_examples :help_without_banner
+  end
+
+  context "running a global command within a project context" do
+    let :command do
+      "create"
+    end
+
+    it "prints an error" do
+      expect(output).to include("  \e[31m›\e[0m Cannot run command \e[3;34mcreate\e[0m within a pakyow project")
+    end
+
+    include_examples :help_without_banner
+  end
+
+  context "running a project command within a global context" do
+    let :project_context do
+      false
+    end
+
+    let :command do
+      "info"
+    end
+
+    it "prints an error" do
+      expect(output).to include("  \e[31m›\e[0m Cannot run command \e[3;34minfo\e[0m outside of a pakyow project")
+    end
   end
 end


### PR DESCRIPTION
Fixes #298.

**Running a project command outside of a project:**

```
$ pakyow boot
  › Cannot run command `boot' outside of a pakyow project
```

**Running a global command within a project:**

```
foo  $ pakyow create
  › Cannot run command `create' within a pakyow project
```