### PR TITLE
Provide an environment-level deprecator

### DIFF
--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `add` **Provide an environment-level deprecator.**
+
+    *Related links:*
+    - [Pull Request #335][pr-335]
+
   * `chg` **Improve bundle bootstrapping to be ~200ms faster.**
 
     *Related links:*
@@ -52,6 +57,7 @@
     - [Pull Request #297][pr-297]
     - [Commit 26f586d][26f586d]
 
+[pr-335]: https://github.com/pakyow/pakyow/pull/335
 [pr-321]: https://github.com/pakyow/pakyow/pull/321
 [pr-314]: https://github.com/pakyow/pakyow/pull/314
 [pr-313]: https://github.com/pakyow/pakyow/pull/313

--- a/pakyow-core/lib/pakyow/behavior/deprecations.rb
+++ b/pakyow-core/lib/pakyow/behavior/deprecations.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "pakyow/support/deprecator"
+require "pakyow/support/inflector"
+
+module Pakyow
+  module Behavior
+    # Provides an environment-level deprecator for reporting deprecations within a project, plugin,
+    # or framework. Guarantees that a deprecator will be available, even if misconfigured.
+    #
+    # Deprecations reported to `Pakyow::Support::Deprecator.global` will be forwarded here. This
+    # allows libraries to safely report deprecations even if they happen to be used outside the
+    # context of the Pakyow environnment.
+    #
+    # To ignore deprecation notices configure the `null` reporter:
+    #
+    #   config.deprecator.reporter = :null
+    #
+    module Deprecations
+      extend Support::Extension
+
+      class_methods do
+        # Returns the environment deprecator, where all runtime deprecations should be reported.
+        #
+        def deprecator
+          @deprecator ||= setup_deprecator(config.deprecator.reporter)
+        end
+
+        # Reports a deprecation to the environment deprecator.
+        #
+        def deprecated(*args)
+          deprecator.deprecated(*args)
+        end
+
+        private def setup_deprecator(deprecator)
+          @deprecator = if reporter = setup_deprecation_reporter(deprecator)
+            Support::Deprecator.new(
+              reporter: reporter
+            )
+          else
+            Support::Deprecator.global
+          end
+        end
+
+        private def setup_deprecation_reporter(deprecator)
+          case deprecator
+          when String, Symbol
+            setup_deprecation_reporter_for_string(
+              deprecator
+            )
+          when Class
+            setup_deprecation_reporter_for_class(
+              deprecator
+            )
+          else
+            deprecator
+          end
+        end
+
+        private def setup_deprecation_reporter_for_string(deprecator)
+          require_deprecation_reporter(deprecator)
+
+          setup_deprecation_reporter_for_class(
+            deprecation_reporter_class(deprecator)
+          )
+        end
+
+        private def setup_deprecation_reporter_for_class(deprecator)
+          if deprecator.respond_to?(:default)
+            deprecator.default
+          else
+            deprecator
+          end
+        end
+
+        private def require_deprecation_reporter(deprecator)
+          require "pakyow/support/deprecator/reporters/#{deprecator}"
+        end
+
+        private def deprecation_reporter_class(deprecator)
+          Support::Deprecator::Reporters.const_get(
+            Support.inflector.classify(
+              deprecator
+            )
+          )
+        end
+
+        private def fallback_deprecation_reporter
+          setup_deprecation_reporter_for_string("log")
+        end
+      end
+
+      apply_extension do
+        after "setup" do
+          @deprecator = setup_deprecator(config.deprecator.reporter)
+
+          unless @deprecator.equal?(Support::Deprecator.global)
+            Support::Deprecator.global >> @deprecator
+          end
+        end
+      end
+    end
+  end
+end

--- a/pakyow-core/lib/pakyow/config.rb
+++ b/pakyow-core/lib/pakyow/config.rb
@@ -174,6 +174,18 @@ module Pakyow
         setting :http_only
         setting :same_site
       end
+
+      configurable :deprecator do
+        setting :reporter, :log
+
+        defaults :test do
+          setting :reporter, :warn
+        end
+
+        defaults :production do
+          setting :reporter, :null
+        end
+      end
     end
   end
 end

--- a/pakyow-core/lib/pakyow/environment.rb
+++ b/pakyow-core/lib/pakyow/environment.rb
@@ -16,6 +16,7 @@ require "pakyow/support/pipeline"
 require "pakyow/support/inflector"
 
 require "pakyow/config"
+require "pakyow/behavior/deprecations"
 require "pakyow/behavior/initializers"
 require "pakyow/behavior/input_parsing"
 require "pakyow/behavior/plugins"
@@ -387,4 +388,6 @@ module Pakyow
       end
     end
   end
+
+  include Behavior::Deprecations
 end

--- a/pakyow-core/spec/features/deprecations_spec.rb
+++ b/pakyow-core/spec/features/deprecations_spec.rb
@@ -1,0 +1,148 @@
+RSpec.describe "setting up the environment deprecator" do
+  context "before setup" do
+    it "exposes a default deprecator" do
+      expect(Pakyow.deprecator).to be_instance_of(Pakyow::Support::Deprecator)
+    end
+
+    describe "default deprecator" do
+      it "uses the log reporter" do
+        expect(
+          Pakyow.deprecator.instance_variable_get(:@reporter)
+        ).to be_instance_of(Pakyow::Support::Deprecator::Reporters::Log)
+      end
+
+      it "reports to the environment logger" do
+        expect(
+          Pakyow.deprecator.instance_variable_get(:@reporter).instance_variable_get(:@logger)
+        ).to be(Pakyow.logger)
+      end
+    end
+  end
+
+  shared_examples "string configured reporter" do
+    before do
+      local = self
+      Pakyow.configure :test do
+        config.deprecator.reporter = local.reporter
+      end
+    end
+
+    include_context "app"
+
+    it "sets up the deprecator" do
+      expect(
+        Pakyow.deprecator.instance_variable_get(:@reporter)
+      ).to be(Pakyow::Support::Deprecator::Reporters::Null)
+    end
+  end
+
+  context "configured reporter is a string" do
+    it_behaves_like "string configured reporter" do
+      let(:reporter) {
+        "null"
+      }
+    end
+  end
+
+  context "configured reporter is a symbol" do
+    it_behaves_like "string configured reporter" do
+      let(:reporter) {
+        :null
+      }
+    end
+  end
+
+  context "configured reporter is a class" do
+    before do
+      local = self
+      Pakyow.configure :test do
+        config.deprecator.reporter = local.reporter
+      end
+    end
+
+    include_context "app"
+
+    let(:reporter) {
+      Class.new
+    }
+
+    it "sets up the deprecator" do
+      expect(
+        Pakyow.deprecator.instance_variable_get(:@reporter)
+      ).to be(reporter)
+    end
+
+    context "deprecator responds to default" do
+      let(:reporter) {
+        Class.new do
+          def self.default
+            "default"
+          end
+        end
+      }
+
+      it "sets up the deprecator" do
+        expect(
+          Pakyow.deprecator.instance_variable_get(:@reporter)
+        ).to eq("default")
+      end
+    end
+  end
+
+  context "configured reporter is an instance" do
+    before do
+      local = self
+      Pakyow.configure :test do
+        config.deprecator.reporter = local.reporter
+      end
+    end
+
+    include_context "app"
+
+    let(:reporter) {
+      reporter_class.new
+    }
+
+    let(:reporter_class) {
+      Class.new
+    }
+
+    it "sets up the deprecator" do
+      expect(
+        Pakyow.deprecator.instance_variable_get(:@reporter)
+      ).to be_instance_of(reporter_class)
+    end
+  end
+
+  context "configured reporter is nil" do
+    before do
+      Pakyow.configure :test do
+        config.deprecator.reporter = nil
+      end
+    end
+
+    include_context "app"
+
+    it "sets up the global deprecator" do
+      expect(Pakyow.deprecator).to be(Pakyow::Support::Deprecator.global)
+    end
+  end
+end
+
+RSpec.describe "reporting deprecations through the environment" do
+  include_context "app"
+
+  it "reports deprecations" do
+    expect(Pakyow.deprecator).to receive(:deprecated).with(:foo)
+    Pakyow.deprecated(:foo)
+  end
+end
+
+RSpec.describe "reporting deprecations through the global deprecator" do
+  include_context "app"
+
+  it "forwards to the environment deprecator" do
+    expect(Pakyow.deprecator).to receive(:deprecated).with(:foo)
+    Pakyow::Support::Deprecator.global.deprecated(:foo)
+  end
+end

--- a/pakyow-core/spec/unit/environment/config_spec.rb
+++ b/pakyow-core/spec/unit/environment/config_spec.rb
@@ -368,5 +368,31 @@ RSpec.describe Pakyow do
         expect(Pakyow.config.cookies.same_site).to be(nil)
       end
     end
+
+    describe "deprecator.reporter" do
+      it "defaults to :log" do
+        expect(Pakyow.config.deprecator.reporter).to eq(:log)
+      end
+
+      context "in test" do
+        before do
+          Pakyow.configure!(:test)
+        end
+
+        it "defaults to :warn" do
+          expect(Pakyow.config.deprecator.reporter).to eq(:warn)
+        end
+      end
+
+      context "in production" do
+        before do
+          Pakyow.configure!(:production)
+        end
+
+        it "defaults to :null" do
+          expect(Pakyow.config.deprecator.reporter).to eq(:null)
+        end
+      end
+    end
   end
 end

--- a/pakyow-support/lib/pakyow/support/deprecator/reporters/log.rb
+++ b/pakyow-support/lib/pakyow/support/deprecator/reporters/log.rb
@@ -17,6 +17,14 @@ module Pakyow
         #   => [deprecation] `foo' is deprecated; solution: use `bar'
         #
         class Log
+          class << self
+            # Builds a default instance using the environment logger.
+            #
+            def default
+              new(logger: Pakyow.logger)
+            end
+          end
+
           def initialize(logger:, level: :warn)
             @logger, @level = logger, level
           end

--- a/pakyow-support/spec/unit/deprecator/reporters/log_spec.rb
+++ b/pakyow-support/spec/unit/deprecator/reporters/log_spec.rb
@@ -1,0 +1,37 @@
+require "pakyow/support/deprecator/reporters/log"
+
+RSpec.describe Pakyow::Support::Deprecator::Reporters::Log do
+  module PakyowWithLogger
+    def self.logger; end
+  end
+
+  describe "::default" do
+    before do
+      stub_const "Pakyow", PakyowWithLogger
+      allow(Pakyow).to receive(:logger).and_return(logger)
+    end
+
+    after do
+      if @defined_logger
+
+      end
+    end
+
+    let(:logger) {
+      double(:logger)
+    }
+
+    it "builds an instance with the environment logger" do
+      expect(described_class).to receive(:new).with(logger: logger)
+      described_class.default
+    end
+
+    it "returns an instance of itself" do
+      expect(described_class.default).to be_instance_of(described_class)
+    end
+
+    it "returns a new instance" do
+      expect(described_class.default).not_to be(described_class.default)
+    end
+  end
+end

--- a/spec/spec_config.rb
+++ b/spec/spec_config.rb
@@ -132,7 +132,7 @@ RSpec.configure do |config|
       end
     end
 
-    [:@port, :@host, :@logger, :@app, :@global_logger].each do |ivar|
+    [:@port, :@host, :@logger, :@app, :@global_logger, :@deprecator].each do |ivar|
       if Pakyow.instance_variable_defined?(ivar)
         Pakyow.remove_instance_variable(ivar)
       end
@@ -140,6 +140,10 @@ RSpec.configure do |config|
 
     if Object.const_defined?("Pakyow::Presenter::Composers::View")
       Pakyow::Presenter::Composers::View.__cache.clear
+    end
+
+    if defined?(Pakyow::Support::Deprecator) && Pakyow::Support::Deprecator.instance_variable_defined?(:@global)
+      Pakyow::Support::Deprecator.remove_instance_variable(:@global)
     end
 
     remove_constants(


### PR DESCRIPTION
Deprecations within a project, plugin, or framework can now be reported through the environment:

```ruby
Pakyow.deprecated :foo, "use `bar'"
=> `foo' is deprecated; solution: use `bar'
```

The environment deprecator automatically configures itself as a forwarding destination with the global deprecator. This allows libraries that might be used outside the context of the environment to simply use the global deprecator. If the larger environment is available the environment deprecator will collect all deprecations, including those reported to the global instance. 

In short, these two lines are functionally equivalent when the environment is available:

```ruby
Pakyow::Support::Deprecator.global.deprecated :foo, "use `bar'"
Pakyow.deprecated :foo, "use `bar'"
```

---

- [x] Update CHANGELOG