### PR TITLE
Fix message verification when digest contains `--`

### DIFF
--- a/pakyow-core/spec/unit/app/connection/session/cookie_spec.rb
+++ b/pakyow-core/spec/unit/app/connection/session/cookie_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Pakyow::Application::Connection::Session::Cookie do
       context "session has been tampered with" do
         before do
           string = connection.cookies["test.session"]
-          signed, signature = Base64.urlsafe_decode64(string).split("--")
+          signed, signature = Base64.urlsafe_decode64(string).split(Pakyow::Support::MessageVerifier::JOIN_CHARACTER)
           object = Marshal.load(Base64.urlsafe_decode64(signed))
           object[:foo] = "baz"
 

--- a/pakyow-presenter/spec/features/csrf_meta_tags_spec.rb
+++ b/pakyow-presenter/spec/features/csrf_meta_tags_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "embedding csrf meta tags in a rendered view" do
       response_body = response[2]
       expect(response_body).to include("meta name=\"pw-authenticity-token\"")
 
-      authenticity_client_id, authenticity_digest = response_body.match(/name=\"pw-authenticity-token\" content=\"([^\"]+)\"/)[1].split("--")
+      authenticity_client_id, authenticity_digest = response_body.match(/name=\"pw-authenticity-token\" content=\"([^\"]+)\"/)[1].split(Pakyow::Support::MessageVerifier::JOIN_CHARACTER)
       computed_digest = Pakyow::Support::MessageVerifier.digest(Base64.decode64(authenticity_client_id), key: $connection_verifier_key)
 
       expect(authenticity_digest).to eq(computed_digest)

--- a/pakyow-presenter/spec/features/forms/csrf_spec.rb
+++ b/pakyow-presenter/spec/features/forms/csrf_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "forms csrf" do
         response_body = response[2]
         expect(response_body).to include("input type=\"hidden\" name=\"pw-authenticity-token\"")
 
-        authenticity_client_id, authenticity_digest = response_body.match(/name=\"pw-authenticity-token\" value=\"([^\"]+)\"/)[1].split("--")
+        authenticity_client_id, authenticity_digest = response_body.match(/name=\"pw-authenticity-token\" value=\"([^\"]+)\"/)[1].split(Pakyow::Support::MessageVerifier::JOIN_CHARACTER)
         computed_digest = Pakyow::Support::MessageVerifier.digest(Base64.decode64(authenticity_client_id), key: $connection_verifier_key)
 
         expect(authenticity_digest).to eq(computed_digest)
@@ -73,7 +73,8 @@ RSpec.describe "forms csrf" do
         response_body = response[2]
         expect(response_body).to include("input type=\"hidden\" name=\"pw-authenticity-token\"")
 
-        authenticity_client_id, authenticity_digest = response_body.match(/name=\"pw-authenticity-token\" value=\"([^\"]+)\"/)[1].split("--")
+        pp response_body.match(/name=\"pw-authenticity-token\" value=\"([^\"]+)\"/)[1]
+        authenticity_client_id, authenticity_digest = response_body.match(/name=\"pw-authenticity-token\" value=\"([^\"]+)\"/)[1].split("~")
         computed_digest = Pakyow::Support::MessageVerifier.digest(Base64.decode64(authenticity_client_id), key: $connection_verifier_key)
 
         expect(authenticity_digest).to eq(computed_digest)

--- a/pakyow-realtime/spec/features/installing_spec.rb
+++ b/pakyow-realtime/spec/features/installing_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "installing the socket" do
   it "installs the socket" do
     expect(call("/")[2]).to include_sans_whitespace(
       <<~HTML
-        <meta name="pw-socket" data-ui="socket(global: true, endpoint: ws://localhost/pw-socket?id=MTIzMjE=--FGhnpS-4JBlFz4V-78zKBAIr0m7e-Mf1mryud9JZt0U=)">
+        <meta name="pw-socket" data-ui="socket(global: true, endpoint: ws://localhost/pw-socket?id=MTIzMjE=~FGhnpS-4JBlFz4V-78zKBAIr0m7e-Mf1mryud9JZt0U=)">
       HTML
     )
   end
@@ -22,7 +22,7 @@ RSpec.describe "installing the socket" do
     it "configures the socket to connect directly to the app" do
       expect(call("/")[2]).to include_sans_whitespace(
         <<~HTML
-          <meta name="pw-socket" data-ui="socket(global: true, endpoint: ws://localhost:3000/pw-socket?id=MTIzMjE=--FGhnpS-4JBlFz4V-78zKBAIr0m7e-Mf1mryud9JZt0U=)">
+          <meta name="pw-socket" data-ui="socket(global: true, endpoint: ws://localhost:3000/pw-socket?id=MTIzMjE=~FGhnpS-4JBlFz4V-78zKBAIr0m7e-Mf1mryud9JZt0U=)">
         HTML
       )
     end
@@ -32,7 +32,7 @@ RSpec.describe "installing the socket" do
     it "configures the socket to connect with wss" do
       expect(call("/", scheme: "https")[2]).to include_sans_whitespace(
         <<~HTML
-          <meta name="pw-socket" data-ui="socket(global: true, endpoint: wss://localhost/pw-socket?id=MTIzMjE=--FGhnpS-4JBlFz4V-78zKBAIr0m7e-Mf1mryud9JZt0U=)">
+          <meta name="pw-socket" data-ui="socket(global: true, endpoint: wss://localhost/pw-socket?id=MTIzMjE=~FGhnpS-4JBlFz4V-78zKBAIr0m7e-Mf1mryud9JZt0U=)">
         HTML
       )
     end

--- a/pakyow-support/CHANGELOG.md
+++ b/pakyow-support/CHANGELOG.md
@@ -3,6 +3,7 @@
   * [changed] `Config` now supports multiple default config blocks per environnment
   * [changed] `Config#defaults` now supports passing multiple environments
   * [fixed] Bug that occurs if a named action shares a name with a method on the pipelined object
+  * [fixed] Message verification no longer fails when the digest contains `--`
 
 # 1.0
 

--- a/pakyow-support/lib/pakyow/support/message_verifier.rb
+++ b/pakyow-support/lib/pakyow/support/message_verifier.rb
@@ -11,7 +11,7 @@ module Pakyow
     class MessageVerifier
       attr_reader :key
 
-      JOIN_CHARACTER = "--"
+      JOIN_CHARACTER = "~"
 
       # TODO: support configuring the digest
       # TODO: support rotations by calling `rotate` with options

--- a/pakyow-support/spec/unit/message_verifier_spec.rb
+++ b/pakyow-support/spec/unit/message_verifier_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Pakyow::Support::MessageVerifier do
 
     it "encodes and signs the message" do
       expect(described_class).to receive(:digest).with(message, key: instance.key).and_return(digest)
-      expect(instance.sign(message)).to eq("#{Base64.urlsafe_encode64(message)}--#{digest}")
+      expect(instance.sign(message)).to eq("#{Base64.urlsafe_encode64(message)}~#{digest}")
     end
   end
 


### PR DESCRIPTION
Message verification fails from time to time because a url safe base64 encoded string sometimes contains `--`, which is the special join character we use when building the digest. We also want the digest to be url safe, and tilde is not used for url safe base64 encodes. So, this change replaces the existing join character `--` with a new join character `~`.