### PR TITLE
Improve Pakyow::ProcessManager

### DIFF
--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # v1.1.0 (unreleased)
 
+  * `chg` **Improve `Pakyow::ProcessManager` api with the addition of a `Pakyow::Process` value object.**
+
+    *Related links:*
+    - [Pull Request #339][pr-339]
+    - [Commit be9b292][be9b292]
+
   * `chg` **Rename `Pakyow::global_logger` to `Pakyow::output`.**
 
     *Related links:*
@@ -64,11 +70,18 @@
 
 ## Deprecations
 
+  * `Pakyow::ProcessManager#add` no longer accepts a `Hash`.
+
+    *Related links:*
+    - [Pull Request #339][pr-339]
+    - [Commit be9b292][be9b292]
+
   * `Pakyow::global_logger` has been deprecated in favor of `Pakyow::output`.
 
     *Related links:*
     - [Pull Request #338][pr-338]
 
+[pr-339]: https://github.com/pakyow/pakyow/pull/339
 [pr-338]: https://github.com/pakyow/pakyow/pull/338
 [pr-335]: https://github.com/pakyow/pakyow/pull/335
 [pr-321]: https://github.com/pakyow/pakyow/pull/321
@@ -79,6 +92,7 @@
 [pr-301]: https://github.com/pakyow/pakyow/pull/301
 [is-298]: https://github.com/pakyow/pakyow/issues/298
 [pr-297]: https://github.com/pakyow/pakyow/pull/297
+[be9b292]: https://github.com/pakyow/pakyow/commit/be9b292ba090976667b3c7a1ee6314cda7995591
 [d55e932]: https://github.com/pakyow/pakyow/commit/d55e9320dcca51ac7d12d8eef4f7f8aaf8faaa4f
 [26f586d]: https://github.com/pakyow/pakyow/commit/26f586d35c5fa0611cac6914fb2f249e3798ec79
 

--- a/pakyow-core/lib/pakyow/behavior/running.rb
+++ b/pakyow-core/lib/pakyow/behavior/running.rb
@@ -6,6 +6,7 @@ require "async/http/endpoint"
 
 require "pakyow/support/extension"
 
+require "pakyow/process"
 require "pakyow/process_manager"
 require "pakyow/processes/proxy"
 require "pakyow/processes/server"
@@ -71,12 +72,12 @@ module Pakyow
 
       class_methods do
         def process(name, count: 1, restartable: true, &block)
-          @processes << {
+          @processes << Process.new(
             name: name,
-            block: block,
-            count: count.to_i,
-            restartable: restartable
-          }
+            count: count,
+            restartable: restartable,
+            &block
+          )
         end
 
         def run
@@ -85,10 +86,10 @@ module Pakyow
               manager.add(process)
             }
 
-            root_pid = Process.pid
+            root_pid = ::Process.pid
 
             at_exit do
-              if Process.pid == root_pid
+              if ::Process.pid == root_pid
                 shutdown
               else
                 @apps.select { |app|

--- a/pakyow-core/lib/pakyow/process.rb
+++ b/pakyow-core/lib/pakyow/process.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Pakyow
+  # A process, runnable within a {ProcessManager}.
+  #
+  class Process
+    attr_reader :name, :count
+
+    def initialize(name:, count: 1, restartable: false, &block)
+      @name, @count, @restartable, @block = name, count.to_i, restartable, block
+    end
+
+    # Returns `true' if this process is restartable.
+    #
+    def restartable?
+      @restartable == true
+    end
+
+    # Calls the given block associated with this process.
+    #
+    def call
+      @block.call
+    end
+  end
+end
+

--- a/pakyow-core/lib/pakyow/process_manager.rb
+++ b/pakyow-core/lib/pakyow/process_manager.rb
@@ -7,11 +7,15 @@ require "pakyow/process"
 require "pakyow/support/inflector"
 
 module Pakyow
+  # Manages one or more processes.
+  #
   class ProcessManager
     def initialize
       @group, @stopped = ::Process::Group.new, false
     end
 
+    # Adds a {Process} instance, where it is immediately run within this manager.
+    #
     def add(process)
       if process.is_a?(Hash)
         Pakyow.deprecated "passing a `Hash' to `Pakyow::ProcessManager#add'", "pass a `Pakyow::Process' instance"
@@ -22,15 +26,21 @@ module Pakyow
       run(process)
     end
 
+    # Waits for all processes to exit.
+    #
     def wait
       @group.wait
     end
 
+    # Stops all processes.
+    #
     def stop(signal = :INT)
       @stopped = true
       @group.kill(signal)
     end
 
+    # Restarts all restartable processes.
+    #
     def restart
       @group.running.each do |pid, process|
         if process.options[:object].restartable?

--- a/pakyow-core/lib/pakyow/process_manager.rb
+++ b/pakyow-core/lib/pakyow/process_manager.rb
@@ -7,13 +7,11 @@ require "pakyow/support/inflector"
 module Pakyow
   class ProcessManager
     def initialize
-      @group, @processes, @stopped = Process::Group.new, [], false
+      @group, @stopped = Process::Group.new, false
     end
 
     def add(process)
-      process = process.dup
       run_process(process)
-      @processes << process
     end
 
     def wait
@@ -27,7 +25,7 @@ module Pakyow
 
     def restart
       @group.running.each do |pid, forked|
-        if forked.instance_variable_get(:@options)[:restartable]
+        if restartable?(forked)
           Process.kill(:INT, pid)
         end
       end
@@ -53,6 +51,10 @@ module Pakyow
           end
         }.resume
       end
+    end
+
+    def restartable?(process)
+      process.options[:restartable]
     end
   end
 end

--- a/pakyow-core/spec/unit/process_manager_spec.rb
+++ b/pakyow-core/spec/unit/process_manager_spec.rb
@@ -21,12 +21,12 @@ RSpec.describe Pakyow::ProcessManager do
   }
 
   let(:process) {
-    {
+    Pakyow::Process.new(
       name: process_name,
-      block: process_block,
       count: process_count,
-      restartable: process_is_restartable
-    }
+      restartable: process_is_restartable,
+      &process_block
+    )
   }
 
   let(:process_name) {
@@ -75,6 +75,64 @@ RSpec.describe Pakyow::ProcessManager do
         expect(process_group).to receive(:fork).once.and_call_original
         instance.add(process)
         instance.wait
+      end
+    end
+
+    describe "backwards compatibility with old hash style processes" do
+      before do
+        allow(instance).to receive(:run)
+        allow(Pakyow).to receive(:deprecated)
+      end
+
+      let(:instance) {
+        described_class.new
+      }
+
+      let(:process) {
+        {
+          name: process_name,
+          block: process_block,
+          count: process_count,
+          restartable: process_is_restartable,
+        }
+      }
+
+      let(:process_name) {
+        "test"
+      }
+
+      let(:process_block) {
+        Proc.new do
+          "called"
+        end
+      }
+
+      let(:process_count) {
+        42
+      }
+
+      let(:process_is_restartable) {
+        true
+      }
+
+      it "is deprecated" do
+        expect(Pakyow).to receive(:deprecated).with(
+          "passing a `Hash' to `Pakyow::ProcessManager#add'",
+          "pass a `Pakyow::Process' instance"
+        )
+
+        instance.add(process)
+      end
+
+      it "builds and runs a Process instance" do
+        expect(instance).to receive(:run) do |process_to_run|
+          expect(process_to_run.name).to eq(process_name)
+          expect(process_to_run.count).to eq(process_count)
+          expect(process_to_run.restartable?).to eq(process_is_restartable)
+          expect(process_to_run.call).to eq("called")
+        end
+
+        instance.add(process)
       end
     end
   end

--- a/pakyow-core/spec/unit/process_spec.rb
+++ b/pakyow-core/spec/unit/process_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe Pakyow::Process do
+  describe "initialization" do
+    context "count is not an integer" do
+      it "is typecast to an integer" do
+        expect(described_class.new(name: "test", count: "42").count).to eq(42)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Introduces a few small optimizations and improvements to the `Pakyow::ProcessManager` internals. Also simplifies the public api to use a new `Pakyow::Process` value object. This api change is introduced in a backwards-compatible way with a deprecation.