### PR TITLE
Insulate from deep freezing

### DIFF
--- a/pakyow-core/lib/pakyow/behavior/running.rb
+++ b/pakyow-core/lib/pakyow/behavior/running.rb
@@ -16,7 +16,7 @@ module Pakyow
       extend Support::Extension
 
       apply_extension do
-        unfreezable :process_manager
+        insulate :process_manager
 
         class_state :processes, default: []
 

--- a/pakyow-core/lib/pakyow/behavior/watching.rb
+++ b/pakyow-core/lib/pakyow/behavior/watching.rb
@@ -15,7 +15,7 @@ module Pakyow
         class_state :on_change_matchers, default: {}
         class_state :watched_paths, default: []
 
-        unfreezable :filewatcher, :filewatcher_thread
+        insulate :filewatcher, :filewatcher_thread
 
         after "run" do
           @filewatcher = Filewatcher.new(

--- a/pakyow-core/lib/pakyow/environment.rb
+++ b/pakyow-core/lib/pakyow/environment.rb
@@ -99,7 +99,7 @@ module Pakyow
   using Support::Refinements::Array::Ensurable
 
   extend Support::DeepFreeze
-  unfreezable :output, :app
+  insulate :output, :app
 
   include Support::Hookable
   events :load, :configure, :setup, :boot, :shutdown, :run

--- a/pakyow-core/lib/pakyow/logger/thread_local.rb
+++ b/pakyow-core/lib/pakyow/logger/thread_local.rb
@@ -12,7 +12,7 @@ module Pakyow
     #
     class ThreadLocal
       extend Support::DeepFreeze
-      unfreezable :default
+      insulate :default
 
       extend Forwardable
       def_delegators :target, *(Logger.instance_methods - Object.instance_methods)

--- a/pakyow-core/lib/pakyow/task.rb
+++ b/pakyow-core/lib/pakyow/task.rb
@@ -19,7 +19,7 @@ module Pakyow
     def_delegators :@rake, :name
 
     extend Support::DeepFreeze
-    unfreezable :rake
+    insulate :rake
 
     attr_reader :description
 

--- a/pakyow-core/spec/features/initializers_spec.rb
+++ b/pakyow-core/spec/features/initializers_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "environment initializers" do
   end
 
   it "loads each initializer" do
-    allow(Pakyow).to receive(:require)
+    allow(Pakyow).to receive(:require).and_call_original
 
     expect(Pakyow).to receive(:require).with(File.join(
       Pakyow.config.root, "config/initializers/environment/bar.rb"

--- a/pakyow-data/lib/pakyow/data/connection.rb
+++ b/pakyow-data/lib/pakyow/data/connection.rb
@@ -17,7 +17,7 @@ module Pakyow
       attr_reader :type, :name, :opts, :adapter, :failure
 
       extend Support::DeepFreeze
-      unfreezable :logger, :adapter
+      insulate :logger, :adapter
 
       def initialize(type:, name:, string: nil, opts: nil, logger: nil)
         @type, @name, @logger, @failure = type, name, logger, nil

--- a/pakyow-data/lib/pakyow/data/subscribers.rb
+++ b/pakyow-data/lib/pakyow/data/subscribers.rb
@@ -12,7 +12,7 @@ module Pakyow
       attr_accessor :lookup, :adapter
 
       extend Support::DeepFreeze
-      unfreezable :executor
+      insulate :executor
 
       using Support::Refinements::Method::Introspection
 

--- a/pakyow-data/lib/pakyow/data/subscribers/adapters/memory.rb
+++ b/pakyow-data/lib/pakyow/data/subscribers/adapters/memory.rb
@@ -28,7 +28,7 @@ module Pakyow
           using Support::DeepDup
 
           extend Support::DeepFreeze
-          unfreezable :subscriptions_by_id, :subscription_ids_by_source, :subscribers_by_subscription_id, :subscription_ids_by_subscriber, :expirations_for_subscriber
+          insulate :subscriptions_by_id, :subscription_ids_by_source, :subscribers_by_subscription_id, :subscription_ids_by_subscriber, :expirations_for_subscriber
 
           def initialize(*)
             @subscriptions_by_id = Concurrent::Hash.new

--- a/pakyow-data/lib/pakyow/data/subscribers/adapters/redis.rb
+++ b/pakyow-data/lib/pakyow/data/subscribers/adapters/redis.rb
@@ -35,7 +35,7 @@ module Pakyow
           INFINITY = "+inf"
 
           extend Support::DeepFreeze
-          unfreezable :redis
+          insulate :redis
 
           def initialize(config)
             @redis = ConnectionPool.new(**config[:pool]) {

--- a/pakyow-presenter/lib/pakyow/presenter/renderer.rb
+++ b/pakyow-presenter/lib/pakyow/presenter/renderer.rb
@@ -24,7 +24,7 @@ module Pakyow
       class_state :__expose_fns, default: [], inheritable: true
 
       extend Support::DeepFreeze
-      unfreezable :__presenters_by_path, :__presenter_views
+      insulate :__presenters_by_path, :__presenter_views
 
       include Support::Hookable
       events :render

--- a/pakyow-realtime/lib/pakyow/application/behavior/realtime/server.rb
+++ b/pakyow-realtime/lib/pakyow/application/behavior/realtime/server.rb
@@ -14,7 +14,7 @@ module Pakyow
 
           apply_extension do
             extend Support::DeepFreeze
-            unfreezable :websocket_server
+            insulate :websocket_server
             attr_reader :websocket_server
 
             after "initialize", priority: :high do

--- a/pakyow-support/CHANGELOG.md
+++ b/pakyow-support/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `add` **Let objects to insulate themselves from a deep freeze.`**
+
+    *Related links:*
+    - [Pull Request #340][pr-340]
+
   * `add` **Introduce `Pakyow::Support::Deprecator`**
 
     *Related links:*
@@ -12,6 +17,7 @@
     *Related links:*
     - [Commit 787681d][787681d]
 
+[pr-340]: https://github.com/pakyow/pakyow/pull/340
 [pr-330]: https://github.com/pakyow/pakyow/pull/330
 [787681d]: https://github.com/pakyow/pakyow/commit/787681dacbbd3ce79f6e38a5672749635903a85b
 

--- a/pakyow-support/lib/pakyow/support/configurable/config.rb
+++ b/pakyow-support/lib/pakyow/support/configurable/config.rb
@@ -15,7 +15,7 @@ module Pakyow
         using DeepDup
 
         extend DeepFreeze
-        unfreezable :configurable
+        insulate :configurable
 
         # @api private
         attr_reader :__settings, :__defaults, :__groups

--- a/pakyow-support/lib/pakyow/support/configurable/setting.rb
+++ b/pakyow-support/lib/pakyow/support/configurable/setting.rb
@@ -11,7 +11,7 @@ module Pakyow
         using DeepDup
 
         extend DeepFreeze
-        unfreezable :configurable, :value
+        insulate :configurable, :value
 
         def initialize(default:, configurable:, &block)
           @default, @block, @configurable = default, block, configurable

--- a/pakyow-support/lib/pakyow/support/deep_freeze.rb
+++ b/pakyow-support/lib/pakyow/support/deep_freeze.rb
@@ -3,6 +3,7 @@
 require "delegate"
 
 require "pakyow/support/class_state"
+require "pakyow/support/deprecator"
 
 module Pakyow
   module Support
@@ -12,12 +13,18 @@ module Pakyow
         base.class_state :__insulated_variables, inheritable: true, default: []
       end
 
-      def unfreezable(*instance_variables)
+      def insulate(*instance_variables)
         @__insulated_variables.concat(
           instance_variables.map { |instance_variable|
             :"@#{instance_variable}"
           }
         ).uniq!
+      end
+
+      def unfreezable(*instance_variables)
+        Deprecator.global.deprecated :unfreezable, "use `insulate'"
+
+        insulate(*instance_variables)
       end
 
       [Object, Delegator].each do |klass|

--- a/pakyow-support/lib/pakyow/support/deep_freeze.rb
+++ b/pakyow-support/lib/pakyow/support/deep_freeze.rb
@@ -24,7 +24,9 @@ module Pakyow
         refine klass do
           def deep_freeze
             if !frozen? && respond_to?(:freeze)
-              freeze
+              if !respond_to?(:insulated?) || !insulated?
+                freeze
+              end
 
               freezable_variables.each do |name|
                 instance_variable_get(name).deep_freeze

--- a/pakyow-support/spec/unit/deep_freeze_spec.rb
+++ b/pakyow-support/spec/unit/deep_freeze_spec.rb
@@ -1,8 +1,9 @@
 require "pakyow/support/deep_freeze"
 using Pakyow::Support::DeepFreeze
+
 class MyObject
   extend Pakyow::Support::DeepFreeze
-  unfreezable :fire
+  insulate :fire
 
   attr_reader :fire, :water
 
@@ -149,6 +150,26 @@ RSpec.describe Pakyow::Support::DeepFreeze do
       it "freezes contained state" do
         expect(insulated_object.internal.frozen?).to be(true)
       end
+    end
+  end
+
+  describe "::unfreezeable" do
+    before do
+      allow(Pakyow::Support::Deprecator.global).to receive(:deprecated)
+    end
+
+    it "is deprecated" do
+      expect(
+        Pakyow::Support::Deprecator.global
+      ).to receive(:deprecated).with(:unfreezable, "use `insulate'")
+
+      MyObject.unfreezable :foo
+    end
+
+    it "calls ::insulate" do
+      expect(MyObject).to receive(:insulate).with(:foo)
+
+      MyObject.unfreezable :foo
     end
   end
 end

--- a/pakyow-support/spec/unit/deep_freeze_spec.rb
+++ b/pakyow-support/spec/unit/deep_freeze_spec.rb
@@ -1,22 +1,25 @@
 require "pakyow/support/deep_freeze"
-using Pakyow::Support::DeepFreeze
-
-class MyObject
-  extend Pakyow::Support::DeepFreeze
-  insulate :fire
-
-  attr_reader :fire, :water
-
-  def initialize
-    @fire = 'fire'
-    @water = 'water'
-  end
-end
 
 RSpec.describe Pakyow::Support::DeepFreeze do
-  let :obj_with_unfreezable do
-    MyObject.new
-  end
+  using Pakyow::Support::DeepFreeze
+
+  let(:unfreezable_object) {
+    unfreezable_class.new
+  }
+
+  let(:unfreezable_class) {
+    Class.new do
+      extend Pakyow::Support::DeepFreeze
+      insulate :fire
+
+      attr_reader :fire, :water
+
+      def initialize
+        @fire = 'fire'
+        @water = 'water'
+      end
+    end
+  }
 
   describe "deep_freeze" do
     it "refines Object" do
@@ -107,11 +110,11 @@ RSpec.describe Pakyow::Support::DeepFreeze do
     end
 
     it "doesn't freeze unfreezeable" do
-      obj_with_unfreezable.deep_freeze
+      unfreezable_object.deep_freeze
 
-      expect(obj_with_unfreezable).to be_frozen
-      expect(obj_with_unfreezable.water).to be_frozen
-      expect(obj_with_unfreezable.fire).not_to be_frozen
+      expect(unfreezable_object).to be_frozen
+      expect(unfreezable_object.water).to be_frozen
+      expect(unfreezable_object.fire).not_to be_frozen
     end
 
     it "doesn't freeze objects that can't be frozen" do
@@ -163,13 +166,13 @@ RSpec.describe Pakyow::Support::DeepFreeze do
         Pakyow::Support::Deprecator.global
       ).to receive(:deprecated).with(:unfreezable, "use `insulate'")
 
-      MyObject.unfreezable :foo
+      unfreezable_class.unfreezable :foo
     end
 
     it "calls ::insulate" do
-      expect(MyObject).to receive(:insulate).with(:foo)
+      expect(unfreezable_class).to receive(:insulate).with(:foo)
 
-      MyObject.unfreezable :foo
+      unfreezable_class.unfreezable :foo
     end
   end
 end

--- a/pakyow-support/spec/unit/deep_freeze_spec.rb
+++ b/pakyow-support/spec/unit/deep_freeze_spec.rb
@@ -118,5 +118,37 @@ RSpec.describe Pakyow::Support::DeepFreeze do
       object.instance_eval("undef :freeze")
       expect { object.deep_freeze }.not_to raise_error
     end
+
+    context "object defines itself as insulated" do
+      let(:insulated_class) {
+        Class.new do
+          attr_reader :internal
+
+          def initialize
+            @internal = []
+          end
+
+          def insulated?
+            true
+          end
+        end
+      }
+
+      let(:insulated_object) {
+        insulated_class.new
+      }
+
+      before do
+        insulated_object.deep_freeze
+      end
+
+      it "does not freeze the object" do
+        expect(insulated_object.frozen?).to be(false)
+      end
+
+      it "freezes contained state" do
+        expect(insulated_object.internal.frozen?).to be(true)
+      end
+    end
   end
 end

--- a/pakyow-ui/lib/pakyow/ui/framework.rb
+++ b/pakyow-ui/lib/pakyow/ui/framework.rb
@@ -75,7 +75,7 @@ module Pakyow
 
           # @api private
           attr_reader :ui_executor
-          unfreezable :ui_executor
+          insulate :ui_executor
 
           after "initialize" do
             @ui_executor = Concurrent::SingleThreadExecutor.new(


### PR DESCRIPTION
Allows objects to insulate themselves from a deep freeze. For example, an object may want to freeze some internal state but allow other bits to be changed even after the parent is frozen:

```ruby
class ObjectWithStatus
  attr_reader :status

  def initialize
    @status, @state = Status.new, []
  end

  def <<(object)
    @state << object
  end

  class Status
    ...
  end
end

instance = ObjectWithStatus.new
instance.deep_freeze

# status can still be changed after being frozen
instance.status.frozen?
# => false

# but the instance itself can no longer be modified
instance << :bar
# => FrozenError
```