### PR TITLE
Handle failed processes by logging and exiting with an error code

### DIFF
--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -63,6 +63,15 @@
 [d55e932]: https://github.com/pakyow/pakyow/commit/d55e9320dcca51ac7d12d8eef4f7f8aaf8faaa4f
 [26f586d]: https://github.com/pakyow/pakyow/commit/26f586d35c5fa0611cac6914fb2f249e3798ec79
 
+# v1.0.3 (unreleased)
+
+  * `fix` **Prevent failed processes from restarting indefinitely.**
+
+    *Related links:*
+    - [Pull Request #328][pr-328]
+
+[pr-328]: https://github.com/pakyow/pakyow/pull/328
+
 # v1.0.2
 
   * `fix` **Relocate `version.rb` from the meta gem into `pakyow/core`.**

--- a/pakyow-core/lib/pakyow/process_manager.rb
+++ b/pakyow-core/lib/pakyow/process_manager.rb
@@ -38,12 +38,15 @@ module Pakyow
     def run_process(process)
       Fiber.new {
         until @stopped
-          status = @group.fork(process) {
-            begin
-              Async(&process[:block])
-            rescue Interrupt
+          status = @group.fork(process) do
+            Async do
+              process[:block].call
+            rescue => error
+              Pakyow.logger.houston(error)
+              exit 1
             end
-          }
+          rescue Interrupt
+          end
 
           break unless status.success?
         end

--- a/pakyow-core/spec/unit/process_manager_spec.rb
+++ b/pakyow-core/spec/unit/process_manager_spec.rb
@@ -1,0 +1,61 @@
+RSpec.describe Pakyow::ProcessManager do
+  before do
+    allow(Process::Group).to receive(:new).and_return(process_group)
+    allow(Pakyow).to receive(:logger).and_return(logger)
+  end
+
+  after do
+    instance.stop
+  end
+
+  let(:logger) {
+    double(:logger, houston: nil)
+  }
+
+  let(:process_group) {
+    Process::Group.new
+  }
+
+  let(:instance) {
+    described_class.new
+  }
+
+  let(:process) {
+    {
+      name: process_name,
+      block: process_block,
+      count: process_count,
+      restartable: process_is_restartable
+    }
+  }
+
+  let(:process_name) {
+    "test process"
+  }
+
+  let(:process_block) {
+    -> { sleep }
+  }
+
+  let(:process_count) {
+    1
+  }
+
+  let(:process_is_restartable) {
+    true
+  }
+
+  describe "#add" do
+    context "process fails to start" do
+      let(:process_block) {
+        -> { fail }
+      }
+
+      it "only tries to start the process once" do
+        expect(process_group).to receive(:fork).once.and_call_original
+        instance.add(process)
+        instance.wait
+      end
+    end
+  end
+end


### PR DESCRIPTION
Prevents failed processes from being restarted indefinitely.