### PR TITLE
Setup default logger, global logger in the environment

### DIFF
--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -65,6 +65,11 @@
 
 # v1.0.3 (unreleased)
 
+  * `fix` **Ensure a logger and output is always available in the environment.**
+
+    *Related links:*
+    - [Pull Request #331][pr-331]
+
   * `fix` **Start multiple processes when the process count specifies more than one.**
 
     *Related links:*

--- a/pakyow-core/lib/pakyow/environment.rb
+++ b/pakyow-core/lib/pakyow/environment.rb
@@ -34,6 +34,7 @@ require "pakyow/actions/restart"
 
 require "pakyow/application"
 
+require "pakyow/logger"
 require "pakyow/logger/destination"
 require "pakyow/logger/multiplexed"
 require "pakyow/logger/thread_local"
@@ -142,17 +143,32 @@ module Pakyow
     #
     attr_reader :env
 
-    # Logger instance for the environment
-    #
-    attr_reader :logger
-
-    # Global logger instance
-    #
-    attr_reader :global_logger
-
     # Any error encountered during the boot process
     #
     attr_reader :error
+
+    # Global log output.
+    #
+    # Builds and returns a default global output that's replaced in `setup`.
+    #
+    def global_logger
+      unless defined?(@global_logger)
+        require "pakyow/logger/formatters/human"
+        @global_logger = Logger::Formatters::Human.new(
+          Logger::Destination.new(:stdout, $stdout)
+        )
+      end
+
+      @global_logger
+    end
+
+    # Logger instance for the environment.
+    #
+    # Builds and returns a default logger that's replaced in `setup`.
+    #
+    def logger
+      @logger ||= Logger.new("dflt", output: global_logger, level: :all)
+    end
 
     # Mounts an app at a path.
     #
@@ -207,20 +223,24 @@ module Pakyow
       end
 
       performing :setup do
-        init_global_logger
+        destinations = Logger::Multiplexed.new(
+          *config.logger.destinations.map { |destination, io|
+            io.sync = config.logger.sync
+            Logger::Destination.new(destination, io)
+          }
+        )
+
+        @global_logger = config.logger.formatter.new(destinations)
+
+        @logger = Logger::ThreadLocal.new(
+          Logger.new("pkyw", output: @global_logger, level: config.logger.level)
+        )
+
+        Console.logger = Logger.new("asnc", output: @global_logger, level: :warn)
       end
 
       self
     rescue => error
-      begin
-        # Try again to initialize the logger, since we may have failed before that point.
-        #
-        unless Pakyow.logger
-          init_global_logger
-        end
-      rescue
-      end
-
       @setup_error = error; self
     end
 
@@ -351,23 +371,6 @@ module Pakyow
 
     private
 
-    def init_global_logger
-      destinations = Logger::Multiplexed.new(
-        *config.logger.destinations.map { |destination, io|
-          io.sync = config.logger.sync
-          Logger::Destination.new(destination, io)
-        }
-      )
-
-      @global_logger = config.logger.formatter.new(destinations)
-
-      @logger = Logger::ThreadLocal.new(
-        Logger.new("pkyw", output: @global_logger, level: config.logger.level)
-      )
-
-      Console.logger = Logger.new("asnc", output: @global_logger, level: :warn)
-    end
-
     def ensure_setup_succeeded
       if @setup_error
         handle_boot_failure(@setup_error)
@@ -377,23 +380,11 @@ module Pakyow
     def handle_boot_failure(error)
       @error = error
 
-      safe_logger do |logger|
-        if logger.respond_to?(:houston)
-          logger.houston(error)
-        else
-          logger.error(error)
-        end
-      end
+      logger.houston(error)
 
       if config.exit_on_boot_failure
         exit(false)
       end
-    end
-
-    require "logger"
-
-    def safe_logger
-      yield logger || ::Logger.new($stdout)
     end
   end
 end

--- a/pakyow-core/spec/features/async_logger_spec.rb
+++ b/pakyow-core/spec/features/async_logger_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe "the async logger" do
+  include_context "app"
+
+  it "is of the expected type" do
+    expect(Console.logger.type).to eq("asnc")
+  end
+
+  it "outputs to the global logger" do
+    expect(Console.logger.output).to be(Pakyow.global_logger)
+  end
+
+  it "logs messages at the warn level" do
+    expect(Console.logger.level).to be(3)
+  end
+end

--- a/pakyow-core/spec/features/global_logger_spec.rb
+++ b/pakyow-core/spec/features/global_logger_spec.rb
@@ -1,11 +1,62 @@
 RSpec.describe "the global logger" do
-  describe "setting the sync mode on destinations" do
-    context "config.logger.sync is true" do
-      it "sets the sync mode to true"
+  context "before setup" do
+    it "builds a human formatter" do
+      expect(Pakyow.global_logger).to be_instance_of(Pakyow::Logger::Formatters::Human)
     end
 
-    context "config.logger.sync is false" do
-      it "sets the sync mode to false"
+    it "includes stdout as a destination" do
+      destination = Pakyow.global_logger.output
+      expect(destination.name).to eq(:stdout)
+      expect(destination.io).to be($stdout)
+    end
+  end
+
+  context "after setup" do
+    before do
+      Pakyow.config.logger.formatter = Pakyow::Logger::Formatters::Logfmt
+      Pakyow.config.logger.destinations = { io1: io1, io2: io2, io3: io3 }
+
+      # Build the default logger.
+      #
+      Pakyow.global_logger
+    end
+
+    include_context "app"
+
+    let(:io1) {
+      StringIO.new
+    }
+
+    let(:io2) {
+      StringIO.new
+    }
+
+    let(:io3) {
+      StringIO.new
+    }
+
+    it "builds a formatter of the configured type" do
+      expect(Pakyow.global_logger).to be_instance_of(Pakyow::Logger::Formatters::Logfmt)
+    end
+
+    it "includes all configured destinations" do
+      destinations = Pakyow.global_logger.output.destinations
+      expect(destinations[0].name).to eq(:io1)
+      expect(destinations[0].io).to be(io1)
+      expect(destinations[1].name).to eq(:io2)
+      expect(destinations[1].io).to be(io2)
+      expect(destinations[2].name).to eq(:io3)
+      expect(destinations[2].io).to be(io3)
+    end
+
+    describe "setting the sync mode on destinations" do
+      context "config.logger.sync is true" do
+        it "sets the sync mode to true"
+      end
+
+      context "config.logger.sync is false" do
+        it "sets the sync mode to false"
+      end
     end
   end
 end

--- a/pakyow-core/spec/features/logger_spec.rb
+++ b/pakyow-core/spec/features/logger_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe "the environment logger" do
+  context "before setup" do
+    it "is a default logger" do
+      expect(Pakyow.logger.type).to eq("dflt")
+    end
+
+    it "outputs to the global logger" do
+      expect(Pakyow.logger.output).to be(Pakyow.global_logger)
+    end
+
+    it "logs all messages" do
+      expect(Pakyow.logger.level).to eq(0)
+    end
+  end
+
+  context "after setup" do
+    before do
+      # Build the default logger.
+      #
+      Pakyow.logger
+    end
+
+    include_context "app"
+
+    it "is a thread local logger" do
+      expect(Pakyow.logger).to be_instance_of(Pakyow::Logger::ThreadLocal)
+    end
+
+    it "is of the expected type" do
+      expect(Pakyow.logger.target.type).to eq("pkyw")
+    end
+
+    it "outputs to the new global logger" do
+      expect(Pakyow.logger.target.output).to be(Pakyow.global_logger)
+    end
+
+    it "logs messages of the configured level" do
+      expect(Pakyow.logger.target.level).to eq(7)
+    end
+  end
+end

--- a/pakyow-core/spec/integration/request_logging_spec.rb
+++ b/pakyow-core/spec/integration/request_logging_spec.rb
@@ -41,10 +41,10 @@ RSpec.describe "request logging" do
   end
 
   before do
-    Pakyow.config.logger.destinations = { io: io }
-    Pakyow.config.logger.formatter = formatter
+    allow(Pakyow).to receive(:global_logger).and_return(
+      formatter.new(Pakyow::Logger::Destination.new(:io, io))
+    )
 
-    Pakyow.send(:init_global_logger)
     allow(logger).to receive(:elapsed).and_return(elapsed)
   end
 

--- a/pakyow-core/spec/unit/actions/restart_spec.rb
+++ b/pakyow-core/spec/unit/actions/restart_spec.rb
@@ -20,8 +20,6 @@ RSpec.describe Pakyow::Actions::Restart do
   end
 
   before do
-    Pakyow.send(:init_global_logger)
-
     allow(FileUtils).to receive(:mkdir_p)
     allow(File).to receive(:open)
     allow(connection).to receive(:halt)

--- a/pakyow-core/spec/unit/environment_spec.rb
+++ b/pakyow-core/spec/unit/environment_spec.rb
@@ -643,4 +643,16 @@ RSpec.describe Pakyow do
       end
     end
   end
+
+  describe "::global_logger" do
+    it "is memoized" do
+      expect(Pakyow.global_logger).to be(Pakyow.global_logger)
+    end
+  end
+
+  describe "::logger" do
+    it "is memoized" do
+      expect(Pakyow.logger).to be(Pakyow.logger)
+    end
+  end
 end

--- a/pakyow-presenter/spec/integration/render_nested_bindings_spec.rb
+++ b/pakyow-presenter/spec/integration/render_nested_bindings_spec.rb
@@ -60,10 +60,6 @@ RSpec.describe "rendering nested bindings from a presenter" do
     }.new(:test)
   end
 
-  before do
-    Pakyow.send(:init_global_logger)
-  end
-
   it "renders the nested binding correctly" do
     expect(presenter.to_html).to eq_sans_whitespace(
       <<~HTML

--- a/pakyow-presenter/spec/integration/transforming_with_transforms_spec.rb
+++ b/pakyow-presenter/spec/integration/transforming_with_transforms_spec.rb
@@ -58,10 +58,6 @@ RSpec.describe "transforming a presenter that has future transforms" do
     }.new(:test)
   end
 
-  before do
-    Pakyow.send(:init_global_logger)
-  end
-
   it "applies the future transforms to each node" do
     expect(presenter.to_html).to eq_sans_whitespace(
       <<~HTML

--- a/spec/spec_config.rb
+++ b/spec/spec_config.rb
@@ -132,7 +132,7 @@ RSpec.configure do |config|
       end
     end
 
-    [:@port, :@host, :@logger, :@app].each do |ivar|
+    [:@port, :@host, :@logger, :@app, :@global_logger].each do |ivar|
       if Pakyow.instance_variable_defined?(ivar)
         Pakyow.remove_instance_variable(ivar)
       end


### PR DESCRIPTION
It's sometimes necessary to log messages prior to the environment being setup. The environment now builds a default logger / global logger on demand, which is then replaced with a properly configured logger during setup. This ensures there's always a usable logger available no matter what state the environment is in.