### PR TITLE
Refactor some Dependency helpers into System

### DIFF
--- a/pakyow-core/spec/features/commands/info/endpoints_spec.rb
+++ b/pakyow-core/spec/features/commands/info/endpoints_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "cli: info:endpoints" do
           path: "/pakyow",
           source_location: [
             File.join(
-              Pakyow::Support::Dependencies.local_framework_path,
+              Pakyow::Support::System.local_framework_path_string,
               "pakyow-framework/endpoint.rb"
             ), 1
           ]

--- a/pakyow-data/spec/features/tasks/info/sources_spec.rb
+++ b/pakyow-data/spec/features/tasks/info/sources_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "cli: info:sources" do
       source :comments do
         self.__source_location = [
           File.join(
-            Pakyow::Support::Dependencies.local_framework_path,
+            Pakyow::Support::System.local_framework_path_string,
             "pakyow-framework/comments.rb"
           ), 1
         ]

--- a/pakyow-support/lib/pakyow/support/system.rb
+++ b/pakyow-support/lib/pakyow/support/system.rb
@@ -12,12 +12,44 @@ module Pakyow
         @__current_path ||= Pathname.new(File.expand_path("."))
       end
 
+      def current_path_string
+        @__current_path_string ||= current_path.to_s
+      end
+
       def gemfile_path
         @__gemfile_path ||= current_path.join("Gemfile")
       end
 
+      def gemfile_path_string
+        @__gemfile_path_string ||= gemfile_path.to_s
+      end
+
       def gemfile?
         gemfile_path.exist?
+      end
+
+      def bundler_gem_path
+        @__bundler_gem_path ||= Bundler.bundle_path.join("bundler/gems")
+      end
+
+      def bundler_gem_path_string
+        @__bundler_gem_path_string ||= bundler_gem_path.to_s
+      end
+
+      def local_framework_path
+        @__local_framework_path ||= Pathname.new(File.expand_path("../../../../../", __FILE__))
+      end
+
+      def local_framework_path_string
+        @__local_framework_path_string ||= local_framework_path.to_s
+      end
+
+      def ruby_gem_path
+        @__ruby_gem_path ||= Pathname.new(Gem.dir).join("gems")
+      end
+
+      def ruby_gem_path_string
+        @__ruby_gem_path_string ||= ruby_gem_path.to_s
       end
     end
   end

--- a/pakyow-support/spec/unit/system_spec.rb
+++ b/pakyow-support/spec/unit/system_spec.rb
@@ -2,35 +2,78 @@ require "pakyow/support/system"
 
 RSpec.describe Pakyow::Support::System do
   before do
-    allow(File).to receive(:expand_path).with(".").and_return("/")
+    allow(File).to receive(:expand_path).with(".").and_return("/pwd")
+    allow(File).to receive(:expand_path).with("../../../../../", anything).and_return("/framework")
+    allow(Bundler).to receive(:bundle_path).and_return(Pathname.new("/bundle"))
+    allow(Gem).to receive(:dir).and_return("/gemdir")
+  end
+
+  shared_examples :memoized_pathname do
+    it "returns a pathname" do
+      expect(call).to be_instance_of(Pathname)
+    end
+
+    it "memoizes" do
+      expect(call).to be(call)
+    end
+  end
+
+  shared_examples :memoized_string do
+    it "returns a string" do
+      expect(call).to be_instance_of(String)
+    end
+
+    it "memoizes" do
+      expect(call).to be(call)
+    end
   end
 
   describe "#current_path" do
+    def call
+      subject.current_path
+    end
+
     it "expands ." do
-      expect(subject.current_path.to_s).to eq("/")
+      expect(call.to_s).to eq("/pwd")
     end
 
-    it "returns a pathname" do
-      expect(subject.current_path).to be_instance_of(Pathname)
+    it_behaves_like :memoized_pathname
+  end
+
+  describe "#current_path_string" do
+    def call
+      subject.current_path_string
     end
 
-    it "memoizes" do
-      expect(subject.current_path).to be(subject.current_path)
+    it "stringifies current_path" do
+      expect(call).to eq(subject.current_path.to_s)
     end
+
+    it_behaves_like :memoized_string
   end
 
   describe "#gemfile_path" do
+    def call
+      subject.gemfile_path
+    end
+
     it "is a path to the gemfile, relative to current_path" do
-      expect(subject.gemfile_path.to_s).to eq("/Gemfile")
+      expect(call.to_s).to eq("/pwd/Gemfile")
     end
 
-    it "returns a pathname" do
-      expect(subject.gemfile_path).to be_instance_of(Pathname)
+    it_behaves_like :memoized_pathname
+  end
+
+  describe "#gemfile_path_string" do
+    def call
+      subject.gemfile_path_string
     end
 
-    it "memoizes" do
-      expect(subject.gemfile_path).to be(subject.gemfile_path)
+    it "stringifies gemfile_path" do
+      expect(call).to eq(subject.gemfile_path.to_s)
     end
+
+    it_behaves_like :memoized_string
   end
 
   describe "#gemfile?" do
@@ -47,37 +90,145 @@ RSpec.describe Pakyow::Support::System do
     end
   end
 
+  describe "#bundler_gem_path" do
+    def call
+      subject.bundler_gem_path
+    end
+
+    it "is a path to the bundler gems" do
+      expect(call.to_s).to eq("/bundle/bundler/gems")
+    end
+
+    it_behaves_like :memoized_pathname
+  end
+
+  describe "#bundler_gem_path_string" do
+    def call
+      subject.bundler_gem_path_string
+    end
+
+    it "stringifies bundler_gem_path" do
+      expect(call).to eq(subject.bundler_gem_path.to_s)
+    end
+
+    it_behaves_like :memoized_string
+  end
+
+  describe "#local_framework_path" do
+    def call
+      subject.local_framework_path
+    end
+
+    it "is a path to the local framework" do
+      expect(call.to_s).to eq("/framework")
+    end
+
+    it_behaves_like :memoized_pathname
+  end
+
+  describe "#local_framework_path_string" do
+    def call
+      subject.local_framework_path_string
+    end
+
+    it "stringifies local_framework_path" do
+      expect(call).to eq(subject.local_framework_path.to_s)
+    end
+
+    it_behaves_like :memoized_string
+  end
+
+  describe "#ruby_gem_path" do
+    def call
+      subject.ruby_gem_path
+    end
+
+    it "is a path to ruby gems" do
+      expect(call.to_s).to eq("/gemdir/gems")
+    end
+
+    it_behaves_like :memoized_pathname
+  end
+
+  describe "#ruby_gem_path_string" do
+    def call
+      subject.ruby_gem_path_string
+    end
+
+    it "stringifies ruby_gem_path" do
+      expect(call).to eq(subject.ruby_gem_path.to_s)
+    end
+
+    it_behaves_like :memoized_string
+  end
+
   context "included into a class" do
     subject { Class.new.tap { |c| c.include described_class }.new }
 
-    describe "#current_path" do
+    shared_examples :private_behavior do
       it "is private" do
-        expect { subject.current_path }.to raise_error(NoMethodError)
+        expect { subject.public_send(method) }.to raise_error(NoMethodError)
+        expect { subject.send(method) }.to_not raise_error(NoMethodError)
       end
 
-      it "behaves like ::current_path" do
-        expect(subject.send(:current_path)).to eq(described_class.current_path)
+      it "behaves like the class method" do
+        expect(subject.send(method)).to eq(described_class.public_send(method))
       end
+    end
+
+    describe "#current_path" do
+      let(:method) { :current_path }
+      it_behaves_like :private_behavior
+    end
+
+    describe "#current_path_string" do
+      let(:method) { :current_path_string }
+      it_behaves_like :private_behavior
     end
 
     describe "#gemfile_path" do
-      it "is private" do
-        expect { subject.gemfile_path }.to raise_error(NoMethodError)
-      end
+      let(:method) { :gemfile_path }
+      it_behaves_like :private_behavior
+    end
 
-      it "behaves like ::gemfile_path" do
-        expect(subject.send(:gemfile_path)).to eq(described_class.gemfile_path)
-      end
+    describe "#gemfile_path_string" do
+      let(:method) { :gemfile_path_string }
+      it_behaves_like :private_behavior
     end
 
     describe "#gemfile?" do
-      it "is private" do
-        expect { subject.gemfile? }.to raise_error(NoMethodError)
-      end
+      let(:method) { :gemfile? }
+      it_behaves_like :private_behavior
+    end
 
-      it "behaves like ::gemfile?" do
-        expect(subject.send(:gemfile?)).to eq(described_class.gemfile?)
-      end
+    describe "#bundler_gem_path" do
+      let(:method) { :bundler_gem_path }
+      it_behaves_like :private_behavior
+    end
+
+    describe "#bundler_gem_path_string" do
+      let(:method) { :bundler_gem_path_string }
+      it_behaves_like :private_behavior
+    end
+
+    describe "#local_framework_path" do
+      let(:method) { :local_framework_path }
+      it_behaves_like :private_behavior
+    end
+
+    describe "#local_framework_path_string" do
+      let(:method) { :local_framework_path_string }
+      it_behaves_like :private_behavior
+    end
+
+    describe "#ruby_gem_path" do
+      let(:method) { :ruby_gem_path }
+      it_behaves_like :private_behavior
+    end
+
+    describe "#ruby_gem_path_string" do
+      let(:method) { :ruby_gem_path_string }
+      it_behaves_like :private_behavior
     end
   end
 end


### PR DESCRIPTION
Sets `Pakyow::Support::Dependencies` up to be refactored into a new `Pakyow::Backtrace` object.