### PR TITLE
Bootstrap bundler without exec

### DIFF
--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -22,6 +22,7 @@
   * [added] Require https by default when running in production
   * [fixed] Query string missing from normalized uris
   * [added] Configure normalization through a canonical uri
+  * [changed] Improved bundle bootstrapping to be ~200ms faster
 
 # 1.0.1
 

--- a/pakyow-core/commands/pakyow
+++ b/pakyow-core/commands/pakyow
@@ -1,13 +1,17 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# Automatically run with bundler.
+require "pakyow/support/system"
+
+# Setup Bundler automatically if it isn't available and we're within a project that supports it.
 #
-current_path = File.expand_path(".")
-binstub_path = File.join(current_path, "bin/pakyow")
-if !defined?(Bundler) && File.exist?(binstub_path)
-  exec "#{binstub_path} #{ARGV.join(" ")}"
-else
-  require "pakyow/cli"
-  Pakyow::CLI.new
+if !defined?(Bundler) && Pakyow::Support::System.gemfile?
+  begin
+    require "bundler/setup"
+  rescue LoadError
+    # Bundler isn't installed.
+  end
 end
+
+require "pakyow/cli"
+Pakyow::CLI.new

--- a/pakyow-core/spec/unit/command_spec.rb
+++ b/pakyow-core/spec/unit/command_spec.rb
@@ -24,11 +24,11 @@ RSpec.describe "pakyow command" do
   context "without bundler" do
     before do
       hide_const("Bundler")
+      allow(Pakyow::CLI).to receive(:new)
     end
 
     context "gemfile exists" do
       before do
-        allow(Pakyow::CLI).to receive(:new)
         allow(self).to receive(:require).with("pakyow/support/system")
         allow(self).to receive(:require).with("pakyow/cli")
         allow(self).to receive(:require).with("bundler/setup")

--- a/pakyow-support/lib/pakyow/support/system.rb
+++ b/pakyow-support/lib/pakyow/support/system.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Pakyow
+  module Support
+    # Information about the local system.
+    #
+    # @api private
+    module System
+      module_function
+
+      def pwd
+        @pwd ||= Pathname.new(File.expand_path("."))
+      end
+
+      def gemfile
+        @gemfile ||= pwd.join("Gemfile")
+      end
+
+      def gemfile?
+        gemfile.exist?
+      end
+    end
+  end
+end

--- a/pakyow-support/lib/pakyow/support/system.rb
+++ b/pakyow-support/lib/pakyow/support/system.rb
@@ -8,16 +8,16 @@ module Pakyow
     module System
       module_function
 
-      def pwd
-        @__pwd ||= Pathname.new(File.expand_path("."))
+      def current_path
+        @__current_path ||= Pathname.new(File.expand_path("."))
       end
 
-      def gemfile
-        @__gemfile ||= pwd.join("Gemfile")
+      def gemfile_path
+        @__gemfile_path ||= current_path.join("Gemfile")
       end
 
       def gemfile?
-        gemfile.exist?
+        gemfile_path.exist?
       end
     end
   end

--- a/pakyow-support/lib/pakyow/support/system.rb
+++ b/pakyow-support/lib/pakyow/support/system.rb
@@ -9,11 +9,11 @@ module Pakyow
       module_function
 
       def pwd
-        @pwd ||= Pathname.new(File.expand_path("."))
+        @__pwd ||= Pathname.new(File.expand_path("."))
       end
 
       def gemfile
-        @gemfile ||= pwd.join("Gemfile")
+        @__gemfile ||= pwd.join("Gemfile")
       end
 
       def gemfile?

--- a/pakyow-support/spec/unit/system_spec.rb
+++ b/pakyow-support/spec/unit/system_spec.rb
@@ -5,40 +5,40 @@ RSpec.describe Pakyow::Support::System do
     allow(File).to receive(:expand_path).with(".").and_return("/")
   end
 
-  describe "#pwd" do
+  describe "#current_path" do
     it "expands ." do
-      expect(subject.pwd.to_s).to eq("/")
+      expect(subject.current_path.to_s).to eq("/")
     end
 
     it "returns a pathname" do
-      expect(subject.pwd).to be_instance_of(Pathname)
+      expect(subject.current_path).to be_instance_of(Pathname)
     end
 
     it "memoizes" do
-      expect(subject.pwd).to be(subject.pwd)
+      expect(subject.current_path).to be(subject.current_path)
     end
   end
 
-  describe "#gemfile" do
-    it "is a path to the gemfile, relative to pwd" do
-      expect(subject.gemfile.to_s).to eq("/Gemfile")
+  describe "#gemfile_path" do
+    it "is a path to the gemfile, relative to current_path" do
+      expect(subject.gemfile_path.to_s).to eq("/Gemfile")
     end
 
     it "returns a pathname" do
-      expect(subject.gemfile).to be_instance_of(Pathname)
+      expect(subject.gemfile_path).to be_instance_of(Pathname)
     end
 
     it "memoizes" do
-      expect(subject.gemfile).to be(subject.gemfile)
+      expect(subject.gemfile_path).to be(subject.gemfile_path)
     end
   end
 
   describe "#gemfile?" do
     before do
-      allow(subject).to receive(:gemfile).and_return(gemfile_double)
+      allow(subject).to receive(:gemfile_path).and_return(gemfile_path_double)
     end
 
-    let(:gemfile_double) {
+    let(:gemfile_path_double) {
       instance_double(Pathname, exist?: true)
     }
 
@@ -50,23 +50,23 @@ RSpec.describe Pakyow::Support::System do
   context "included into a class" do
     subject { Class.new.tap { |c| c.include described_class }.new }
 
-    describe "#pwd" do
+    describe "#current_path" do
       it "is private" do
-        expect { subject.pwd }.to raise_error(NoMethodError)
+        expect { subject.current_path }.to raise_error(NoMethodError)
       end
 
-      it "behaves like ::pwd" do
-        expect(subject.send(:pwd)).to eq(described_class.pwd)
+      it "behaves like ::current_path" do
+        expect(subject.send(:current_path)).to eq(described_class.current_path)
       end
     end
 
-    describe "#gemfile" do
+    describe "#gemfile_path" do
       it "is private" do
-        expect { subject.gemfile }.to raise_error(NoMethodError)
+        expect { subject.gemfile_path }.to raise_error(NoMethodError)
       end
 
-      it "behaves like ::gemfile" do
-        expect(subject.send(:gemfile)).to eq(described_class.gemfile)
+      it "behaves like ::gemfile_path" do
+        expect(subject.send(:gemfile_path)).to eq(described_class.gemfile_path)
       end
     end
 

--- a/pakyow-support/spec/unit/system_spec.rb
+++ b/pakyow-support/spec/unit/system_spec.rb
@@ -1,0 +1,83 @@
+require "pakyow/support/system"
+
+RSpec.describe Pakyow::Support::System do
+  before do
+    allow(File).to receive(:expand_path).with(".").and_return("/")
+  end
+
+  describe "#pwd" do
+    it "expands ." do
+      expect(subject.pwd.to_s).to eq("/")
+    end
+
+    it "returns a pathname" do
+      expect(subject.pwd).to be_instance_of(Pathname)
+    end
+
+    it "memoizes" do
+      expect(subject.pwd).to be(subject.pwd)
+    end
+  end
+
+  describe "#gemfile" do
+    it "is a path to the gemfile, relative to pwd" do
+      expect(subject.gemfile.to_s).to eq("/Gemfile")
+    end
+
+    it "returns a pathname" do
+      expect(subject.gemfile).to be_instance_of(Pathname)
+    end
+
+    it "memoizes" do
+      expect(subject.gemfile).to be(subject.gemfile)
+    end
+  end
+
+  describe "#gemfile?" do
+    before do
+      allow(subject).to receive(:gemfile).and_return(gemfile_double)
+    end
+
+    let(:gemfile_double) {
+      instance_double(Pathname, exist?: true)
+    }
+
+    it "checks if the gemfile exists" do
+      expect(subject.gemfile?).to be(true)
+    end
+  end
+
+  context "included into a class" do
+    subject { Class.new.tap { |c| c.include described_class }.new }
+
+    describe "#pwd" do
+      it "is private" do
+        expect { subject.pwd }.to raise_error(NoMethodError)
+      end
+
+      it "behaves like ::pwd" do
+        expect(subject.send(:pwd)).to eq(described_class.pwd)
+      end
+    end
+
+    describe "#gemfile" do
+      it "is private" do
+        expect { subject.gemfile }.to raise_error(NoMethodError)
+      end
+
+      it "behaves like ::gemfile" do
+        expect(subject.send(:gemfile)).to eq(described_class.gemfile)
+      end
+    end
+
+    describe "#gemfile?" do
+      it "is private" do
+        expect { subject.gemfile? }.to raise_error(NoMethodError)
+      end
+
+      it "behaves like ::gemfile?" do
+        expect(subject.send(:gemfile?)).to eq(described_class.gemfile?)
+      end
+    end
+  end
+end


### PR DESCRIPTION
The `pakyow` command automatically bootstraps bundler, preventing the user from having to add `bundle exec` to every command. Our previous approach was to replace the process with one that ran the binstub using `exec`. This ended up not being ideal for a couple of reasons:

1. It only worked if you ran `bundle install --binstubs`.
2. Replacing processes is slow.

This commit changes the approach by setuping up Bundler in the current process if a `Gemfile` is present. In my testing it saves ~200ms.