### PR TITLE
Introduce hookable observers

### DIFF
--- a/pakyow-support/lib/pakyow/support/hookable.rb
+++ b/pakyow-support/lib/pakyow/support/hookable.rb
@@ -149,7 +149,7 @@ module Pakyow
           call_hooks(:before, event_name, *args)
 
           value = increase_hookable_depth do
-            yield
+            yield if block_given?
           end
 
           call_hooks(:after, event_name, *args)

--- a/pakyow-support/spec/unit/hookable_spec.rb
+++ b/pakyow-support/spec/unit/hookable_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Pakyow::Support::Hookable do
           $context = self
         end
 
-        object.performing event do; end
+        object.performing event
 
         expect($context).to be(object)
       end
@@ -104,7 +104,7 @@ RSpec.describe Pakyow::Support::Hookable do
           $context = self
         end
 
-        object.performing event do; end
+        object.performing event
 
         expect($context).to be(object)
       end
@@ -114,7 +114,7 @@ RSpec.describe Pakyow::Support::Hookable do
           $context = self
         end
 
-        object.performing event do; end
+        object.performing event
 
         expect($context).to be(self)
       end
@@ -133,13 +133,13 @@ RSpec.describe Pakyow::Support::Hookable do
       end
 
       it "calls the observer before the event" do
-        object.performing events.first do; end
+        object.performing events.first
         expect(calls[0][0]).to eq(:before)
         expect(calls[0][1].name).to eq(events.first)
       end
 
       it "calls the observer after the event" do
-        object.performing events.first do; end
+        object.performing events.first
         expect(calls[1][0]).to eq(:after)
         expect(calls[1][1].name).to eq(events.first)
       end
@@ -277,18 +277,18 @@ RSpec.describe Pakyow::Support::Hookable do
         end
 
         it "observes the named hook" do
-          hookable.performing events.first do; end
+          hookable.performing events.first
           expect(calls[1][0]).to eq(:before)
           expect(calls[1][1].name).to eq(:"foo.bar")
         end
 
         it "correctly sets the event depth" do
-          hookable.performing events.first do; end
+          hookable.performing events.first
           expect(calls[1][1].depth).to eq(1)
         end
 
         it "observes in the correct order" do
-          hookable.performing events.first do; end
+          hookable.performing events.first
           expect(calls.map { |c| c[1].name }).to eq([:event_one, :"foo.bar", :"foo.bar", :event_one])
         end
       end
@@ -296,7 +296,7 @@ RSpec.describe Pakyow::Support::Hookable do
       context "nested event occurs" do
         before do
           hookable.performing events[0] do
-            hookable.performing events[1] do; end
+            hookable.performing events[1]
           end
         end
 
@@ -314,7 +314,7 @@ RSpec.describe Pakyow::Support::Hookable do
         before do
           hookable.performing events[0] do
             hookable.performing events[1] do
-              hookable.performing events[2] do; end
+              hookable.performing events[2]
             end
           end
         end
@@ -449,6 +449,14 @@ RSpec.describe Pakyow::Support::Hookable do
       expect(calls[3]).to eq 1
       expect(calls[4]).to eq 4
       expect(calls[5]).to eq 3
+    end
+  end
+
+  describe "performing without passing a block" do
+    it "performs" do
+      expect {
+        hookable.performing events.first
+      }.to_not raise_error
     end
   end
 end

--- a/pakyow-support/spec/unit/hookable_spec.rb
+++ b/pakyow-support/spec/unit/hookable_spec.rb
@@ -119,6 +119,215 @@ RSpec.describe Pakyow::Support::Hookable do
         expect($context).to be(self)
       end
     end
+
+    describe "observing events" do
+      before do
+        @calls = []
+        hookable.observe do |action, event|
+          @calls << [action, event.dup]
+        end
+      end
+
+      let :calls do
+        @calls
+      end
+
+      it "calls the observer before the event" do
+        object.performing events.first do; end
+        expect(calls[0][0]).to eq(:before)
+        expect(calls[0][1].name).to eq(events.first)
+      end
+
+      it "calls the observer after the event" do
+        object.performing events.first do; end
+        expect(calls[1][0]).to eq(:after)
+        expect(calls[1][1].name).to eq(events.first)
+      end
+
+      describe "the event" do
+        before do
+          object.performing events.first, &block
+        end
+
+        let :block do
+          proc {}
+        end
+
+        let :event do
+          calls[1][1]
+        end
+
+        it "has a name" do
+          expect(event.name).to eq(events.first)
+        end
+
+        it "has an object" do
+          expect(event.object).to be(object)
+        end
+
+        it "has a timestamp" do
+          expect(event.timestamp).to be_instance_of(Time)
+        end
+
+        it "has a depth" do
+          expect(event.depth).to eq(0)
+        end
+
+        describe "duration" do
+          let :block do
+            proc {
+              sleep 0.1
+            }
+          end
+
+          context "before" do
+            let :event do
+              calls[0][1]
+            end
+
+            context "unstarted" do
+              it "returns nil" do
+                expect(event.duration).to be(nil)
+              end
+            end
+
+            context "started" do
+              it "returns the computed duration" do
+                event.start!
+                sleep 0.1
+                expect(event.duration).to be_within(0.01).of(0.1)
+              end
+            end
+          end
+
+          context "after" do
+            let :event do
+              calls[1][1]
+            end
+
+            it "returns the total duration" do
+              expect(event.duration).to be_within(0.01).of(0.1)
+            end
+
+            it "does not recompute the total duration" do
+              sleep 0.1
+              expect(event.duration).to be_within(0.01).of(0.1)
+            end
+          end
+        end
+
+        describe "allocations" do
+          let :block do
+            proc {
+              String.new
+              String.new
+              String.new
+            }
+          end
+
+          context "before" do
+            let :event do
+              calls[0][1]
+            end
+
+            context "unstarted" do
+              it "returns nil" do
+                expect(event.allocations).to be(nil)
+              end
+            end
+
+            context "started" do
+              it "returns the computed allocations" do
+                event.start!
+                String.new
+                String.new
+                String.new
+                expect(event.allocations).to eq(3)
+              end
+            end
+          end
+
+          context "after" do
+            let :event do
+              calls[1][1]
+            end
+
+            let :overhead do
+              object.respond_to?(:new) ? 7 : 8
+            end
+
+            it "returns the total allocations" do
+              expect(event.allocations).to eq(3 + overhead)
+            end
+
+            it "does not recompute the total allocations" do
+              expect {
+                String.new
+              }.to_not change {
+                event.allocations
+              }
+            end
+          end
+        end
+      end
+
+      context "named hook is defined" do
+        before do
+          hookable.before events.first, "foo.bar" do; end
+        end
+
+        it "observes the named hook" do
+          hookable.performing events.first do; end
+          expect(calls[1][0]).to eq(:before)
+          expect(calls[1][1].name).to eq(:"foo.bar")
+        end
+
+        it "correctly sets the event depth" do
+          hookable.performing events.first do; end
+          expect(calls[1][1].depth).to eq(1)
+        end
+
+        it "observes in the correct order" do
+          hookable.performing events.first do; end
+          expect(calls.map { |c| c[1].name }).to eq([:event_one, :"foo.bar", :"foo.bar", :event_one])
+        end
+      end
+
+      context "nested event occurs" do
+        before do
+          hookable.performing events[0] do
+            hookable.performing events[1] do; end
+          end
+        end
+
+        it "observes in the correct order" do
+          expect(calls.map { |c| c[1].name }).to eq([:event_one, :event_two, :event_two, :event_one])
+        end
+
+        it "correctly sets the event depth" do
+          expect(calls.map { |c| c[1].depth }).to eq([0, 1, 1, 0])
+        end
+
+      end
+
+      context "deeply nested event occurs" do
+        before do
+          hookable.performing events[0] do
+            hookable.performing events[1] do
+              hookable.performing events[2] do; end
+            end
+          end
+        end
+
+        it "observes in the correct order" do
+          expect(calls.map { |c| c[1].name }).to eq([:event_one, :event_two, :event_three, :event_three, :event_two, :event_one])
+        end
+
+        it "correctly sets the event depth" do
+          expect(calls.map { |c| c[1].depth }).to eq([0, 1, 2, 2, 1, 0])
+        end
+      end
+    end
   end
 
   describe "hookable class" do


### PR DESCRIPTION
Observers are registered on hookable objects and called when any event is performed. The observer is passed an `Event` instance that contains various metadata, including event duration as well as an object allocation count.

I decided to implement observers separately from hooks, as the main purpose of hooks is to perform behavior in response to an event while observers observe the system for debugging and/or introspection purposes. Observers form the foundation for an upcoming object profiling feature.