### PR TITLE
Client-side logging, component debugging

### DIFF
--- a/pakyow-js/CHANGELOG.md
+++ b/pakyow-js/CHANGELOG.md
@@ -4,6 +4,10 @@
     * Automatically reloads the page when the code changes
     * Click on mode to restart in development or prototype mode
     * Gracefully handles the difference between uris in prototype and development modes
+  * [added] Introduces log streaming from client to server
+    * Anything logged via `console` will also be logged on the server
+  * [added] Introduces debug mode to ui components
+    * Set `debug: true` in the component config
 
 # 1.0
 

--- a/pakyow-js/__tests__/features/component/debug.spec.js
+++ b/pakyow-js/__tests__/features/component/debug.spec.js
@@ -1,0 +1,74 @@
+require("../support/helpers/setup.js");
+require("../support/helpers/components.js");
+
+describe("debugging a component", () => {
+  let init = () => {
+    pw.Component.init(document.querySelector("html"));
+  }
+
+  let spy;
+
+  beforeEach(() => {
+    spy = jest.spyOn(console, "debug").mockImplementation(() => {});
+
+    document.querySelector("html").innerHTML = `
+      <head>
+      </head>
+      <body>
+        <div data-ui="foo(debug: true)"></div>
+        <div data-ui="bar(debug: true)"></div>
+      </body>
+    `;
+  });
+
+  test("logs initialization", () => {
+    init();
+    expect(spy.mock.calls).toEqual([
+      ["[component] `foo': initializing"],
+      ["[component] `foo': initialized"],
+      ["[component] `bar': initializing"],
+      ["[component] `bar': initialized"]
+    ]);
+  });
+
+  test("logs listen", () => {
+    init();
+    spy.mockClear();
+    pw.Component.instances[0].listen("foo", () => {});
+
+    expect(spy.mock.calls).toEqual([
+      ["[component] foo listening for events on `foo'"]
+    ]);
+  });
+
+  test("logs ignore", () => {
+    init();
+    spy.mockClear();
+    pw.Component.instances[0].ignore("foo");
+
+    expect(spy.mock.calls).toEqual([
+      ["[component] foo ignoring events on `foo'"]
+    ]);
+  });
+
+  test("logs trigger", () => {
+    init();
+    pw.Component.instances[0].listen("bar", () => {});
+    spy.mockClear();
+    pw.broadcast("bar", { bar: "baz" });
+
+    expect(spy.mock.calls).toEqual([
+      ["[component] foo triggering `bar': {\"bar\":\"baz\"}"]
+    ]);
+  });
+
+  test("logs trigger", () => {
+    init();
+    spy.mockClear();
+    pw.Component.instances[0].bubble("baz", { bar: "baz" });
+
+    expect(spy.mock.calls).toEqual([
+      ["[component] foo bubbling `baz': {\"bar\":\"baz\"}"]
+    ]);
+  });
+});

--- a/pakyow-js/__tests__/features/component/init-error.spec.js
+++ b/pakyow-js/__tests__/features/component/init-error.spec.js
@@ -12,12 +12,20 @@ function sleep(ms){
   });
 }
 
+let originalConsole = console;
+
+beforeEach(() => {
+  console.error = jest.fn();
+});
+
 afterEach(() => {
   while(pw.Component.instances.length > 0) {
     pw.Component.instances.pop();
   }
 
   pw.Component.clearObserver();
+
+  console.error = originalConsole.error;
 });
 
 describe("component errors on initialization", () => {

--- a/pakyow-js/__tests__/features/components/devtools.spec.js
+++ b/pakyow-js/__tests__/features/components/devtools.spec.js
@@ -186,7 +186,7 @@ describe("devtools", () => {
 
         test("sets the document location to the view path", () => {
           document.location.assign = jest.fn();
-          pw.broadcast("pw:socket:connected");
+          pw.broadcast("pw:socket:connected", { config: {} });
           expect(document.location.assign).toHaveBeenCalledWith("/foo");
         });
       });
@@ -211,7 +211,7 @@ describe("devtools", () => {
 
         test("sets the document location to the mapping for the view path", () => {
           document.location.assign = jest.fn();
-          pw.broadcast("pw:socket:connected");
+          pw.broadcast("pw:socket:connected", { config: {} });
           expect(document.location.assign).toHaveBeenCalledWith("/foo/bar");
         });
       });

--- a/pakyow-js/__tests__/features/components/socket.spec.js
+++ b/pakyow-js/__tests__/features/components/socket.spec.js
@@ -1,0 +1,46 @@
+require("../support/helpers/setup.js");
+require("../support/helpers/components.js");
+
+require("../../../src/components/socket.js");
+
+describe("socket", () => {
+  beforeEach(() => {
+    document.querySelector("html").innerHTML = `
+      <head>
+        <meta name="pw-socket" data-ui="socket(endpoint: ws://localhost/pw-socket?id=4242)">
+      </head>
+
+      <body>
+      </body>
+    `;
+  });
+
+  describe("beat", () => {
+    test("sends a beat", () => {
+      let send = jest.fn();
+      pw.Component.init(document.querySelector("html"));
+      pw.Component.instances[0].send = send;
+      pw.Component.instances[0].beat();
+      expect(send).toHaveBeenCalledWith("beat");
+    });
+  });
+
+  describe("send", () => {
+    let send = jest.fn();
+
+    beforeEach(() => {
+      pw.Component.init(document.querySelector("html"));
+      pw.Component.instances[0].connection.send = send;
+    });
+
+    test("sends a stringified object through the connection", () => {
+      pw.Component.instances[0].send({ foo: "bar" }, "foo");
+      expect(send).toHaveBeenCalledWith("{\"type\":\"foo\",\"payload\":{\"foo\":\"bar\"}}");
+    });
+
+    test("sends with unknown type when type is not passed", () => {
+      pw.Component.instances[0].send({ foo: "bar" });
+      expect(send).toHaveBeenCalledWith("{\"type\":\"unknown\",\"payload\":{\"foo\":\"bar\"}}");
+    });
+  });
+});

--- a/pakyow-js/__tests__/features/logger.spec.js
+++ b/pakyow-js/__tests__/features/logger.spec.js
@@ -1,0 +1,54 @@
+require("./support/helpers/setup.js");
+
+describe("logger", () => {
+  describe("log", () => {
+    let socket = {
+      send: jest.fn()
+    };
+
+    let perform = () => {
+      pw.logger.log("error", "error", "foo", "bar");
+    };
+
+    afterEach(() => {
+      socket.send.mockClear();
+    });
+
+    describe("socket is available", () => {
+      beforeEach(() => {
+        pw.server.socket = socket;
+      });
+
+      describe("server is reachable", () => {
+        beforeEach(() => {
+          pw.server.reachable = true;
+        });
+
+        test("sends each message", () => {
+          perform();
+
+          expect(socket.send.mock.calls).toEqual(
+            [
+              [{ severity: "error", message: "foo" }, "log"],
+              [{ severity: "error", message: "bar" }, "log"]
+            ]
+          );
+        });
+      });
+
+      describe("server is unreachable", () => {
+        test("does not log", () => {
+          expect(socket.send).not.toHaveBeenCalled();
+          perform();
+        });
+      });
+    });
+
+    describe("socket is unavailable", () => {
+      test("does not log", () => {
+        expect(socket.send).not.toHaveBeenCalled();
+        perform();
+      });
+    });
+  });
+});

--- a/pakyow-js/__tests__/features/logger/flush.spec.js
+++ b/pakyow-js/__tests__/features/logger/flush.spec.js
@@ -1,0 +1,42 @@
+require("../support/helpers/setup.js");
+
+describe("logger", () => {
+  describe("flush", () => {
+    let socket = {
+      send: jest.fn()
+    };
+
+    beforeEach(() => {
+      pw.logger.log("unknown", "log", "foo");
+      pw.logger.log("error", "error", "bar");
+
+      pw.server.socket = socket;
+      pw.server.reachable = true;
+    });
+
+    afterEach(() => {
+      socket.send.mockClear();
+    });
+
+    test("sends each unsent message", () => {
+      pw.logger.flush();
+
+      expect(socket.send.mock.calls).toEqual(
+        [
+          [{ severity: "unknown", message: "foo" }, "log"],
+          [{ severity: "error", message: "bar" }, "log"]
+        ]
+      );
+    });
+
+    describe("flushed again", () => {
+      test("does not send anything", () => {
+        pw.logger.flush();
+        socket.send.mockClear();
+
+        expect(socket.send).not.toHaveBeenCalled();
+        pw.logger.flush();
+      });
+    });
+  });
+});

--- a/pakyow-js/__tests__/features/logger/install.spec.js
+++ b/pakyow-js/__tests__/features/logger/install.spec.js
@@ -1,0 +1,105 @@
+require("../support/helpers/setup.js");
+
+describe("logger", () => {
+  describe("install", () => {
+    let logSpy;
+
+    let consoleLogSpy = jest.fn();
+    let consoleDebugSpy = jest.fn();
+    let consoleInfoSpy = jest.fn();
+    let consoleWarnSpy = jest.fn();
+    let consoleErrorSpy = jest.fn();
+    let consoleTraceSpy = jest.fn();
+
+    beforeEach(() => {
+      logSpy = jest.spyOn(pw.logger, "log");
+
+      console.log = consoleLogSpy;
+      console.debug = consoleDebugSpy;
+      console.info = consoleInfoSpy;
+      console.warn = consoleWarnSpy;
+      console.error = consoleErrorSpy;
+      console.trace = consoleTraceSpy;
+
+      pw.logger.install();
+    });
+
+    afterEach(() => {
+      logSpy.mockClear();
+
+      consoleLogSpy.mockClear();
+      consoleDebugSpy.mockClear();
+      consoleInfoSpy.mockClear();
+      consoleWarnSpy.mockClear();
+      consoleErrorSpy.mockClear();
+      consoleTraceSpy.mockClear();
+    });
+
+    describe("log", () => {
+      test("logs with the logger", () => {
+        console.log("foo", "bar");
+        expect(logSpy).toHaveBeenCalledWith("unknown", "log", "foo", "bar");
+      });
+
+      test("calls the original console.log method", () => {
+        console.log("foo", "bar");
+        expect(consoleLogSpy).toHaveBeenCalledWith("foo", "bar");
+      });
+    });
+
+    describe("debug", () => {
+      test("logs with the logger", () => {
+        console.debug("foo", "bar");
+        expect(logSpy).toHaveBeenCalledWith("debug", null, "foo", "bar");
+      });
+
+      test("calls the original console.debug method", () => {
+        console.debug("foo", "bar");
+        expect(consoleDebugSpy).toHaveBeenCalledWith("foo", "bar");
+      });
+    });
+
+    describe("info", () => {
+      test("logs with the logger", () => {
+        console.info("foo", "bar");
+        expect(logSpy).toHaveBeenCalledWith("info", null, "foo", "bar");
+      });
+
+      test("calls the original console.info method", () => {
+        console.info("foo", "bar");
+        expect(consoleInfoSpy).toHaveBeenCalledWith("foo", "bar");
+      });
+    });
+
+    describe("warn", () => {
+      test("logs with the logger", () => {
+        console.warn("foo", "bar");
+        expect(logSpy).toHaveBeenCalledWith("warn", null, "foo", "bar");
+      });
+
+      test("calls the original console.warn method", () => {
+        console.warn("foo", "bar");
+        expect(consoleWarnSpy).toHaveBeenCalledWith("foo", "bar");
+      });
+    });
+
+    describe("error", () => {
+      test("logs with the logger", () => {
+        console.error("foo", "bar");
+        expect(logSpy).toHaveBeenCalledWith("error", null, "foo", "bar");
+      });
+
+      test("calls the original console.error method", () => {
+        console.error("foo", "bar");
+        expect(consoleErrorSpy).toHaveBeenCalledWith("foo", "bar");
+      });
+    });
+
+    describe("unknown console methods", () => {
+      test("calls the original console method", () => {
+        console.trace();
+        expect(consoleTraceSpy).toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/pakyow-js/__tests__/features/ready/logger.spec.js
+++ b/pakyow-js/__tests__/features/ready/logger.spec.js
@@ -1,0 +1,36 @@
+require("../support/helpers/setup.js");
+
+describe("ready", () => {
+  let ready = () => {
+    require("../../../index");
+    document.dispatchEvent(
+      new CustomEvent("DOMContentLoaded")
+    );
+  }
+
+  describe("logger", () => {
+    test("installs the logger", () => {
+      let spy = jest.spyOn(pw.logger, "install");
+      ready();
+      expect(spy).toHaveBeenCalled();
+    });
+
+    describe("global socket connects", () => {
+      test("flushes the logger", () => {
+        ready();
+        let spy = jest.spyOn(pw.logger, "flush");
+        pw.broadcast("pw:socket:connected", { config: { global: true } });
+        expect(spy).toHaveBeenCalled();
+      });
+    });
+
+    describe("non-global socket connects", () => {
+      test("does not flush the logger", () => {
+        ready();
+        let spy = jest.spyOn(pw.logger, "flush");
+        pw.broadcast("pw:socket:connected", { config: {} });
+        expect(spy).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/pakyow-js/__tests__/features/ready/reachability.spec.js
+++ b/pakyow-js/__tests__/features/ready/reachability.spec.js
@@ -1,0 +1,82 @@
+require("../support/helpers/setup.js");
+
+describe("ready", () => {
+  let ready = () => {
+    require("../../../index");
+    document.dispatchEvent(
+      new CustomEvent("DOMContentLoaded")
+    );
+  }
+
+  describe("reachability", () => {
+    describe("global socket connects", () => {
+      test("sets the server as reachable", () => {
+        ready();
+        expect(pw.server.reachable).toEqual(false);
+        pw.broadcast("pw:socket:connected", { config: { global: true } });
+        expect(pw.server.reachable).toEqual(true);
+      });
+    });
+
+    describe("global socket disconnects", () => {
+      beforeEach(() => {
+        ready();
+        pw.broadcast("pw:socket:connected", { config: { global: true } });
+      });
+
+      test("sets the server as unreachable", () => {
+        expect(pw.server.reachable).toEqual(true);
+        pw.broadcast("pw:socket:disconnected", { config: { global: true } });
+        expect(pw.server.reachable).toEqual(false);
+      });
+    });
+
+    describe("global socket disappears", () => {
+      beforeEach(() => {
+        ready();
+        pw.broadcast("pw:socket:connected", { config: { global: true } });
+      });
+
+      test("sets the server as unreachable", () => {
+        expect(pw.server.reachable).toEqual(true);
+        pw.broadcast("pw:socket:disappeared", { config: { global: true } });
+        expect(pw.server.reachable).toEqual(false);
+      });
+    });
+
+    describe("non-global socket connects", () => {
+      test("does not set the server as reachable", () => {
+        ready();
+        expect(pw.server.reachable).toEqual(false);
+        pw.broadcast("pw:socket:connected", { config: {} });
+        expect(pw.server.reachable).toEqual(false);
+      });
+    });
+
+    describe("non-global socket disconnects", () => {
+      beforeEach(() => {
+        ready();
+        pw.broadcast("pw:socket:connected", { config: { global: true } });
+      });
+
+      test("does not set the server as unreachable", () => {
+        expect(pw.server.reachable).toEqual(true);
+        pw.broadcast("pw:socket:disconnected", { config: {} });
+        expect(pw.server.reachable).toEqual(true);
+      });
+    });
+
+    describe("non-global socket disappears", () => {
+      beforeEach(() => {
+        ready();
+        pw.broadcast("pw:socket:connected", { config: { global: true } });
+      });
+
+      test("does not set the server as unreachable", () => {
+        expect(pw.server.reachable).toEqual(true);
+        pw.broadcast("pw:socket:disappeared", { config: {} });
+        expect(pw.server.reachable).toEqual(true);
+      });
+    });
+  });
+});

--- a/pakyow-js/__tests__/features/ready/socket.spec.js
+++ b/pakyow-js/__tests__/features/ready/socket.spec.js
@@ -1,0 +1,56 @@
+require("../support/helpers/setup.js");
+
+describe("ready", () => {
+  let ready = () => {
+    require("../../../index");
+    document.dispatchEvent(
+      new CustomEvent("DOMContentLoaded")
+    );
+  }
+
+  describe("socket", () => {
+    let globalSocket = { config: { global: true } };
+
+    describe("global socket connects", () => {
+      test("sets the server socket", () => {
+        ready();
+        expect(pw.server.socket).toEqual(undefined);
+        pw.broadcast("pw:socket:connected", globalSocket);
+        expect(pw.server.socket).toBe(globalSocket);
+      });
+    });
+
+    describe("global socket disconnects", () => {
+      beforeEach(() => {
+        ready();
+        pw.broadcast("pw:socket:connected", globalSocket);
+      });
+
+      test("unsets the server socket", () => {
+        expect(pw.server.socket).toBe(globalSocket);
+        pw.broadcast("pw:socket:disconnected", globalSocket);
+        expect(pw.server.socket).toEqual(null);
+      });
+    });
+
+    describe("non-global socket connects", () => {
+      test("does not set the server socket", () => {
+        pw.broadcast("pw:socket:connected", { config: {} });
+        expect(pw.server.socket).toEqual(null);
+      });
+    });
+
+    describe("non-global socket disconnects", () => {
+      beforeEach(() => {
+        ready();
+        pw.broadcast("pw:socket:connected", globalSocket);
+      });
+
+      test("does not unset the server socket", () => {
+        expect(pw.server.socket).toBe(globalSocket);
+        pw.broadcast("pw:socket:disconnected", { config: {} });
+        expect(pw.server.socket).toBe(globalSocket);
+      });
+    });
+  });
+});

--- a/pakyow-js/__tests__/features/support/helpers/setup.js
+++ b/pakyow-js/__tests__/features/support/helpers/setup.js
@@ -1,1 +1,3 @@
+require("mutationobserver-shim");
+global.MutationObserver = window.MutationObserver;
 global.pw = require("../../../../src/index");

--- a/pakyow-js/index.js
+++ b/pakyow-js/index.js
@@ -2,18 +2,29 @@ import * as pw from "./src";
 import {default as Transformer} from "./src/internal/transformer";
 
 pw.ready(function () {
+  pw.logger.install();
+
   var pwGlobal = new (pw.Component.create())(new pw.View(document), {});
 
-  pwGlobal.listen("pw:socket:connected", () => {
-    pw.server.reachable = true;
+  pwGlobal.listen("pw:socket:connected", (socket) => {
+    if (socket.config.global) {
+      pw.server.reachable = true;
+      pw.server.socket = socket;
+      pw.logger.flush();
+    }
   });
 
-  pwGlobal.listen("pw:socket:disconnected", () => {
-    pw.server.reachable = false;
+  pwGlobal.listen("pw:socket:disconnected", (socket) => {
+    if (socket.config.global) {
+      pw.server.reachable = false;
+      pw.server.socket = null;
+    }
   });
 
-  pwGlobal.listen("pw:socket:disappeared", () => {
-    pw.server.reachable = false;
+  pwGlobal.listen("pw:socket:disappeared", (socket) => {
+    if (socket.config.global) {
+      pw.server.reachable = false;
+    }
   });
 
   pwGlobal.listen("pw:socket:message:transformation", (message) => {

--- a/pakyow-js/package.json
+++ b/pakyow-js/package.json
@@ -44,6 +44,7 @@
     "testEnvironment": "jest-environment-jsdom-global",
     "setupFiles": [
       "jest-localstorage-mock"
-    ]
+    ],
+    "clearMocks": true
   }
 }

--- a/pakyow-js/src/component.js
+++ b/pakyow-js/src/component.js
@@ -93,6 +93,10 @@ export default class {
 
       for (let uiComponent of uiComponents) {
         try {
+          if (uiComponent.config.debug) {
+            console.debug(`[component] \`${uiComponent.name}': initializing`);
+          }
+
           let object = components[uiComponent.name] || this.create();
           let instance = new object(view, Object.assign({ name: uiComponent.name }, uiComponent.config));
           instances.push(instance);
@@ -114,8 +118,12 @@ export default class {
           }
 
           instance.appear();
+
+          if (instance.config.debug) {
+            console.debug(`[component] \`${uiComponent.name}': initialized`);
+          }
         } catch (error) {
-          console.log(`failed to initialize component \`${uiComponent.name}': ${error}`);
+          console.error(`failed to initialize component \`${uiComponent.name}': ${error}`);
         }
       }
     }
@@ -209,6 +217,10 @@ export default class {
     };
 
     component.prototype.listen = function (channel, callback) {
+      if (this.config.debug) {
+        console.debug(`[component] ${this.config.name} listening for events on \`${channel}'`);
+      }
+
       this.node.addEventListener(channel, (evt) => {
         callback.call(this, evt.detail);
       });
@@ -222,6 +234,10 @@ export default class {
     };
 
     component.prototype.ignore = function (channel) {
+      if (this.config.debug) {
+        console.debug(`[component] ${this.config.name} ignoring events on \`${channel}'`);
+      }
+
       broadcasts[channel].filter((tuple) => {
         return tuple[0].view.node === this.view.node;
       }).forEach((tuple) => {
@@ -233,12 +249,20 @@ export default class {
     };
 
     component.prototype.trigger = function (channel, payload) {
+      if (this.config.debug) {
+        console.debug(`[component] ${this.config.name} triggering \`${channel}': ${JSON.stringify(payload)}`);
+      }
+
       this.view.node.dispatchEvent(
         new CustomEvent(channel, { detail: payload })
       );
     };
 
     component.prototype.bubble = function (channel, payload) {
+      if (this.config.debug) {
+        console.debug(`[component] ${this.config.name} bubbling \`${channel}': ${JSON.stringify(payload)}`);
+      }
+
       this.view.node.dispatchEvent(
         new CustomEvent(channel, { bubbles: true, detail: payload })
       );

--- a/pakyow-js/src/components/socket.js
+++ b/pakyow-js/src/components/socket.js
@@ -71,6 +71,17 @@ pw.define("socket", {
   },
 
   beat() {
-    this.connection.send("beat");
+    this.send("beat");
+  },
+
+  send(payload, type = "unknown") {
+    this.connection.send(
+      JSON.stringify(
+        {
+          type: type,
+          payload: payload
+        }
+      )
+    );
   }
 });

--- a/pakyow-js/src/index.js
+++ b/pakyow-js/src/index.js
@@ -1,5 +1,6 @@
 export {default as broadcast} from "./broadcast";
 export {default as define} from "./define";
+export {default as logger} from "./logger";
 export {default as ready} from "./ready";
 export {default as send} from "./send";
 export {default as server} from "./server";

--- a/pakyow-js/src/internal/transformer.js
+++ b/pakyow-js/src/internal/transformer.js
@@ -39,10 +39,10 @@ export default class {
             )
           );
         } else {
-          console.log(`unknown view method: ${methodName}`, transformable);
+          console.warn(`unknown view method: ${methodName}`, transformable);
         }
       } catch(error) {
-        console.log("error transforming", error, transformable, transformation, calls);
+        console.error("error transforming", error, transformable, transformation, calls);
       }
     }
   }

--- a/pakyow-js/src/logger.js
+++ b/pakyow-js/src/logger.js
@@ -1,0 +1,60 @@
+var unsent = [];
+
+export default class {
+  static install() {
+    let original = window.console;
+
+    window.console = {
+      log: (...args) => {
+        pw.logger.log.apply(null, ["unknown", "log"].concat(args));
+        original.log.apply(null, args);
+      },
+
+      debug: (...args) => {
+        pw.logger.log.apply(null, ["debug", null].concat(args));
+        original.debug.apply(null, args);
+      },
+
+      info: (...args) => {
+        pw.logger.log.apply(null, ["info", null].concat(args));
+        original.info.apply(null, args);
+      },
+
+      warn: (...args) => {
+        pw.logger.log.apply(null, ["warn", null].concat(args));
+        original.warn.apply(null, args);
+      },
+
+      error: (...args) => {
+        pw.logger.log.apply(null, ["error", null].concat(args));
+        original.error.apply(null, args);
+      }
+    };
+
+    for (let prop in original) {
+      if (!window.console.hasOwnProperty(prop)) {
+        window.console[prop] = original[prop];
+      }
+    }
+  }
+
+  static flush() {
+    let message;
+    while (message = unsent.shift()) {
+      this.log.apply(null, [message[0], message[1]].concat(message[2]));
+    }
+  }
+
+  static log(severity, method, ...messages) {
+    if (pw.server.socket && pw.server.reachable) {
+      for (let message of messages) {
+        pw.server.socket.send({
+          severity: severity,
+          message: message
+        }, "log");
+      }
+    } else {
+      unsent.push([severity, method || severity, messages]);
+    }
+  }
+}

--- a/pakyow-js/src/server.js
+++ b/pakyow-js/src/server.js
@@ -1,4 +1,5 @@
 var reachable = false;
+var socket;
 
 export default class {
   static get reachable() {
@@ -7,5 +8,13 @@ export default class {
 
   static set reachable(value) {
     reachable = !!value;
+  }
+
+  static get socket() {
+    return socket;
+  }
+
+  static set socket(value) {
+    socket = value;
   }
 }

--- a/pakyow-realtime/CHANGELOG.md
+++ b/pakyow-realtime/CHANGELOG.md
@@ -5,6 +5,7 @@
   * [changed] Send heartbeats every second from websocket instances
     * This and the change prior seem to resolve intermittent timeouts on production
   * [added] WebSocket message handlers
+  * [changed] Installed WebSocket is now configured to be a global socket
 
 # 1.0
 

--- a/pakyow-realtime/CHANGELOG.md
+++ b/pakyow-realtime/CHANGELOG.md
@@ -4,6 +4,7 @@
   * [changed] Let websocket instances manage their own heartbeats, rather than the websocket server
   * [changed] Send heartbeats every second from websocket instances
     * This and the change prior seem to resolve intermittent timeouts on production
+  * [added] WebSocket message handlers
 
 # 1.0
 

--- a/pakyow-realtime/lib/pakyow/application/behavior/realtime/handling.rb
+++ b/pakyow-realtime/lib/pakyow/application/behavior/realtime/handling.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "pakyow/support/extension"
+
+module Pakyow
+  class Application
+    module Behavior
+      module Realtime
+        # Handles incoming websocket messages.
+        #
+        module Handling
+          extend Support::Extension
+
+          apply_extension do
+            class_state :__websocket_handlers, default: {}
+          end
+
+          class_methods do
+            def handle_websocket_message(type, &block)
+              (@__websocket_handlers[type.to_s] ||= []) << block
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/pakyow-realtime/lib/pakyow/presenter/renderer/behavior/realtime/install_websocket.rb
+++ b/pakyow-realtime/lib/pakyow/presenter/renderer/behavior/realtime/install_websocket.rb
@@ -41,7 +41,7 @@ module Pakyow
                     end
                   end
 
-                  attributes["data-ui"] = "socket(endpoint: #{endpoint}?id=#{presentables[:__verifier].sign(presentables[:__socket_client_id])})"
+                  attributes["data-ui"] = "socket(global: true, endpoint: #{endpoint}?id=#{presentables[:__verifier].sign(presentables[:__socket_client_id])})"
                 end
               end
 

--- a/pakyow-realtime/lib/pakyow/realtime/framework.rb
+++ b/pakyow-realtime/lib/pakyow/realtime/framework.rb
@@ -7,6 +7,7 @@ require "pakyow/application/helpers/realtime/subscriptions"
 require "pakyow/application/helpers/realtime/socket"
 
 require "pakyow/application/config/realtime"
+require "pakyow/application/behavior/realtime/handling"
 require "pakyow/application/behavior/realtime/serialization"
 require "pakyow/application/behavior/realtime/server"
 require "pakyow/application/behavior/realtime/silencing"
@@ -28,6 +29,7 @@ module Pakyow
 
           include Application::Config::Realtime
           include Application::Behavior::Realtime::Server
+          include Application::Behavior::Realtime::Handling
           include Application::Behavior::Realtime::Silencing
           include Application::Behavior::Realtime::Serialization
 

--- a/pakyow-realtime/lib/pakyow/realtime/websocket.rb
+++ b/pakyow-realtime/lib/pakyow/realtime/websocket.rb
@@ -38,26 +38,13 @@ module Pakyow
       include Pakyow::Application::Helpers::Application
       include Pakyow::Application::Helpers::Connection
 
-      attr_reader :id
+      attr_reader :id, :connection, :logger
 
       def initialize(id, connection)
         @id, @connection, @open = id, connection, false
         @logger = Logger.new(:sock, id: @id[0..7], output: Pakyow.global_logger, level: Pakyow.config.logger.level)
         @server = @connection.app.websocket_server
-
-        response = Async::WebSocket::Adapters::Native.open(@connection.request, handler: Connection) do |socket|
-          @socket = socket
-
-          handle_open
-          while message = socket.read
-            handle_message(message)
-          end
-        rescue EOFError, Protocol::WebSocket::ClosedError
-        ensure
-          @socket&.close; shutdown
-        end
-
-        @connection.__getobj__.instance_variable_set(:@response, response)
+        open
       end
 
       def open?
@@ -96,6 +83,22 @@ module Pakyow
 
       private
 
+      def open
+        response = Async::WebSocket::Adapters::Native.open(@connection.request, handler: Connection) do |socket|
+          @socket = socket
+
+          handle_open
+          while message = socket.read
+            handle_message(message)
+          end
+        rescue EOFError, Protocol::WebSocket::ClosedError
+        ensure
+          @socket&.close; shutdown
+        end
+
+        @connection.__getobj__.instance_variable_set(:@response, response)
+      end
+
       def handle_open
         @server.socket_connect(self)
         @open = true
@@ -105,10 +108,17 @@ module Pakyow
         start_heartbeat
       end
 
-      def handle_message(message)
+      def handle_message(raw)
         @logger.internal {
-          "< " + message
+          "< " + raw
         }
+
+        message = JSON.parse(raw)
+        if handlers = @connection.app.class.__websocket_handlers[message["type"]]
+          handlers.each do |handler|
+            instance_exec(message["payload"], &handler)
+          end
+        end
       end
 
       def trigger_presence(event)

--- a/pakyow-realtime/spec/context/websocket_context.rb
+++ b/pakyow-realtime/spec/context/websocket_context.rb
@@ -1,0 +1,32 @@
+RSpec.shared_context "websocket" do
+  class MockConnection
+    attr_reader :app
+
+    def initialize(app)
+      @app = app
+    end
+  end
+
+  class MockWebSocket < Pakyow::Realtime::WebSocket
+    def initialize(app)
+      id = SecureRandom.hex(4)
+      connection = MockConnection.new(app)
+      super(id, connection)
+    end
+
+    def open
+    end
+
+    def <<(payload)
+      handle_message(payload.to_json)
+    end
+  end
+
+  let :websocket do
+    MockWebSocket.new(Pakyow.app(websocket_app_name))
+  end
+
+  let :websocket_app_name do
+    :test
+  end
+end

--- a/pakyow-realtime/spec/features/installing_spec.rb
+++ b/pakyow-realtime/spec/features/installing_spec.rb
@@ -1,0 +1,40 @@
+RSpec.describe "installing the socket" do
+  include_context "app"
+
+  before do
+    allow(Pakyow::Support::MessageVerifier).to receive(:key).and_return("12321")
+    Pakyow.config.server.proxy = false
+  end
+
+  it "installs the socket" do
+    expect(call("/")[2]).to include_sans_whitespace(
+      <<~HTML
+        <meta name="pw-socket" data-ui="socket(global: true, endpoint: ws://localhost/pw-socket?id=MTIzMjE=--FGhnpS-4JBlFz4V-78zKBAIr0m7e-Mf1mryud9JZt0U=)">
+      HTML
+    )
+  end
+
+  context "running in proxy mode" do
+    before do
+      Pakyow.config.server.proxy = true
+    end
+
+    it "configures the socket to connect directly to the app" do
+      expect(call("/")[2]).to include_sans_whitespace(
+        <<~HTML
+          <meta name="pw-socket" data-ui="socket(global: true, endpoint: ws://localhost:3000/pw-socket?id=MTIzMjE=--FGhnpS-4JBlFz4V-78zKBAIr0m7e-Mf1mryud9JZt0U=)">
+        HTML
+      )
+    end
+  end
+
+  context "secure request" do
+    it "configures the socket to connect with wss" do
+      expect(call("/", scheme: "https")[2]).to include_sans_whitespace(
+        <<~HTML
+          <meta name="pw-socket" data-ui="socket(global: true, endpoint: wss://localhost/pw-socket?id=MTIzMjE=--FGhnpS-4JBlFz4V-78zKBAIr0m7e-Mf1mryud9JZt0U=)">
+        HTML
+      )
+    end
+  end
+end

--- a/pakyow-realtime/spec/features/message_handling_spec.rb
+++ b/pakyow-realtime/spec/features/message_handling_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe "message handling" do
+  include_context "app"
+  include_context "websocket"
+
+  let :app_def do
+    local = self
+    Proc.new do
+      handle_websocket_message :test1 do |payload|
+        local.calls << ["test1", payload, self]
+      end
+
+      handle_websocket_message :test2 do |payload|
+        local.calls << ["test2", payload, self]
+      end
+    end
+  end
+
+  let :calls do
+    []
+  end
+
+  before do
+    websocket << {
+      type: "test1", payload: "foo"
+    }
+  end
+
+  it "calls the handler with the payload" do
+    expect(calls.count).to eq(1)
+    expect(calls[0][0]).to eq("test1")
+    expect(calls[0][1]).to eq("foo")
+  end
+
+  describe "handler call context" do
+    it "is the websocket instance" do
+      expect(calls[0][2]).to be_a(Pakyow::Realtime::WebSocket)
+    end
+  end
+end

--- a/pakyow-realtime/spec/spec_helper.rb
+++ b/pakyow-realtime/spec/spec_helper.rb
@@ -20,6 +20,7 @@ RSpec.configure do |spec_config|
   end
 end
 
+require_relative "context/websocket_context"
 require_relative "../../spec/context/app_context"
 require_relative "../../spec/context/suppressed_output_context"
 

--- a/pakyow-ui/CHANGELOG.md
+++ b/pakyow-ui/CHANGELOG.md
@@ -2,6 +2,7 @@
 
   * [added] Log errors encountered when setting up ui subscriptions
   * [fixed] Issue causing data subscriptions to never be expired for a web socket connection
+  * [added] WebSocket message handler for logging from the ui
 
 # 1.0
 

--- a/pakyow-ui/lib/pakyow/application/behavior/ui/logging.rb
+++ b/pakyow-ui/lib/pakyow/application/behavior/ui/logging.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "pakyow/support/extension"
+
+module Pakyow
+  class Application
+    module Behavior
+      module UI
+        # Logs client-side messages and errors on the server.
+        #
+        module Logging
+          extend Support::Extension
+
+          apply_extension do
+            handle_websocket_message :log do |payload|
+              Logging.log(payload, self)
+            end
+          end
+
+          # @api private
+          def self.log(payload, socket)
+            socket.logger.public_send(payload["severity"], payload["message"])
+          end
+        end
+      end
+    end
+  end
+end

--- a/pakyow-ui/lib/pakyow/ui/framework.rb
+++ b/pakyow-ui/lib/pakyow/ui/framework.rb
@@ -6,6 +6,7 @@ require "pakyow/framework"
 
 require "pakyow/application/helpers/ui"
 
+require "pakyow/application/behavior/ui/logging"
 require "pakyow/application/behavior/ui/recording"
 require "pakyow/application/behavior/ui/rendering"
 require "pakyow/application/behavior/ui/timeouts"
@@ -35,6 +36,7 @@ module Pakyow
         object.class_eval do
           register_helper :passive, Application::Helpers::UI
 
+          include Application::Behavior::UI::Logging
           include Application::Behavior::UI::Recording
           include Application::Behavior::UI::Rendering
           include Application::Behavior::UI::Timeouts

--- a/pakyow-ui/spec/features/ui_logging_spec.rb
+++ b/pakyow-ui/spec/features/ui_logging_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe "ui logging" do
+  include_context "app"
+
+  it "registers a `log' handler" do
+    expect(Pakyow.app(:test).class.__websocket_handlers["log"].count).to eq(1)
+  end
+
+  describe "handler" do
+    let :payload do
+      {}
+    end
+
+    let :socket do
+      double
+    end
+
+    it "calls Pakyow::Application::Behavior::UI::Logging::log" do
+      expect(Pakyow::Application::Behavior::UI::Logging).to receive(:log).with(payload, Test::Application)
+      Pakyow.app(:test).class.__websocket_handlers["log"][0].call(payload, socket)
+    end
+  end
+end

--- a/pakyow-ui/spec/unit/application/behavior/logging_spec.rb
+++ b/pakyow-ui/spec/unit/application/behavior/logging_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe Pakyow::Application::Behavior::UI::Logging do
+  describe "::log" do
+    let :payload do
+      {
+        "severity" => "error",
+        "message" => "foo"
+      }
+    end
+
+    let :socket do
+      double(logger: logger)
+    end
+
+    let :logger do
+      double
+    end
+
+    it "logs the message at the severity using the socket's logger" do
+      expect(logger).to receive(:error).with("foo")
+      described_class.log(payload, socket)
+    end
+  end
+end

--- a/spec/context/app_context.rb
+++ b/spec/context/app_context.rb
@@ -74,7 +74,7 @@ RSpec.shared_context "app" do
   end
 
   DEFAULT_HEADERS = { "content-type" => "text/html" }.freeze
-  def call(path = "/", headers: {}, method: :get, tuple: true, input: nil, params: nil)
+  def call(path = "/", headers: {}, method: :get, tuple: true, input: nil, params: nil, scheme: "http")
     connection_for_call = nil
     allow_any_instance_of(Pakyow::Connection).to receive(:finalize).and_wrap_original do |method|
       connection_for_call = method.receiver
@@ -88,7 +88,7 @@ RSpec.shared_context "app" do
 
     body = Async::HTTP::Body::Buffered.wrap(input)
     request = Async::HTTP::Protocol::Request.new(
-      "http", "localhost", method.to_s.upcase, path, nil, Protocol::HTTP::Headers.new(DEFAULT_HEADERS.merge(headers).to_a), body
+      scheme, "localhost", method.to_s.upcase, path, nil, Protocol::HTTP::Headers.new(DEFAULT_HEADERS.merge(headers).to_a), body
     ).tap do |request|
       request.remote_address = Addrinfo.tcp("localhost", "http")
     end


### PR DESCRIPTION
Streams `console` logs from the client to the server, where they're logged with the websocket logger. Includes a new `debug` mode for client-side components that logs additional details. 

This was born out of a need to more easily debug issues on user's browsers in production. If bugs are reported that may relate to a particular component, place it in `debug` mode:

```html
<div ui="my-component(debug: true)">
  ...
</div>
```

```js
pw.define("my-component"), {
  constructor() {
    this.listen("foo", () => {
      console.log("called");
    });
  }
});

// some other component broadcasts:
pw.broadcast("foo", "bar");
```

Pakyow.js logs events for initialization, `listen`, `ignore`, `trigger`, and `bubble` to the console log, streaming events to the server through the current global websocket:

```
539.00μs sock.b054da05 | opened
   7.06s sock.b054da05 | [component] my-component initializing
   7.06s sock.b054da05 | [component] my-component listening for events on `foo'
   7.06s sock.b054da05 | [component] my-component initialized
  18.03s sock.b054da05 | [component] my-component triggering `foo': bar
  18.03s sock.b054da05 | called
  35.01s sock.b054da05 | shutdown
```

Note that the times (e.g. `7.06s`) roughly correspond to the time of the user's browser session, since the logger is created when the websocket connection is established. This provides insight into how the user uses the interface, especially when paired with custom log statements.

**Writing custom logs**

Use `console.log`, `console.error`, etc as you would normally.

**Collecting logs before the websocket connects**

`pw.logger` is installed as the first step in `ready()`, before the websocket connects. It queues log messages and flushes them to the server when the connection is established. This also works for periodic disconnects, helping to ensure that logs aren't missed.