### PR TITLE
Replace the thread local's internal logger instead of overwriting

### DIFF
--- a/pakyow-core/lib/pakyow/environment.rb
+++ b/pakyow-core/lib/pakyow/environment.rb
@@ -167,7 +167,7 @@ module Pakyow
     # Builds and returns a default logger that's replaced in `setup`.
     #
     def logger
-      @logger ||= Logger.new("dflt", output: global_logger, level: :all)
+      @logger ||= Logger::ThreadLocal.new(Logger.new("dflt", output: global_logger, level: :all))
     end
 
     # Mounts an app at a path.
@@ -232,9 +232,11 @@ module Pakyow
 
         @global_logger = config.logger.formatter.new(destinations)
 
-        @logger = Logger::ThreadLocal.new(
-          Logger.new("pkyw", output: @global_logger, level: config.logger.level)
-        )
+        # Replace the default logger with a configured logger. We don't overwrite `@logger` here so
+        # that objects that hold a reference to the thread local logger before setup still point to
+        # the right object and log to the appropriate logger after setup.
+        #
+        logger.replace(Logger.new("pkyw", output: @global_logger, level: config.logger.level))
 
         Console.logger = Logger.new("asnc", output: @global_logger, level: :warn)
       end

--- a/pakyow-core/lib/pakyow/logger/thread_local.rb
+++ b/pakyow-core/lib/pakyow/logger/thread_local.rb
@@ -24,6 +24,10 @@ module Pakyow
       def target
         Thread.current[:pakyow_logger] || @default
       end
+
+      def replace(logger)
+        @default = logger
+      end
     end
   end
 end

--- a/pakyow-core/spec/features/logger_spec.rb
+++ b/pakyow-core/spec/features/logger_spec.rb
@@ -38,4 +38,19 @@ RSpec.describe "the environment logger" do
       expect(Pakyow.logger.target.level).to eq(7)
     end
   end
+
+  describe "holding a reference to the thread local before setup" do
+    before do
+      @logger = Pakyow.logger
+    end
+
+    include_context "app"
+
+    context "after setup" do
+      it "uses the configured logger" do
+        expect(@logger.target).to receive(:warn).with("foo")
+        Pakyow.logger.warn "foo"
+      end
+    end
+  end
 end


### PR DESCRIPTION
This allows objects that hold a reference to the thread local logger before setup to still point to the right object and log to the appropriate logger after setup. A good example to think through is the environment deprecator. If the deprecator is used before setup, it is initialized with a reference to `Pakyow.logger`. When we overwrite the logger, the reference that the deprecator holds is the old logger instead of the new one. This change avoids the whole issue by replacing the thread local's internal logger instead of replacing the entire instance.