### PR TITLE
Resolve several issues with respawns, restarts

### DIFF
--- a/pakyow-assets/lib/pakyow/application/behavior/assets/externals.rb
+++ b/pakyow-assets/lib/pakyow/application/behavior/assets/externals.rb
@@ -53,8 +53,7 @@ module Pakyow
                 end
 
                 if fetched
-                  FileUtils.mkdir_p "./tmp"
-                  FileUtils.touch "./tmp/restart.txt"
+                  touch_restart
                 end
               end
             end

--- a/pakyow-assets/spec/features/externals_spec.rb
+++ b/pakyow-assets/spec/features/externals_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "external scripts" do
     end
 
     it "touches .tmp/restart.txt" do
-      expect(FileUtils).to have_received(:touch).with("./tmp/restart.txt")
+      expect(FileUtils).to have_received(:touch).with(File.expand_path("../../support/app/tmp/restart.txt", __FILE__))
     end
 
     context "external exists" do

--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -98,6 +98,11 @@
 
 # v1.0.3 (unreleased)
 
+  * `fix` **Resolve several issues with respawns, restarts.**
+
+    *Related links:*
+    - [Pull Request #342][pr-342]
+
   * `fix` **Ensure a logger and output is always available in the environment.**
 
     *Related links:*
@@ -113,6 +118,7 @@
     *Related links:*
     - [Pull Request #328][pr-328]
 
+[pr-342]: https://github.com/pakyow/pakyow/pull/342
 [pr-331]: https://github.com/pakyow/pakyow/pull/331
 [pr-329]: https://github.com/pakyow/pakyow/pull/329
 [pr-328]: https://github.com/pakyow/pakyow/pull/328

--- a/pakyow-core/lib/pakyow/application/behavior/restarting.rb
+++ b/pakyow-core/lib/pakyow/application/behavior/restarting.rb
@@ -44,6 +44,11 @@ module Pakyow
           end
         end
 
+        def touch_restart
+          FileUtils.mkdir_p(File.join(config.root, "tmp"))
+          FileUtils.touch(File.join(config.root, "tmp/restart.txt"))
+        end
+
         private
 
         def setup_for_restarting
@@ -53,15 +58,14 @@ module Pakyow
 
             # FIXME: this doesn't need to be hardcoded, but instead determined
             # from the source location when registered with the environment
-            config.process.watched_paths << "./config/application.rb"
+            config.process.watched_paths << File.join(config.root, "config/application.rb")
 
             Thread.new do
               Filewatcher.new(
                 config.process.watched_paths,
                 exclude: config.process.excluded_paths
               ).watch do |_path, _event|
-                FileUtils.mkdir_p "./tmp"
-                FileUtils.touch "./tmp/restart.txt"
+                touch_restart
               end
             end
           end

--- a/pakyow-support/lib/pakyow/support/system.rb
+++ b/pakyow-support/lib/pakyow/support/system.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "pathname"
+
 module Pakyow
   module Support
     # Information about the local system.

--- a/spec/smoke/respawn_spec.rb
+++ b/spec/smoke/respawn_spec.rb
@@ -1,0 +1,50 @@
+require "smoke_helper"
+
+RSpec.describe "respawning a project", smoke: true do
+  before do
+    # Add the markdown page.
+    #
+    File.open(project_path.join("frontend/pages/index.md"), "w+") do |file|
+      file.write <<~SOURCE
+        **hello web**
+      SOURCE
+    end
+
+    # Disable external asset fetching.
+    # TODO: Remove this once we no longer restart when externals are fetched.
+    #
+    File.open(project_path.join("config/application.rb"), "w+") do |file|
+      file.write <<~SOURCE
+        Pakyow.app :smoke_test do
+          configure do
+            config.assets.externals.fetch = false
+          end
+        end
+      SOURCE
+    end
+
+    boot
+  end
+
+  context "gem is added" do
+    it "respawns" do
+      # We have to sleep here, or filewatcher doesn't get initialized in time.
+      # TODO: See if this can go away once we own file watching.
+      #
+      sleep 1
+
+      File.open(project_path.join("Gemfile"), "a") do |file|
+        file.write("\ngem \"pakyow-markdown\"")
+      end
+
+      # Wait for the process to respawn.
+      #
+      sleep 10
+
+      response = HTTP.get("http://localhost:#{port}")
+
+      expect(response.status).to eq(200)
+      expect(response.body.to_s).to include("<strong>hello web</strong>")
+    end
+  end
+end

--- a/spec/smoke/restart_spec.rb
+++ b/spec/smoke/restart_spec.rb
@@ -1,0 +1,44 @@
+require "smoke_helper"
+
+RSpec.describe "restarting a project", smoke: true do
+  before do
+    # Disable external asset fetching.
+    # TODO: Remove this once we no longer restart when externals are fetched.
+    #
+    project_path.join("config/application.rb").open("w+") do |file|
+      file.write <<~SOURCE
+        Pakyow.app :smoke_test do
+          configure do
+            config.assets.externals.fetch = false
+          end
+        end
+      SOURCE
+    end
+
+    boot
+  end
+
+  context "page is added" do
+    it "restarts" do
+      # We have to sleep here, or filewatcher doesn't get initialized in time.
+      # TODO: See if this can go away once we own file watching.
+      #
+      sleep 1
+
+      project_path.join("frontend/pages/index.html").open("w+") do |file|
+        file.write <<~SOURCE
+          hello web
+        SOURCE
+      end
+
+      # wait for the process to restart
+      #
+      sleep 5
+
+      response = HTTP.get("http://localhost:#{port}")
+
+      expect(response.status).to eq(200)
+      expect(response.body.to_s).to include("hello web")
+    end
+  end
+end

--- a/spec/smoke/startup_spec.rb
+++ b/spec/smoke/startup_spec.rb
@@ -2,6 +2,19 @@ require "smoke_helper"
 
 RSpec.describe "starting up a newly generated project", smoke: true do
   before do
+    # Disable external asset fetching.
+    # TODO: Remove this once we no longer restart when externals are fetched.
+    #
+    File.open(project_path.join("config/application.rb"), "w+") do |file|
+      file.write <<~SOURCE
+        Pakyow.app :smoke_test do
+          configure do
+            config.assets.externals.fetch = false
+          end
+        end
+      SOURCE
+    end
+
     boot do
       # TODO: Enable this once externals are fetched in the background.
       #


### PR DESCRIPTION
* Make watch paths relative to environment and/or application root.
* Close the bound endpoint on shutdown so the port can be reused by respawns.
* Add smoke tests for restarts and respawns.