### PR TITLE
Configure normalization through a canonical uri

### DIFF
--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -20,6 +20,7 @@
     * `normalizer.require_https`: Requires https scheme if true, otherwise http
     * `normalizer.allowed_http_hosts`: Array of hosts that are allowed as http (e.g. localhost)
   * [added] Require https by default when running in production
+  * [added] Configure normalization through a canonical uri
 
 # 1.0.1
 

--- a/pakyow-core/lib/pakyow/actions/normalizer.rb
+++ b/pakyow-core/lib/pakyow/actions/normalizer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "uri"
+
 require "pakyow/support/core_refinements/string/normalization"
 
 module Pakyow
@@ -9,6 +11,12 @@ module Pakyow
     class Normalizer
       using Support::Refinements::String::Normalization
 
+      def initialize
+        if canonical_uri = Pakyow.config.normalizer.canonical_uri
+          configure_canonical_uri!(canonical_uri)
+        end
+      end
+
       def call(connection)
         if strict_https? && require_https? && !https?(connection)
           unless http_allowed?(connection)
@@ -16,6 +24,8 @@ module Pakyow
           end
         elsif strict_https? && !require_https? && https?(connection)
           redirect!(connection, "http://#{File.join(connection.authority, connection.fullpath)}")
+        elsif strict_host? && !canonical?(connection)
+          redirect!(connection, "#{connection.scheme}://#{File.join(@canonical_uri.host, connection.fullpath)}")
         elsif strict_www? && require_www? && !www?(connection) && !subdomain?(connection)
           redirect!(connection, File.join(add_www(connection), connection.path))
         elsif strict_www? && !require_www? && www?(connection)
@@ -26,6 +36,17 @@ module Pakyow
       end
 
       private
+
+      def configure_canonical_uri!(canonical_uri)
+        @canonical_uri = if canonical_uri.is_a?(URI)
+          canonical_uri
+        else
+          URI(canonical_uri)
+        end
+
+        Pakyow.config.normalizer.require_https = @canonical_uri.scheme == "https"
+        Pakyow.config.normalizer.require_www = false
+      end
 
       def redirect!(connection, location)
         connection.status = 301
@@ -89,6 +110,14 @@ module Pakyow
 
       def http_allowed?(connection)
         Pakyow.config.normalizer.allowed_http_hosts.include?(connection.host)
+      end
+
+      def strict_host?
+        instance_variable_defined?(:@canonical_uri)
+      end
+
+      def canonical?(connection)
+        connection.host == @canonical_uri.host
       end
     end
   end

--- a/pakyow-core/lib/pakyow/config.rb
+++ b/pakyow-core/lib/pakyow/config.rb
@@ -122,6 +122,8 @@ module Pakyow
       end
 
       configurable :normalizer do
+        setting :canonical_uri
+
         setting :strict_path, true
 
         setting :strict_www, false

--- a/pakyow-core/spec/unit/environment/config_spec.rb
+++ b/pakyow-core/spec/unit/environment/config_spec.rb
@@ -184,6 +184,12 @@ RSpec.describe Pakyow do
       end
     end
 
+    describe "normalizer.canonical_uri" do
+      it "has a default value" do
+        expect(Pakyow.config.normalizer.canonical_uri).to eq(nil)
+      end
+    end
+
     describe "normalizer.strict_path" do
       it "has a default value" do
         expect(Pakyow.config.normalizer.strict_path).to eq(true)


### PR DESCRIPTION
Sets the host and scheme based on `normalizer.canonical_url` config option in the environment.

```ruby
Pakyow.config.normalizer.canonical_url = "https://pakyow.com"
```