### PR TITLE
Lock process-group to v1.1.0

### DIFF
--- a/pakyow-core/pakyow-core.gemspec
+++ b/pakyow-core/pakyow-core.gemspec
@@ -33,6 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "method_source", "~> 0.9.2"
   spec.add_dependency "mini_mime", "~> 1.0"
   spec.add_dependency "multipart-parser", "~> 0.1.1"
-  spec.add_dependency "process-group", "~> 1.1"
+  spec.add_dependency "process-group", "~> 1.1.0"
   spec.add_dependency "rake", "~> 13.0"
 end


### PR DESCRIPTION
Temporary change until https://github.com/socketry/process-group/issues/2 is resolved.