### PR TITLE
Deprecate Pakyow::global_logger in favor of Pakyow::output

### DIFF
--- a/pakyow-assets/spec/features/silent_spec.rb
+++ b/pakyow-assets/spec/features/silent_spec.rb
@@ -22,12 +22,12 @@ RSpec.describe "silencing requests" do
       end
 
       it "does not log the asset request" do
-        expect(Pakyow.global_logger).not_to receive(:call)
+        expect(Pakyow.output).not_to receive(:call)
         call("/assets/foo.bar")
       end
 
       it "does log a non-asset request" do
-        expect(Pakyow.global_logger).to receive(:call).at_least(:once)
+        expect(Pakyow.output).to receive(:call).at_least(:once)
         call("/foo.bar.baz")
       end
     end
@@ -42,7 +42,7 @@ RSpec.describe "silencing requests" do
       end
 
       it "logs the asset request" do
-        expect(Pakyow.global_logger).to receive(:call).at_least(:once)
+        expect(Pakyow.output).to receive(:call).at_least(:once)
         call("/assets/foo.bar")
       end
     end
@@ -58,12 +58,12 @@ RSpec.describe "silencing requests" do
       end
 
       it "does not log the public request" do
-        expect(Pakyow.global_logger).not_to receive(:call)
+        expect(Pakyow.output).not_to receive(:call)
         call("/silent_spec.rb")
       end
 
       it "does log a non-public request" do
-        expect(Pakyow.global_logger).to receive(:call).at_least(:once)
+        expect(Pakyow.output).to receive(:call).at_least(:once)
         call("/foo.bar")
       end
     end
@@ -77,7 +77,7 @@ RSpec.describe "silencing requests" do
       end
 
       it "logs the public request" do
-        expect(Pakyow.global_logger).to receive(:call).at_least(:once)
+        expect(Pakyow.output).to receive(:call).at_least(:once)
         call("/silent_spec.rb")
       end
     end

--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `chg` **Rename `Pakyow::global_logger` to `Pakyow::output`.**
+
+    *Related links:*
+    - [Pull Request #338][pr-338]
+
   * `add` **Provide an environment-level deprecator.**
 
     *Related links:*
@@ -57,6 +62,14 @@
     - [Pull Request #297][pr-297]
     - [Commit 26f586d][26f586d]
 
+## Deprecations
+
+  * `Pakyow::global_logger` has been deprecated in favor of `Pakyow::output`.
+
+    *Related links:*
+    - [Pull Request #338][pr-338]
+
+[pr-338]: https://github.com/pakyow/pakyow/pull/338
 [pr-335]: https://github.com/pakyow/pakyow/pull/335
 [pr-321]: https://github.com/pakyow/pakyow/pull/321
 [pr-314]: https://github.com/pakyow/pakyow/pull/314

--- a/pakyow-core/lib/pakyow/connection.rb
+++ b/pakyow-core/lib/pakyow/connection.rb
@@ -61,7 +61,7 @@ module Pakyow
       @request = request
       @body = Async::HTTP::Body::Buffered.wrap(StringIO.new)
       @params = Pakyow::Connection::Params.new
-      @logger = Logger.new(:http, started_at: @timestamp, id: @id, output: Pakyow.global_logger, level: Pakyow.config.logger.level)
+      @logger = Logger.new(:http, started_at: @timestamp, id: @id, output: Pakyow.output, level: Pakyow.config.logger.level)
       @streams = []
     end
 

--- a/pakyow-core/spec/features/async_logger_spec.rb
+++ b/pakyow-core/spec/features/async_logger_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe "the async logger" do
     expect(Console.logger.type).to eq("asnc")
   end
 
-  it "outputs to the global logger" do
-    expect(Console.logger.output).to be(Pakyow.global_logger)
+  it "outputs to the environment output" do
+    expect(Console.logger.output).to be(Pakyow.output)
   end
 
   it "logs messages at the warn level" do

--- a/pakyow-core/spec/features/logger_spec.rb
+++ b/pakyow-core/spec/features/logger_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe "the environment logger" do
       expect(Pakyow.logger.type).to eq("dflt")
     end
 
-    it "outputs to the global logger" do
-      expect(Pakyow.logger.output).to be(Pakyow.global_logger)
+    it "outputs to the environment output" do
+      expect(Pakyow.logger.output).to be(Pakyow.output)
     end
 
     it "logs all messages" do
@@ -30,8 +30,8 @@ RSpec.describe "the environment logger" do
       expect(Pakyow.logger.target.type).to eq("pkyw")
     end
 
-    it "outputs to the new global logger" do
-      expect(Pakyow.logger.target.output).to be(Pakyow.global_logger)
+    it "outputs to the new environment output" do
+      expect(Pakyow.logger.target.output).to be(Pakyow.output)
     end
 
     it "logs messages of the configured level" do

--- a/pakyow-core/spec/features/output_spec.rb
+++ b/pakyow-core/spec/features/output_spec.rb
@@ -1,11 +1,11 @@
-RSpec.describe "the global logger" do
+RSpec.describe "the environment output" do
   context "before setup" do
     it "builds a human formatter" do
-      expect(Pakyow.global_logger).to be_instance_of(Pakyow::Logger::Formatters::Human)
+      expect(Pakyow.output).to be_instance_of(Pakyow::Logger::Formatters::Human)
     end
 
     it "includes stdout as a destination" do
-      destination = Pakyow.global_logger.output
+      destination = Pakyow.output.output
       expect(destination.name).to eq(:stdout)
       expect(destination.io).to be($stdout)
     end
@@ -18,7 +18,7 @@ RSpec.describe "the global logger" do
 
       # Build the default logger.
       #
-      Pakyow.global_logger
+      Pakyow.output
     end
 
     include_context "app"
@@ -36,11 +36,11 @@ RSpec.describe "the global logger" do
     }
 
     it "builds a formatter of the configured type" do
-      expect(Pakyow.global_logger).to be_instance_of(Pakyow::Logger::Formatters::Logfmt)
+      expect(Pakyow.output).to be_instance_of(Pakyow::Logger::Formatters::Logfmt)
     end
 
     it "includes all configured destinations" do
-      destinations = Pakyow.global_logger.output.destinations
+      destinations = Pakyow.output.output.destinations
       expect(destinations[0].name).to eq(:io1)
       expect(destinations[0].io).to be(io1)
       expect(destinations[1].name).to eq(:io2)

--- a/pakyow-core/spec/integration/request_logging_spec.rb
+++ b/pakyow-core/spec/integration/request_logging_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "request logging" do
   let :logger do
-    Pakyow::Logger.new(:http, output: Pakyow.global_logger, level: Pakyow.config.logger.level)
+    Pakyow::Logger.new(:http, output: Pakyow.output, level: Pakyow.config.logger.level)
   end
 
   let :io do
@@ -41,7 +41,7 @@ RSpec.describe "request logging" do
   end
 
   before do
-    allow(Pakyow).to receive(:global_logger).and_return(
+    allow(Pakyow).to receive(:output).and_return(
       formatter.new(Pakyow::Logger::Destination.new(:io, io))
     )
 

--- a/pakyow-core/spec/unit/actions/input_parser_spec.rb
+++ b/pakyow-core/spec/unit/actions/input_parser_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe Pakyow::Actions::InputParser do
   end
 
   before do
-    allow(Pakyow).to receive(:global_logger).and_return(
-      double(:global_logger, level: 2, verbose!: nil)
+    allow(Pakyow).to receive(:output).and_return(
+      double(:output, level: 2, verbose!: nil)
     )
   end
 

--- a/pakyow-core/spec/unit/actions/normalizer_spec.rb
+++ b/pakyow-core/spec/unit/actions/normalizer_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe Pakyow::Actions::Normalizer do
   end
 
   before do
-    allow(Pakyow).to receive(:global_logger).and_return(
-      double(:global_logger, level: 2, verbose!: nil)
+    allow(Pakyow).to receive(:output).and_return(
+      double(:output, level: 2, verbose!: nil)
     )
   end
 

--- a/pakyow-core/spec/unit/app/connection_spec.rb
+++ b/pakyow-core/spec/unit/app/connection_spec.rb
@@ -36,8 +36,8 @@ RSpec.describe Pakyow::Application::Connection do
   end
 
   before do
-    allow(Pakyow).to receive(:global_logger).and_return(
-      double(:global_logger, level: 2, verbose!: nil)
+    allow(Pakyow).to receive(:output).and_return(
+      double(:output, level: 2, verbose!: nil)
     )
   end
 

--- a/pakyow-core/spec/unit/app_spec.rb
+++ b/pakyow-core/spec/unit/app_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe Pakyow::Application do
   end
 
   before do
-    allow(Pakyow).to receive(:global_logger).and_return(
-      double(:global_logger, level: 2, verbose!: nil)
+    allow(Pakyow).to receive(:output).and_return(
+      double(:output, level: 2, verbose!: nil)
     )
   end
 

--- a/pakyow-core/spec/unit/connection_spec.rb
+++ b/pakyow-core/spec/unit/connection_spec.rb
@@ -62,8 +62,8 @@ RSpec.shared_examples :connection do
   end
 
   before do
-    allow(Pakyow).to receive(:global_logger).and_return(
-      double(:global_logger, level: 2, verbose!: nil)
+    allow(Pakyow).to receive(:output).and_return(
+      double(:output, level: 2, verbose!: nil)
     )
   end
 

--- a/pakyow-core/spec/unit/environment_spec.rb
+++ b/pakyow-core/spec/unit/environment_spec.rb
@@ -394,13 +394,13 @@ RSpec.describe Pakyow do
       Pakyow.setup(env: env)
     end
 
-    it "initializes the global logger" do
-      Pakyow.instance_variable_set(:@global_logger, nil)
+    it "initializes the environment output" do
+      Pakyow.instance_variable_set(:@output, nil)
       Pakyow.setup
 
-      expect(Pakyow.global_logger).to be_instance_of(Pakyow::Logger::Formatters::Human)
-      expect(Pakyow.global_logger.output).to be_instance_of(Pakyow::Logger::Multiplexed)
-      expect(Pakyow.global_logger.output.destinations.count).to eq(1)
+      expect(Pakyow.output).to be_instance_of(Pakyow::Logger::Formatters::Human)
+      expect(Pakyow.output.output).to be_instance_of(Pakyow::Logger::Multiplexed)
+      expect(Pakyow.output.output.destinations.count).to eq(1)
     end
 
     it "initializes the logger" do
@@ -644,15 +644,30 @@ RSpec.describe Pakyow do
     end
   end
 
-  describe "::global_logger" do
+  describe "::output" do
     it "is memoized" do
-      expect(Pakyow.global_logger).to be(Pakyow.global_logger)
+      expect(Pakyow.output).to be(Pakyow.output)
     end
   end
 
   describe "::logger" do
     it "is memoized" do
       expect(Pakyow.logger).to be(Pakyow.logger)
+    end
+  end
+
+  describe "::global_logger" do
+    it "is deprecated" do
+      expect(Pakyow).to receive(:deprecated).with(:global_logger, "use `output'")
+
+      Pakyow.global_logger
+    end
+
+    it "calls ::output" do
+      allow(Pakyow).to receive(:deprecated)
+      expect(Pakyow).to receive(:output).at_least(:once).and_call_original
+
+      Pakyow.global_logger
     end
   end
 end

--- a/pakyow-core/spec/unit/logger/formatters/shared.rb
+++ b/pakyow-core/spec/unit/logger/formatters/shared.rb
@@ -68,8 +68,8 @@ RSpec.shared_examples :log_formatter do
   end
 
   before do
-    allow(Pakyow).to receive(:global_logger).and_return(
-      double(:global_logger, level: 2, verbose!: nil)
+    allow(Pakyow).to receive(:output).and_return(
+      double(:output, level: 2, verbose!: nil)
     )
   end
 end

--- a/pakyow-core/spec/unit/logger_spec.rb
+++ b/pakyow-core/spec/unit/logger_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Pakyow::Logger do
   end
 
   before do
-    allow(Pakyow).to receive(:global_logger).and_return(
+    allow(Pakyow).to receive(:output).and_return(
       double(:global_output, call: nil, verbose!: nil)
     )
   end

--- a/pakyow-data/spec/features/tasks/bootstrap_spec.rb
+++ b/pakyow-data/spec/features/tasks/bootstrap_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "bootstrapping a connection" do
       task_double
     )
 
-    logger = double(:logger)
+    logger = double(:logger, replace: nil)
     allow(Pakyow).to receive(:logger).and_return(logger)
     expect(logger).to receive(:info).with("[db:bootstrap] running: db:create")
     expect(logger).to receive(:info).with("[db:bootstrap] running: db:migrate")

--- a/pakyow-data/spec/features/tasks/reset_spec.rb
+++ b/pakyow-data/spec/features/tasks/reset_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "resetting a connection" do
       task_double
     )
 
-    logger = double(:logger)
+    logger = double(:logger, replace: nil)
     allow(Pakyow).to receive(:logger).and_return(logger)
     expect(logger).to receive(:info).with("[db:reset] running: db:drop")
     expect(logger).to receive(:info).with("[db:reset] running: db:bootstrap")

--- a/pakyow-realtime/lib/pakyow/realtime/websocket.rb
+++ b/pakyow-realtime/lib/pakyow/realtime/websocket.rb
@@ -42,7 +42,7 @@ module Pakyow
 
       def initialize(id, connection)
         @id, @connection, @open = id, connection, false
-        @logger = Logger.new(:sock, id: @id[0..7], output: Pakyow.global_logger, level: Pakyow.config.logger.level)
+        @logger = Logger.new(:sock, id: @id[0..7], output: Pakyow.output, level: Pakyow.config.logger.level)
         @server = @connection.app.websocket_server
         open
       end

--- a/pakyow-routing/spec/unit/security/base_spec.rb
+++ b/pakyow-routing/spec/unit/security/base_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe Pakyow::Security::Base do
   end
 
   before do
-    allow(Pakyow).to receive(:global_logger).and_return(
-      double(:global_logger, level: 2, verbose!: nil, call: nil)
+    allow(Pakyow).to receive(:output).and_return(
+      double(:output, level: 2, verbose!: nil, call: nil)
     )
   end
 

--- a/pakyow-routing/spec/unit/security/csrf/verify_same_origin_spec.rb
+++ b/pakyow-routing/spec/unit/security/csrf/verify_same_origin_spec.rb
@@ -55,8 +55,8 @@ RSpec.describe Pakyow::Security::CSRF::VerifySameOrigin do
       connection.status = 403
     }
 
-    allow(Pakyow).to receive(:global_logger).and_return(
-      double(:global_logger, level: 2, verbose!: nil)
+    allow(Pakyow).to receive(:output).and_return(
+      double(:output, level: 2, verbose!: nil)
     )
   end
 

--- a/spec/spec_config.rb
+++ b/spec/spec_config.rb
@@ -132,7 +132,7 @@ RSpec.configure do |config|
       end
     end
 
-    [:@port, :@host, :@logger, :@app, :@global_logger, :@deprecator].each do |ivar|
+    [:@port, :@host, :@logger, :@app, :@output, :@deprecator].each do |ivar|
       if Pakyow.instance_variable_defined?(ivar)
         Pakyow.remove_instance_variable(ivar)
       end


### PR DESCRIPTION
`Pakyow::output` more accurately describes what this object is.