### PR TITLE
Run CI on external servers

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,38 +1,14 @@
 name: Smoke Test
 
-on: [push]
+on:
+  push:
+  repository_dispatch:
 
 jobs:
-  test-linux:
+  smoke-tests:
     runs-on: ubuntu-latest
 
-    name: ${{ matrix.ruby }}
-
-    container:
-      image: pakyow/ci-ruby-${{ matrix.ruby }}
-
-    services:
-      mysql:
-        image: mysql:latest
-        ports:
-          - 3307:3306
-        env:
-          MYSQL_ROOT_PASSWORD: pakyow
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
-
-      postgres:
-        image: postgres:latest
-        ports:
-          - 5432:5432
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: pakyow
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-
-      redis:
-        image: redis:latest
-        ports:
-          - 6379:6379
+    name: ${{ matrix.ruby }} Smoke Test
 
     strategy:
       matrix:
@@ -44,18 +20,28 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/setup-ruby@v1
 
-      - name: Setup
-        shell: bash -l -e -o pipefail {0}
+      - name: Cleanup directories
         run: |
-          rm -f Gemfile.lock
-          bundle install --jobs=3 && bundle update --jobs=3
+          rm -rf .git
 
-      - name: Test
-        shell: bash -l -e -o pipefail {0}
+      - name: Create zip
         run: |
-          CI=true CI_SMOKE=true bundle exec rspec spec/smoke
+          cd ../
+          zip -rq pakyow pakyow
+          mv pakyow.zip ../
+
+      - name: Clone ci-helpers
+        run: |
+          cd ../../
+          git clone https://github.com/pakyow/ci-helpers.git
+
+      - name: Run CI
+        run: |
+          cd ../../ci-helpers
+          gem install bundler
+          bundle install
+          bundle exec commands/runner --ruby ${{ matrix.ruby }} --path '../pakyow.zip' -e 'CI=true' -e 'SMOKE=true' -f 'mysql postgres redis' 'bundle exec rspec spec/smoke'
         env:
-          MYSQL_URL: mysql2://root:pakyow@mysql:${{ job.services.mysql.ports[3307] }}
-          POSTGRES_URL: postgres://postgres:pakyow@postgres:${{ job.services.postgres.ports[5432] }}
-          REDIS_URL: redis://redis:${{ job.services.redis.ports[6379] }}
+          GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}

--- a/.github/workflows/test-node.yml
+++ b/.github/workflows/test-node.yml
@@ -1,9 +1,11 @@
 name: Test Node
 
-on: [push]
+on:
+  push:
+  repository_dispatch:
 
 jobs:
-  test-ruby:
+  test-node:
     runs-on: ubuntu-latest
 
     name: Pakyow.js

--- a/.github/workflows/test-ruby-head.yml
+++ b/.github/workflows/test-ruby-head.yml
@@ -1,40 +1,15 @@
-name: Test Ruby Head
+name: Test Ruby HEAD
 
 on:
   schedule:
     - cron: '0 1 * * *'
+  repository_dispatch:
 
 jobs:
-  test-ruby:
+  test-ruby-head:
     runs-on: ubuntu-latest
 
     name: ${{ matrix.ruby }} ${{ matrix.gem }}
-
-    container:
-      image: pakyow/ci-ruby-${{ matrix.ruby }}
-
-    services:
-      mysql:
-        image: mysql:latest
-        ports:
-          - 3307:3306
-        env:
-          MYSQL_ROOT_PASSWORD: pakyow
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
-
-      postgres:
-        image: postgres:latest
-        ports:
-          - 5432:5432
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: pakyow
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-
-      redis:
-        image: redis:latest
-        ports:
-          - 6379:6379
 
     strategy:
       matrix:
@@ -44,65 +19,91 @@ jobs:
         gem:
           - assets
           - core
-          - data
           - form
           - mailer
-          - presenter
-          - realtime
           - routing
           - support
+
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-ruby@v1
+
+      - name: Cleanup directories
+        run: |
+          rm -rf .git
+
+      - name: Create zip
+        run: |
+          cd ../
+          zip -rq pakyow pakyow
+          mv pakyow.zip ../
+
+      - name: Clone ci-helpers
+        run: |
+          cd ../../
+          git clone https://github.com/pakyow/ci-helpers.git
+
+      - name: Run CI
+        run: |
+          cd ../../ci-helpers
+          gem install bundler
+          bundle install
+          bundle exec commands/runner --ruby ${{ matrix.ruby }} --path '../pakyow.zip' -e 'CI=true' -f '' 'cd pakyow-${{ matrix.gem }} && bundle exec rspec'
+        env:
+          GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
+
+  test-ruby-head-presenter-realtime-ui:
+    runs-on: ubuntu-latest
+
+    name: ${{ matrix.ruby }} ${{ matrix.gem }}
+
+    strategy:
+      matrix:
+        ruby:
+          - head
+
+        gem:
+          - form
+          - presenter
+          - realtime
           - ui
 
       fail-fast: false
 
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/setup-ruby@v1
 
-      - name: Setup
-        shell: bash -l -e -o pipefail {0}
+      - name: Cleanup directories
         run: |
-          rm -f Gemfile.lock
-          bundle install --jobs=3 && bundle update --jobs=3
+          rm -rf .git
 
-      - name: Test
-        shell: bash -l -e -o pipefail {0}
+      - name: Create zip
         run: |
-          CI=true bundle exec rake test:${{ matrix.gem }}
+          cd ../
+          zip -rq pakyow pakyow
+          mv pakyow.zip ../
+
+      - name: Clone ci-helpers
+        run: |
+          cd ../../
+          git clone https://github.com/pakyow/ci-helpers.git
+
+      - name: Run CI
+        run: |
+          cd ../../ci-helpers
+          gem install bundler
+          bundle install
+          bundle exec commands/runner --ruby ${{ matrix.ruby }} --path '../pakyow.zip' -e 'CI=true' -f 'redis' 'cd pakyow-${{ matrix.gem }} && bundle exec rspec'
         env:
-          MYSQL_URL: mysql2://root:pakyow@mysql:${{ job.services.mysql.ports[3307] }}
-          POSTGRES_URL: postgres://postgres:pakyow@postgres:${{ job.services.postgres.ports[5432] }}
-          REDIS_URL: redis://redis:${{ job.services.redis.ports[6379] }}
+          GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
 
-  test-ruby-db:
+  test-ruby-head-data:
     runs-on: ubuntu-latest
 
-    name: ${{ matrix.ruby }} ${{ matrix.gem }} ${{ matrix.db }}
-
-    container:
-      image: pakyow/ci-ruby-${{ matrix.ruby }}
-
-    services:
-      mysql:
-        image: mysql:latest
-        ports:
-          - 3307:3306
-        env:
-          MYSQL_ROOT_PASSWORD: pakyow
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
-
-      postgres:
-        image: postgres:latest
-        ports:
-          - 5432:5432
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: pakyow
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-
-      redis:
-        image: redis:latest
-        ports:
-          - 6379:6379
+    name: ${{ matrix.ruby }} ${{ matrix.gem }}
 
     strategy:
       matrix:
@@ -112,27 +113,32 @@ jobs:
         gem:
           - data
 
-        db:
-          - mysql
-          - postgres
-          - sqlite
-
       fail-fast: false
 
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/setup-ruby@v1
 
-      - name: Setup
-        shell: bash -l -e -o pipefail {0}
+      - name: Cleanup directories
         run: |
-          rm -f Gemfile.lock
-          bundle install --jobs=3 && bundle update --jobs=3
+          rm -rf .git
 
-      - name: Test
-        shell: bash -l -e -o pipefail {0}
+      - name: Create zip
         run: |
-          CI=true CI_DB=${{ matrix.db }} bundle exec rake test:${{ matrix.gem }}
+          cd ../
+          zip -rq pakyow pakyow
+          mv pakyow.zip ../
+
+      - name: Clone ci-helpers
+        run: |
+          cd ../../
+          git clone https://github.com/pakyow/ci-helpers.git
+
+      - name: Run CI
+        run: |
+          cd ../../ci-helpers
+          gem install bundler
+          bundle install
+          bundle exec commands/runner --ruby ${{ matrix.ruby }} --path '../pakyow.zip' -e 'CI=true' -f 'mysql postgres redis' 'cd pakyow-${{ matrix.gem }} && bundle exec rspec'
         env:
-          MYSQL_URL: mysql2://root:pakyow@mysql:${{ job.services.mysql.ports[3307] }}
-          POSTGRES_URL: postgres://postgres:pakyow@postgres:${{ job.services.postgres.ports[5432] }}
-          REDIS_URL: redis://redis:${{ job.services.redis.ports[6379] }}
+          GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -1,38 +1,14 @@
 name: Test Ruby
 
-on: [push]
+on:
+  push:
+  repository_dispatch:
 
 jobs:
   test-ruby:
     runs-on: ubuntu-latest
 
     name: ${{ matrix.ruby }} ${{ matrix.gem }}
-
-    container:
-      image: pakyow/ci-ruby-${{ matrix.ruby }}
-
-    services:
-      mysql:
-        image: mysql:latest
-        ports:
-          - 3307:3306
-        env:
-          MYSQL_ROOT_PASSWORD: pakyow
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
-
-      postgres:
-        image: postgres:latest
-        ports:
-          - 5432:5432
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: pakyow
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-
-      redis:
-        image: redis:latest
-        ports:
-          - 6379:6379
 
     strategy:
       matrix:
@@ -43,65 +19,136 @@ jobs:
         gem:
           - assets
           - core
-          - data
           - form
           - mailer
-          - presenter
-          - realtime
           - routing
           - support
+
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-ruby@v1
+
+      - name: Cleanup directories
+        run: |
+          rm -rf .git
+
+      - name: Create zip
+        run: |
+          cd ../
+          zip -rq pakyow pakyow
+          mv pakyow.zip ../
+
+      - name: Clone ci-helpers
+        run: |
+          cd ../../
+          git clone https://github.com/pakyow/ci-helpers.git
+
+      - name: Run CI
+        run: |
+          cd ../../ci-helpers
+          gem install bundler
+          bundle install
+          bundle exec commands/runner --ruby ${{ matrix.ruby }} --path '../pakyow.zip' -e 'CI=true' -f '' 'cd pakyow-${{ matrix.gem }} && bundle exec rspec'
+        env:
+          GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
+
+  test-ruby-presenter-realtime-ui:
+    runs-on: ubuntu-latest
+
+    name: ${{ matrix.ruby }} ${{ matrix.gem }}
+
+    strategy:
+      matrix:
+        ruby:
+          - 2.5.7
+          - 2.6.5
+
+        gem:
+          - form
+          - presenter
+          - realtime
           - ui
 
       fail-fast: false
 
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/setup-ruby@v1
 
-      - name: Setup
-        shell: bash -l -e -o pipefail {0}
+      - name: Cleanup directories
         run: |
-          rm -f Gemfile.lock
-          bundle install --jobs=3 && bundle update --jobs=3
+          rm -rf .git
 
-      - name: Test
-        shell: bash -l -e -o pipefail {0}
+      - name: Create zip
         run: |
-          CI=true bundle exec rake test:${{ matrix.gem }}
+          cd ../
+          zip -rq pakyow pakyow
+          mv pakyow.zip ../
+
+      - name: Clone ci-helpers
+        run: |
+          cd ../../
+          git clone https://github.com/pakyow/ci-helpers.git
+
+      - name: Run CI
+        run: |
+          cd ../../ci-helpers
+          gem install bundler
+          bundle install
+          bundle exec commands/runner --ruby ${{ matrix.ruby }} --path '../pakyow.zip' -e 'CI=true' -f 'redis' 'cd pakyow-${{ matrix.gem }} && bundle exec rspec'
         env:
-          MYSQL_URL: mysql2://root:pakyow@mysql:${{ job.services.mysql.ports[3307] }}
-          POSTGRES_URL: postgres://postgres:pakyow@postgres:${{ job.services.postgres.ports[5432] }}
-          REDIS_URL: redis://redis:${{ job.services.redis.ports[6379] }}
+          GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
 
-  test-ruby-db:
+  test-ruby-data:
+    runs-on: ubuntu-latest
+
+    name: ${{ matrix.ruby }} ${{ matrix.gem }}
+
+    strategy:
+      matrix:
+        ruby:
+          - 2.5.7
+          - 2.6.5
+
+        gem:
+          - data
+
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-ruby@v1
+
+      - name: Cleanup directories
+        run: |
+          rm -rf .git
+
+      - name: Create zip
+        run: |
+          cd ../
+          zip -rq pakyow pakyow
+          mv pakyow.zip ../
+
+      - name: Clone ci-helpers
+        run: |
+          cd ../../
+          git clone https://github.com/pakyow/ci-helpers.git
+
+      - name: Run CI
+        run: |
+          cd ../../ci-helpers
+          gem install bundler
+          bundle install
+          bundle exec commands/runner --ruby ${{ matrix.ruby }} --path '../pakyow.zip' -e 'CI=true' -f 'mysql postgres redis' 'cd pakyow-${{ matrix.gem }} && bundle exec rspec'
+        env:
+          GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
+
+  test-ruby-dbs:
     runs-on: ubuntu-latest
 
     name: ${{ matrix.ruby }} ${{ matrix.gem }} ${{ matrix.db }}
-
-    container:
-      image: pakyow/ci-ruby-${{ matrix.ruby }}
-
-    services:
-      mysql:
-        image: mysql:latest
-        ports:
-          - 3307:3306
-        env:
-          MYSQL_ROOT_PASSWORD: pakyow
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
-
-      postgres:
-        image: postgres:latest
-        ports:
-          - 5432:5432
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: pakyow
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-
-      redis:
-        image: redis:latest
-        ports:
-          - 6379:6379
 
     strategy:
       matrix:
@@ -121,18 +168,28 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/setup-ruby@v1
 
-      - name: Setup
-        shell: bash -l -e -o pipefail {0}
+      - name: Cleanup directories
         run: |
-          rm -f Gemfile.lock
-          bundle install --jobs=3 && bundle update --jobs=3
+          rm -rf .git
 
-      - name: Test
-        shell: bash -l -e -o pipefail {0}
+      - name: Create zip
         run: |
-          CI=true CI_DB=${{ matrix.db }} bundle exec rake test:${{ matrix.gem }}
+          cd ../
+          zip -rq pakyow pakyow
+          mv pakyow.zip ../
+
+      - name: Clone ci-helpers
+        run: |
+          cd ../../
+          git clone https://github.com/pakyow/ci-helpers.git
+
+      - name: Run CI
+        run: |
+          cd ../../ci-helpers
+          gem install bundler
+          bundle install
+          bundle exec commands/runner --ruby ${{ matrix.ruby }} --path '../pakyow.zip' -e 'CI=true' -e 'CI_DB=${{ matrix.db }}' -f 'mysql postgres redis' 'cd pakyow-${{ matrix.gem }} && bundle exec rspec'
         env:
-          MYSQL_URL: mysql2://root:pakyow@mysql:${{ job.services.mysql.ports[3307] }}
-          POSTGRES_URL: postgres://postgres:pakyow@postgres:${{ job.services.postgres.ports[5432] }}
-          REDIS_URL: redis://redis:${{ job.services.redis.ports[6379] }}
+          GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,3 @@ COPY . .
 
 RUN rm -f Gemfile.lock
 RUN bundle install --jobs=3 && bundle update --jobs=3
-RUN rm -f pakyow-js/package-lock.json
-RUN cd pakyow-js && npm install && npm update

--- a/pakyow-ui/spec/spec_helper.rb
+++ b/pakyow-ui/spec/spec_helper.rb
@@ -110,8 +110,10 @@ def process_ui_case_transformations(transformations)
   transformations = JSON.parse(transformations)
 
   replaced_transformation_ids = {}
-  transformations.sort { |a, b|
-    @transformation_ids.index(a["id"]) <=> @transformation_ids.index(b["id"])
+  transformations.select { |transformation|
+    @transformation_ids.include?(transformation["id"])
+  }.sort_by { |transformation|
+    @transformation_ids.index(transformation["id"])
   }.each_with_index do |transformation, i|
     if replaced_transformation_ids.key?(transformation["id"])
       transformation_id = replaced_transformation_ids[transformation["id"]]

--- a/tasks/ci.rake
+++ b/tasks/ci.rake
@@ -4,24 +4,24 @@ namespace :ci do
   desc "Build the ci environment"
   task :build, [:ruby] do |_, args|
     system "docker pull pakyow/ci-ruby-#{args[:ruby]}"
-    system "docker-compose -f docker-compose.yml build --build-arg ruby=#{args[:ruby]}"
+    system "docker-compose build --build-arg ruby=#{args[:ruby]}"
   end
 
   desc "Run a command in the ci environment"
   task :run, [:command] do |_, args|
-    system "docker-compose -f docker-compose.yml run pakyow-ci '#{args[:command]}'"
+    system "docker-compose run pakyow-ci '#{args[:command]}'"
   end
 
   desc "Run framework tests in the ci environment"
   task :test, [:framework, :test] do |_, args|
     if args[:framework] == "js"
-      system "docker-compose -f docker-compose.yml run pakyow-ci 'cd pakyow-js && npm test #{args[:test]}'"
+      system "docker-compose run pakyow-ci 'cd pakyow-js && npm test #{args[:test]}'"
     else
       if args.key?(:test)
         command = "cd pakyow-#{args[:framework]} && bundle exec rspec #{args[:test]}"
-        system "docker-compose -f docker-compose.yml run -e CI=true -e GEMS='#{args[:framework]}' pakyow-ci '#{command}'"
+        system "docker-compose run -e CI=true -e GEMS='#{args[:framework]}' pakyow-ci '#{command}'"
       else
-        system "docker-compose -f docker-compose.yml run -e CI=true -e GEMS='#{args[:framework]}' pakyow-ci 'bundle exec rake'"
+        system "docker-compose run -e CI=true -e GEMS='#{args[:framework]}' pakyow-ci 'bundle exec rake'"
       end
     end
   end


### PR DESCRIPTION
GitHub workflows are failing intermittently due to lack of resources when spinning up MySQL, Postgres, and Redis containers. Something must have changed, because this started all of a sudden after running fine for some time.

This commit changes our workflows to run CI on external servers. For now we'll use inexpensive preemptible instances on Google Cloud Platform, but this gives us the flexibility to easily make a change in the future--either to a different provider or just resizing instances. I also expect this to be useful for automated performance testing.

The [CI Helpers](https://github.com/pakyow/ci-helpers) handle bootstrapping ephemeral instances, uploading the code, and running a remote command. They also handle being preempted by automatically re-running. We keep startup fast by building a custom engine that already has the necessary dependencies.

Costs are kept really low by using preemptible `n1-standard-1` instances. Running all of our tests for Ruby 2.6.5 and 2.5.7 takes about 5.57 compute hours, costing about $0.0557 per run. This is considerably cheaper than other providers and gives us more ownership of the process.