### PR TITLE
Improve the thread local logger

### DIFF
--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -2,6 +2,16 @@
 
   * `chg` **Initialize thread local logger with key, support setting the thread local logger.**
 
+    *Related links:*
+    - [Pull Request #344][pr-344]
+    - [Commit ac9c7a9][ac9c7a9]
+
+  * `chg` **Support silencing in the thread local logger.**
+
+    *Related links:*
+    - [Pull Request #344][pr-344]
+    - [Commit 04e82ff][04e82ff]
+
   * `chg` **Improve `Pakyow::ProcessManager` api with the addition of a `Pakyow::Process` value object.**
 
     *Related links:*
@@ -74,6 +84,10 @@
 
   * `Pakyow::Logger#silence` is deprecated in favor of `Pakyow::Logger::ThreadLocal#silence`.
 
+    *Related links:*
+    - [Pull Request #344][pr-344]
+    - [Commit c75ca74][c75ca74]
+
   * `Pakyow::ProcessManager#add` no longer accepts a `Hash`.
 
     *Related links:*
@@ -85,6 +99,7 @@
     *Related links:*
     - [Pull Request #338][pr-338]
 
+[pr-344]: https://github.com/pakyow/pakyow/pull/344
 [pr-339]: https://github.com/pakyow/pakyow/pull/339
 [pr-338]: https://github.com/pakyow/pakyow/pull/338
 [pr-335]: https://github.com/pakyow/pakyow/pull/335
@@ -96,6 +111,9 @@
 [pr-301]: https://github.com/pakyow/pakyow/pull/301
 [is-298]: https://github.com/pakyow/pakyow/issues/298
 [pr-297]: https://github.com/pakyow/pakyow/pull/297
+[c75ca74]: https://github.com/pakyow/pakyow/commit/c75ca749595e8e6f6e5950fc19f528e7c02230d7
+[ac9c7a9]: https://github.com/pakyow/pakyow/commit/ac9c7a95afef1b86ba5946d34269480e1d5f9081
+[04e82ff]: https://github.com/pakyow/pakyow/commit/04e82fffb77b3c72b3fbb4783744c9d4bdec1a25
 [be9b292]: https://github.com/pakyow/pakyow/commit/be9b292ba090976667b3c7a1ee6314cda7995591
 [d55e932]: https://github.com/pakyow/pakyow/commit/d55e9320dcca51ac7d12d8eef4f7f8aaf8faaa4f
 [26f586d]: https://github.com/pakyow/pakyow/commit/26f586d35c5fa0611cac6914fb2f249e3798ec79

--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -72,6 +72,8 @@
 
 ## Deprecations
 
+  * `Pakyow::Logger#silence` is deprecated in favor of `Pakyow::Logger::ThreadLocal#silence`.
+
   * `Pakyow::ProcessManager#add` no longer accepts a `Hash`.
 
     *Related links:*

--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # v1.1.0 (unreleased)
 
+  * `chg` **Initialize thread local logger with key, support setting the thread local logger.**
+
   * `chg` **Improve `Pakyow::ProcessManager` api with the addition of a `Pakyow::Process` value object.**
 
     *Related links:*

--- a/pakyow-core/lib/pakyow/actions/logger.rb
+++ b/pakyow-core/lib/pakyow/actions/logger.rb
@@ -7,7 +7,7 @@ module Pakyow
     class Logger
       def call(connection, &block)
         if silence?(connection)
-          connection.logger.silence do
+          Pakyow.logger.silence do
             call_with_logging(connection, &block)
           end
         else

--- a/pakyow-core/lib/pakyow/connection.rb
+++ b/pakyow-core/lib/pakyow/connection.rb
@@ -289,7 +289,7 @@ module Pakyow
       end
 
       @streams << Async::Task.current.async { |task|
-        Thread.current[:pakyow_logger] = @logger
+        Pakyow.logger.set(@logger)
 
         begin
           yield self

--- a/pakyow-core/lib/pakyow/connection.rb
+++ b/pakyow-core/lib/pakyow/connection.rb
@@ -47,7 +47,7 @@ module Pakyow
     attr_reader :error
 
     # @api private
-    attr_writer :error, :input_parser
+    attr_writer :error, :input_parser, :logger
     # @api private
     attr_reader :request
 

--- a/pakyow-core/lib/pakyow/connection.rb
+++ b/pakyow-core/lib/pakyow/connection.rb
@@ -3,6 +3,7 @@
 require "cgi"
 require "securerandom"
 
+require "async"
 require "async/http"
 require "async/http/protocol/response"
 
@@ -47,7 +48,7 @@ module Pakyow
     attr_reader :error
 
     # @api private
-    attr_writer :error, :input_parser, :logger
+    attr_writer :error, :input_parser
     # @api private
     attr_reader :request
 
@@ -61,8 +62,15 @@ module Pakyow
       @request = request
       @body = Async::HTTP::Body::Buffered.wrap(StringIO.new)
       @params = Pakyow::Connection::Params.new
-      @logger = Logger.new(:http, started_at: @timestamp, id: @id, output: Pakyow.output, level: Pakyow.config.logger.level)
       @streams = []
+
+      @logger = Logger.new(
+        :http,
+        started_at: @timestamp,
+        id: @id,
+        output: Pakyow.output,
+        level: Pakyow.config.logger.level
+      )
     end
 
     def request_header?(key)
@@ -288,9 +296,7 @@ module Pakyow
         @body = Async::HTTP::Body::Writable.new(length)
       end
 
-      @streams << Async::Task.current.async { |task|
-        Pakyow.logger.set(@logger)
-
+      @streams << async { |task|
         begin
           yield self
         rescue => error
@@ -303,6 +309,27 @@ module Pakyow
 
     def streaming?
       @streams.any?
+    end
+
+    def async
+      unless defined?(@initial_logger)
+        @initial_logger = @logger
+      end
+
+      Async(logger: Pakyow.logger) do |task|
+        original_logger = @logger
+
+        # Always log through the thread-local logger. The thread local gives us a thread-safe way to
+        # do things like silencing, so it's preferred over using the connection logger directly.
+        #
+        @logger = Pakyow.logger
+
+        Pakyow.logger.set(@initial_logger)
+
+        yield task if block_given?
+      ensure
+        @logger = original_logger
+      end
     end
 
     def sleep(seconds)

--- a/pakyow-core/lib/pakyow/environment.rb
+++ b/pakyow-core/lib/pakyow/environment.rb
@@ -327,14 +327,7 @@ module Pakyow
 
     def call(input)
       config.connection_class.new(input).yield_self { |connection|
-        Async(logger: logger) {
-          Pakyow.logger.set(connection.logger)
-
-          # Always log through the thread-local logger. The thread local gives us a thread-safe way to
-          # do things like silencing, so it's preferred over using the connection logger directly.
-          #
-          connection.logger = Pakyow.logger
-
+        connection.async {
           catch :halt do
             @pipeline.call(connection)
           end

--- a/pakyow-core/lib/pakyow/environment.rb
+++ b/pakyow-core/lib/pakyow/environment.rb
@@ -173,7 +173,7 @@ module Pakyow
     # Builds and returns a default logger that's replaced in `setup`.
     #
     def logger
-      @logger ||= Logger::ThreadLocal.new(Logger.new("dflt", output: output, level: :all))
+      @logger ||= Logger::ThreadLocal.new(Logger.new("dflt", output: output, level: :all), key: :pakyow_logger)
     end
 
     # Mounts an app at a path.
@@ -339,7 +339,7 @@ module Pakyow
           # Pakyow is designed so that the connection object and its logger should always be available
           # anywhere you need it. If it isn't, reconsider the design before using the thread local.
           #
-          Thread.current[:pakyow_logger] = connection.logger
+          Pakyow.logger.set(connection.logger)
 
           catch :halt do
             @pipeline.call(connection)

--- a/pakyow-core/lib/pakyow/logger.rb
+++ b/pakyow-core/lib/pakyow/logger.rb
@@ -49,7 +49,11 @@ module Pakyow
 
     # Temporarily silences logs, up to +temporary_level+.
     #
+    # @deprecated Use {Pakyow::Logger::ThreadLocal#silence} instead.
+    #
     def silence(temporary_level = :error)
+      Pakyow.deprecated self, :silence, "use `Pakyow::Logger::ThreadLocal#silence'"
+
       original_level = @level
       self.level = self.class.const_get(:LEVELS)[temporary_level]
       yield

--- a/pakyow-core/spec/unit/actions/logger_spec.rb
+++ b/pakyow-core/spec/unit/actions/logger_spec.rb
@@ -70,11 +70,11 @@ RSpec.describe Pakyow::Actions::Logger do
 
       it "silences log output" do
         expect(logger).to receive(:prologue) do
-          expect(logger.level).to eq(4)
+          expect(Pakyow.logger.level).to eq(4)
         end
 
         expect(logger).to receive(:epilogue) do
-          expect(logger.level).to eq(4)
+          expect(Pakyow.logger.level).to eq(4)
         end
 
         action.call(connection) {}

--- a/pakyow-core/spec/unit/app_spec.rb
+++ b/pakyow-core/spec/unit/app_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Pakyow::Application do
           fail "testing rescue mode"
         end
 
-        Pakyow.instance_variable_set(:@logger, Logger.new(File::NULL))
+        Pakyow.logger.set(Logger.new(File::NULL))
       end
 
       it "halts" do
@@ -69,7 +69,7 @@ RSpec.describe Pakyow::Application do
           eval("if")
         end
 
-        Pakyow.instance_variable_set(:@logger, Logger.new(File::NULL))
+        Pakyow.logger.set(Logger.new(File::NULL))
       end
 
       it "enters rescue mode" do
@@ -141,7 +141,7 @@ RSpec.describe Pakyow::Application do
           fail "testing rescue mode"
         end
 
-        Pakyow.instance_variable_set(:@logger, Logger.new(File::NULL))
+        Pakyow.logger.set(Logger.new(File::NULL))
       end
 
       it "enters rescue mode" do
@@ -170,7 +170,7 @@ RSpec.describe Pakyow::Application do
           eval("if")
         end
 
-        Pakyow.instance_variable_set(:@logger, Logger.new(File::NULL))
+        Pakyow.logger.set(Logger.new(File::NULL))
       end
 
       it "enters rescue mode" do

--- a/pakyow-core/spec/unit/connection/shared_examples/stream.rb
+++ b/pakyow-core/spec/unit/connection/shared_examples/stream.rb
@@ -20,7 +20,7 @@ RSpec.shared_examples :connection_stream do
 
     it "registers an async task that yields the connection" do
       Async::Reactor.run { |task|
-        expect(task).to receive(:async) do |&block|
+        expect(connection).to receive(:async) do |&block|
           block.call
         end
 

--- a/pakyow-core/spec/unit/logger/thread_local_spec.rb
+++ b/pakyow-core/spec/unit/logger/thread_local_spec.rb
@@ -1,4 +1,8 @@
 RSpec.describe Pakyow::Logger::ThreadLocal do
+  before do
+    allow(Pakyow).to receive(:deprecated)
+  end
+
   let(:instance) {
     described_class.new(default)
   }
@@ -7,9 +11,28 @@ RSpec.describe Pakyow::Logger::ThreadLocal do
     instance_double(Pakyow::Logger)
   }
 
+  describe "#initialize" do
+    context "without passing a value for key" do
+      it "is deprecated" do
+        expect(Pakyow).to receive(:deprecated).with(
+          "default value for `Pakyow::Logger::ThreadLocal' argument `key'",
+          "pass value for `key'"
+        )
+
+        instance
+      end
+
+      it "defaults to :pakyow_logger" do
+        instance.set :foo
+
+        expect(Thread.current[:pakyow_logger]).to be(:foo)
+      end
+    end
+  end
+
   describe "#silence" do
     before do
-      Thread.current[:pakyow_logger] = local
+      instance.set(local)
       allow(local).to receive(:dup).and_return(duped)
       allow(duped).to receive(:level=)
     end
@@ -51,7 +74,7 @@ RSpec.describe Pakyow::Logger::ThreadLocal do
 
     context "no thread local logger" do
       before do
-        Thread.current[:pakyow_logger] = nil
+        instance.set(nil)
         allow(default).to receive(:dup).and_return(duped)
       end
 

--- a/pakyow-core/spec/unit/logger/thread_local_spec.rb
+++ b/pakyow-core/spec/unit/logger/thread_local_spec.rb
@@ -1,0 +1,73 @@
+RSpec.describe Pakyow::Logger::ThreadLocal do
+  let(:instance) {
+    described_class.new(default)
+  }
+
+  let(:default) {
+    instance_double(Pakyow::Logger)
+  }
+
+  describe "#silence" do
+    before do
+      Thread.current[:pakyow_logger] = local
+      allow(local).to receive(:dup).and_return(duped)
+      allow(duped).to receive(:level=)
+    end
+
+    let(:local) {
+      instance_double(Pakyow::Logger)
+    }
+
+    let(:duped) {
+      instance_double(Pakyow::Logger)
+    }
+
+    it "yields" do
+      expect { |block|
+        instance.silence(&block)
+      }.to yield_control
+    end
+
+    it "sets a copy of the current logger configured at the given level" do
+      expect(duped).to receive(:level=).with(:warn)
+
+      instance.silence :warn do
+        expect(instance.target).to be(duped)
+        expect(instance.target).not_to be(local)
+      end
+    end
+
+    it "resets the thread local logger back to the original logger" do
+      instance.silence :warn do; end
+      expect(instance.target).to be(local)
+    end
+
+    context "level is not passed" do
+      it "defaults to error" do
+        expect(duped).to receive(:level=).with(:error)
+        instance.silence do; end
+      end
+    end
+
+    context "no thread local logger" do
+      before do
+        Thread.current[:pakyow_logger] = nil
+        allow(default).to receive(:dup).and_return(duped)
+      end
+
+      it "sets a copy of the default logger configured at the given level" do
+        expect(duped).to receive(:level=).with(:warn)
+
+        instance.silence :warn do
+          expect(instance.target).to be(duped)
+          expect(instance.target).not_to be(default)
+        end
+      end
+
+      it "resets the thread local logger back to nil" do
+        instance.silence do; end
+        expect(Thread.current[:pakyow_logger]).to be(nil)
+      end
+    end
+  end
+end

--- a/pakyow-core/spec/unit/logger_spec.rb
+++ b/pakyow-core/spec/unit/logger_spec.rb
@@ -192,6 +192,16 @@ RSpec.describe Pakyow::Logger do
   end
 
   describe "#silence" do
+    before do
+      allow(Pakyow).to receive(:deprecated)
+    end
+
+    it "is deprecated" do
+      expect(Pakyow).to receive(:deprecated).with(instance, :silence, "use `Pakyow::Logger::ThreadLocal#silence'")
+
+      instance.silence do; end
+    end
+
     it "does not log messages below error by default" do
       expect(output).not_to receive(:warn)
 

--- a/pakyow-realtime/lib/pakyow/realtime/websocket.rb
+++ b/pakyow-realtime/lib/pakyow/realtime/websocket.rb
@@ -85,6 +85,10 @@ module Pakyow
 
       def open
         response = Async::WebSocket::Adapters::Native.open(@connection.request, handler: Connection) do |socket|
+          original_logger = @logger
+          Pakyow.logger.set(@logger)
+          @logger = Pakyow.logger
+
           @socket = socket
 
           handle_open
@@ -94,6 +98,7 @@ module Pakyow
         rescue EOFError, Protocol::WebSocket::ClosedError
         ensure
           @socket&.close; shutdown
+          @logger = original_logger
         end
 
         @connection.__getobj__.instance_variable_set(:@response, response)

--- a/pakyow-support/CHANGELOG.md
+++ b/pakyow-support/CHANGELOG.md
@@ -1,7 +1,5 @@
 # v1.1.0 (unreleased)
 
-  * `add` **Support silencing in the thread local logger.**
-
   * `add` **Insulate `Socket`/`IO` from deep freezing.**
 
     *Related links:*

--- a/pakyow-support/CHANGELOG.md
+++ b/pakyow-support/CHANGELOG.md
@@ -1,5 +1,7 @@
 # v1.1.0 (unreleased)
 
+  * `add` **Support silencing in the thread local logger.**
+
   * `add` **Insulate `Socket`/`IO` from deep freezing.**
 
     *Related links:*

--- a/spec/spec_config.rb
+++ b/spec/spec_config.rb
@@ -152,6 +152,8 @@ RSpec.configure do |config|
       }.map(&:to_sym)
     )
 
+    Thread.current[:pakyow_logger] = nil
+
     if ENV["RSS"]
       GC.start
       puts "rss: #{rss} live objects (#{GC.stat[:heap_live_slots]})"


### PR DESCRIPTION
* Initialize `Pakyow::Logger::ThreadLocal` with the thread local key, and set the local logger.
* Support thread safe silencing via `Pakyow::Logger::ThreadLocal#silence`.
* Deprecate `Pakyow::Logger#silence` in favor of `Pakyow::Logger::ThreadLocal#silence`.