### PR TITLE
Normalize HTTP/HTTPS

### DIFF
--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -15,8 +15,10 @@
   * [fixed] Methods defined an an app block are now correctly defined
   * [fixed] Issue with `Pakyow::Error` not detecting gems in rvm
   * [added] Enforce https rules in the normalizer controlled through two new config options:
+  * [added] Enforce https rules in the normalizer controlled through three new config options:
     * `normalizer.strict_https`: Enforces the https requirement if true
     * `normalizer.require_https`: Requires https scheme if true, otherwise http
+    * `normalizer.allowed_http_hosts`: Array of hosts that are allowed as http (e.g. localhost)
   * [added] Require https by default when running in production
 
 # 1.0.1

--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -14,6 +14,10 @@
   * [fixed] App connection path is relative to to the app mount path
   * [fixed] Methods defined an an app block are now correctly defined
   * [fixed] Issue with `Pakyow::Error` not detecting gems in rvm
+  * [added] Enforce https rules in the normalizer controlled through two new config options:
+    * `normalizer.strict_https`: Enforces the https requirement if true
+    * `normalizer.require_https`: Requires https scheme if true, otherwise http
+  * [added] Require https by default when running in production
 
 # 1.0.1
 

--- a/pakyow-core/lib/pakyow/actions/normalizer.rb
+++ b/pakyow-core/lib/pakyow/actions/normalizer.rb
@@ -11,7 +11,9 @@ module Pakyow
 
       def call(connection)
         if strict_https? && require_https? && !https?(connection)
-          redirect!(connection, "https://#{File.join(connection.authority, connection.fullpath)}")
+          unless http_allowed?(connection)
+            redirect!(connection, "https://#{File.join(connection.authority, connection.fullpath)}")
+          end
         elsif strict_https? && !require_https? && https?(connection)
           redirect!(connection, "http://#{File.join(connection.authority, connection.fullpath)}")
         elsif strict_www? && require_www? && !www?(connection) && !subdomain?(connection)
@@ -83,6 +85,10 @@ module Pakyow
 
       def require_https?
         Pakyow.config.normalizer.require_https == true
+      end
+
+      def http_allowed?(connection)
+        Pakyow.config.normalizer.allowed_http_hosts.include?(connection.host)
       end
     end
   end

--- a/pakyow-core/lib/pakyow/actions/normalizer.rb
+++ b/pakyow-core/lib/pakyow/actions/normalizer.rb
@@ -10,7 +10,11 @@ module Pakyow
       using Support::Refinements::String::Normalization
 
       def call(connection)
-        if strict_www? && require_www? && !www?(connection) && !subdomain?(connection)
+        if strict_https? && require_https? && !https?(connection)
+          redirect!(connection, "https://#{File.join(connection.authority, connection.fullpath)}")
+        elsif strict_https? && !require_https? && https?(connection)
+          redirect!(connection, "http://#{File.join(connection.authority, connection.fullpath)}")
+        elsif strict_www? && require_www? && !www?(connection) && !subdomain?(connection)
           redirect!(connection, File.join(add_www(connection), connection.path))
         elsif strict_www? && !require_www? && www?(connection)
           redirect!(connection, File.join(remove_www(connection), connection.path))
@@ -57,6 +61,10 @@ module Pakyow
         connection.subdomain == "www"
       end
 
+      def https?(connection)
+        connection.secure?
+      end
+
       def strict_path?
         Pakyow.config.normalizer.strict_path == true
       end
@@ -67,6 +75,14 @@ module Pakyow
 
       def require_www?
         Pakyow.config.normalizer.require_www == true
+      end
+
+      def strict_https?
+        Pakyow.config.normalizer.strict_https == true
+      end
+
+      def require_https?
+        Pakyow.config.normalizer.require_https == true
       end
     end
   end

--- a/pakyow-core/lib/pakyow/config.rb
+++ b/pakyow-core/lib/pakyow/config.rb
@@ -129,6 +129,7 @@ module Pakyow
 
         setting :strict_https, false
         setting :require_https, true
+        setting :allowed_http_hosts, ["localhost"]
 
         defaults :production do
           setting :strict_https, true

--- a/pakyow-core/lib/pakyow/config.rb
+++ b/pakyow-core/lib/pakyow/config.rb
@@ -123,8 +123,16 @@ module Pakyow
 
       configurable :normalizer do
         setting :strict_path, true
+
         setting :strict_www, false
         setting :require_www, true
+
+        setting :strict_https, false
+        setting :require_https, true
+
+        defaults :production do
+          setting :strict_https, true
+        end
       end
 
       configurable :tasks do

--- a/pakyow-core/spec/unit/actions/normalizer_spec.rb
+++ b/pakyow-core/spec/unit/actions/normalizer_spec.rb
@@ -9,14 +9,22 @@ RSpec.describe Pakyow::Actions::Normalizer do
       allow(connection).to receive(:host).and_return(host)
       allow(connection).to receive(:port).and_return(port)
       allow(connection).to receive(:authority).and_return("#{host}:#{port}")
+      allow(connection).to receive(:scheme).and_return(scheme)
     end
   end
 
   let :request do
-    instance_double(Async::HTTP::Protocol::Request)
+    instance_double(
+      Async::HTTP::Protocol::Request,
+      path: "#{path}#{query}"
+    )
   end
 
   let :path do
+    ""
+  end
+
+  let :query do
     ""
   end
 
@@ -26,6 +34,10 @@ RSpec.describe Pakyow::Actions::Normalizer do
 
   let :port do
     "80"
+  end
+
+  let :scheme do
+    "http"
   end
 
   before do
@@ -312,6 +324,206 @@ RSpec.describe Pakyow::Actions::Normalizer do
         end
 
         context "request uri is a subdomain" do
+          it "does not redirect" do
+            catch :halt do
+              action.call(connection)
+            end
+
+            expect(connection.status).to eq(200)
+            expect(connection.header?("Location")).to be(false)
+          end
+        end
+      end
+    end
+  end
+
+  describe "normalizing https" do
+    context "https is strict" do
+      before do
+        Pakyow.config.normalizer.strict_https = true
+      end
+
+      context "https is required" do
+        before do
+          Pakyow.config.normalizer.require_https = true
+        end
+
+        context "request uri is http" do
+          let :host do
+            "pakyow.com"
+          end
+
+          let :scheme do
+            "http"
+          end
+
+          it "redirects to the normalized path" do
+            catch :halt do
+              action.call(connection)
+            end
+
+            expect(connection.status).to eq(301)
+            expect(connection.header("Location")).to eq("https://pakyow.com:80/")
+          end
+
+          context "request uri has a query string" do
+            let :query do
+              "?foo=bar"
+            end
+
+            it "includes the query string in the normalized path" do
+              catch :halt do
+                action.call(connection)
+              end
+
+              expect(connection.status).to eq(301)
+              expect(connection.header("Location")).to eq("https://pakyow.com:80/?foo=bar")
+            end
+          end
+        end
+
+        context "request uri is https" do
+          let :host do
+            "pakyow.com"
+          end
+
+          let :scheme do
+            "https"
+          end
+
+          it "does not redirect" do
+            catch :halt do
+              action.call(connection)
+            end
+
+            expect(connection.status).to eq(200)
+            expect(connection.header?("Location")).to be(false)
+          end
+        end
+      end
+
+      context "https is not required" do
+        before do
+          Pakyow.config.normalizer.require_https = false
+        end
+
+        context "request uri is https" do
+          let :host do
+            "pakyow.com"
+          end
+
+          let :scheme do
+            "https"
+          end
+
+          it "redirects to the normalized path" do
+            catch :halt do
+              action.call(connection)
+            end
+
+            expect(connection.status).to eq(301)
+            expect(connection.header("Location")).to eq("http://pakyow.com:80/")
+          end
+
+          context "request uri has a query string" do
+            let :query do
+              "?foo=bar"
+            end
+
+            it "includes the query string in the normalized path" do
+              catch :halt do
+                action.call(connection)
+              end
+
+              expect(connection.status).to eq(301)
+              expect(connection.header("Location")).to eq("http://pakyow.com:80/?foo=bar")
+            end
+          end
+        end
+
+        context "request uri is not https" do
+          it "does not redirect" do
+            catch :halt do
+              action.call(connection)
+            end
+
+            expect(connection.status).to eq(200)
+            expect(connection.header?("Location")).to be(false)
+          end
+        end
+      end
+    end
+
+    context "https is not strict" do
+      before do
+        Pakyow.config.normalizer.strict_www = false
+      end
+
+      context "https is required" do
+        before do
+          Pakyow.config.normalizer.require_https = true
+        end
+
+        context "request uri is not https" do
+          let :host do
+            "pakyow.com"
+          end
+
+          let :scheme do
+            "http"
+          end
+
+          it "does not redirect" do
+            catch :halt do
+              action.call(connection)
+            end
+
+            expect(connection.status).to eq(200)
+            expect(connection.header?("Location")).to be(false)
+          end
+        end
+
+        context "request uri is https" do
+          let :host do
+            "https://pakyow.com"
+          end
+
+          it "does not redirect" do
+            catch :halt do
+              action.call(connection)
+            end
+
+            expect(connection.status).to eq(200)
+            expect(connection.header?("Location")).to be(false)
+          end
+        end
+      end
+
+      context "https is not required" do
+        before do
+          Pakyow.config.normalizer.require_https = false
+        end
+
+        context "request uri is https" do
+          let :host do
+            "pakyow.com"
+          end
+
+          let :scheme do
+            "https"
+          end
+
+          it "does not redirect" do
+            catch :halt do
+              action.call(connection)
+            end
+
+            expect(connection.status).to eq(200)
+            expect(connection.header?("Location")).to be(false)
+          end
+        end
+
+        context "request uri is not https" do
           it "does not redirect" do
             catch :halt do
               action.call(connection)

--- a/pakyow-core/spec/unit/actions/normalizer_spec.rb
+++ b/pakyow-core/spec/unit/actions/normalizer_spec.rb
@@ -380,6 +380,21 @@ RSpec.describe Pakyow::Actions::Normalizer do
               expect(connection.header("Location")).to eq("https://pakyow.com:80/?foo=bar")
             end
           end
+
+          context "request host is allowed as http" do
+            let :host do
+              "localhost"
+            end
+
+            it "does not redirect" do
+              catch :halt do
+                action.call(connection)
+              end
+
+              expect(connection.status).to eq(200)
+              expect(connection.header?("Location")).to be(false)
+            end
+          end
         end
 
         context "request uri is https" do

--- a/pakyow-core/spec/unit/environment/config_spec.rb
+++ b/pakyow-core/spec/unit/environment/config_spec.rb
@@ -202,6 +202,28 @@ RSpec.describe Pakyow do
       end
     end
 
+    describe "normalizer.strict_https" do
+      it "has a default value" do
+        expect(Pakyow.config.normalizer.strict_https).to eq(false)
+      end
+
+      context "in production" do
+        before do
+          Pakyow.configure!(:production)
+        end
+
+        it "defaults to true" do
+          expect(Pakyow.config.normalizer.strict_https).to eq(true)
+        end
+      end
+    end
+
+    describe "normalizer.require_https" do
+      it "has a default value" do
+        expect(Pakyow.config.normalizer.require_https).to eq(true)
+      end
+    end
+
     describe "tasks.paths" do
       it "has a default value" do
         expect(Pakyow.config.tasks.paths).to eq(["./tasks", File.expand_path("../../../../lib/pakyow/tasks", __FILE__)])

--- a/pakyow-core/spec/unit/environment/config_spec.rb
+++ b/pakyow-core/spec/unit/environment/config_spec.rb
@@ -224,6 +224,12 @@ RSpec.describe Pakyow do
       end
     end
 
+    describe "normalizer.allowed_http_hosts" do
+      it "has a default value" do
+        expect(Pakyow.config.normalizer.allowed_http_hosts).to eq(["localhost"])
+      end
+    end
+
     describe "tasks.paths" do
       it "has a default value" do
         expect(Pakyow.config.tasks.paths).to eq(["./tasks", File.expand_path("../../../../lib/pakyow/tasks", __FILE__)])


### PR DESCRIPTION
Allows Pakyow Environment to force http or https for some or all hosts.