### PR TITLE
Workaround for process-group v1.2.0

### DIFF
--- a/pakyow-core/lib/pakyow/process_manager.rb
+++ b/pakyow-core/lib/pakyow/process_manager.rb
@@ -7,7 +7,7 @@ require "pakyow/support/inflector"
 module Pakyow
   class ProcessManager
     def initialize
-      @group, @processes, @stopped = Process::Group.new, [], false
+      @group, @processes, @stopped = Process::Group.new(terminal: nil), [], false
     end
 
     def add(process)

--- a/pakyow-core/pakyow-core.gemspec
+++ b/pakyow-core/pakyow-core.gemspec
@@ -33,6 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "method_source", "~> 0.9.2"
   spec.add_dependency "mini_mime", "~> 1.0"
   spec.add_dependency "multipart-parser", "~> 0.1.1"
-  spec.add_dependency "process-group", "~> 1.1"
+  spec.add_dependency "process-group", "~> 1.2"
   spec.add_dependency "rake", "~> 13.0"
 end

--- a/pakyow-core/spec/unit/process_manager_spec.rb
+++ b/pakyow-core/spec/unit/process_manager_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Pakyow::ProcessManager do
   }
 
   let(:process_group) {
-    Process::Group.new
+    Process::Group.new(terminal: nil)
   }
 
   let(:instance) {


### PR DESCRIPTION
Avoids an issue with process-group assuming `/dev/tty` will be present. Since this api changed between `process-group` v1.1.0 and v1.2.0, this change also requires `process-group` v1.2.0.

Depending on how the underlying issue is planned to be resolved, we may want to release this work as part of v1.0.3. An alternative is to lock the `process-group` dependency to v1.1.0 and continue using it as before. This is probably a safer interim path forward, since we don't use any `process-group` v1.2.0 features.

Related issue: https://github.com/socketry/process-group/issues/2