### PR TITLE
Remove lock to process-group v1.1

### DIFF
--- a/pakyow-core/pakyow-core.gemspec
+++ b/pakyow-core/pakyow-core.gemspec
@@ -33,6 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "method_source", "~> 0.9.2"
   spec.add_dependency "mini_mime", "~> 1.0"
   spec.add_dependency "multipart-parser", "~> 0.1.1"
-  spec.add_dependency "process-group", "~> 1.1.0"
+  spec.add_dependency "process-group", "~> 1.1"
   spec.add_dependency "rake", "~> 13.0"
 end


### PR DESCRIPTION
`process-group` v1.2.1 was released that should resolve the underlying issue introduced in v1.2.0.