### PR TITLE
Boot the environment once, prior to forking child processes

### DIFF
--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
   * `chg` **Boot the environment once, prior to forking child processes.**
 
+    *Related links:*
+    - [Pull Request #348][pr-348]
+    - [Commit 641fd12][641fd12]
+
   * `chg` **Run the environment in context of an async reactor.**
 
     *Related links:*
@@ -92,6 +96,10 @@
 
   * The environment's `freeze_on_boot` config option is deprecated and will be removed.
 
+    *Related links:*
+    - [Pull Request #348][pr-348]
+    - [Commit c75ca74][c75ca74]
+
   * `Pakyow::Logger#silence` is deprecated in favor of `Pakyow::Logger::ThreadLocal#silence`.
 
     *Related links:*
@@ -109,6 +117,7 @@
     *Related links:*
     - [Pull Request #338][pr-338]
 
+[pr-348]: https://github.com/pakyow/pakyow/pull/348
 [pr-347]: https://github.com/pakyow/pakyow/pull/347
 [pr-344]: https://github.com/pakyow/pakyow/pull/344
 [pr-339]: https://github.com/pakyow/pakyow/pull/339
@@ -122,6 +131,8 @@
 [pr-301]: https://github.com/pakyow/pakyow/pull/301
 [is-298]: https://github.com/pakyow/pakyow/issues/298
 [pr-297]: https://github.com/pakyow/pakyow/pull/297
+[641fd12]: https://github.com/pakyow/pakyow/commit/641fd12b5abee8558621caf857cec47d38814c8a
+[12de611]: https://github.com/pakyow/pakyow/commit/12de611e480fb9224f1e0bdaf9bd902448dd69e3
 [991f3dd]: https://github.com/pakyow/pakyow/commit/991f3ddd589edc9d08370c4f020e2ef0297433c7
 [c75ca74]: https://github.com/pakyow/pakyow/commit/c75ca749595e8e6f6e5950fc19f528e7c02230d7
 [ac9c7a9]: https://github.com/pakyow/pakyow/commit/ac9c7a95afef1b86ba5946d34269480e1d5f9081

--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # v1.1.0 (unreleased)
 
+  * `chg` **Boot the environment once, prior to forking child processes.**
+
   * `chg` **Run the environment in context of an async reactor.**
 
     *Related links:*

--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -90,6 +90,8 @@
 
 ## Deprecations
 
+  * The environment's `freeze_on_boot` config option is deprecated and will be removed.
+
   * `Pakyow::Logger#silence` is deprecated in favor of `Pakyow::Logger::ThreadLocal#silence`.
 
     *Related links:*

--- a/pakyow-core/lib/pakyow/behavior/running.rb
+++ b/pakyow-core/lib/pakyow/behavior/running.rb
@@ -79,6 +79,8 @@ module Pakyow
         end
 
         def run
+          boot
+
           Async::Reactor.run do |reactor|
             @__reactor = reactor
 

--- a/pakyow-core/lib/pakyow/behavior/running.rb
+++ b/pakyow-core/lib/pakyow/behavior/running.rb
@@ -126,7 +126,7 @@ module Pakyow
             end
           end
 
-          @process_manager.restart
+          boot; @process_manager.restart
         end
 
         def async(&block)

--- a/pakyow-core/lib/pakyow/environment.rb
+++ b/pakyow-core/lib/pakyow/environment.rb
@@ -288,10 +288,6 @@ module Pakyow
         @apps.select { |app| app.respond_to?(:booted) }.each(&:booted)
       end
 
-      if config.freeze_on_boot
-        deep_freeze unless unsafe
-      end
-
       self
     rescue StandardError => error
       handle_boot_failure(error)

--- a/pakyow-core/lib/pakyow/processes/proxy.rb
+++ b/pakyow-core/lib/pakyow/processes/proxy.rb
@@ -40,6 +40,8 @@ module Pakyow
 
           if Pakyow.config.freeze_on_boot
             Pakyow.deep_freeze
+          else
+            Pakyow.deprecated "config.freeze_on_boot", "do not change this setting"
           end
         end
       end

--- a/pakyow-core/lib/pakyow/processes/proxy.rb
+++ b/pakyow-core/lib/pakyow/processes/proxy.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require "pakyow/support/deep_freeze"
+
 module Pakyow
   module Processes
     class Proxy
+      using Support::DeepFreeze
+
       class << self
         def find_local_port
           server = TCPServer.new("127.0.0.1", 0)
@@ -32,6 +36,10 @@ module Pakyow
             Pakyow.logger << Pakyow::Processes::Server.running_text(
               scheme: "http", host: @host, port: @port
             )
+          end
+
+          if Pakyow.config.freeze_on_boot
+            Pakyow.deep_freeze
           end
         end
       end

--- a/pakyow-core/lib/pakyow/processes/server.rb
+++ b/pakyow-core/lib/pakyow/processes/server.rb
@@ -2,11 +2,14 @@
 
 require "async/http/server"
 
+require "pakyow/support/deep_freeze"
 require "pakyow/support/extension"
 
 module Pakyow
   module Processes
     class Server
+      using Support::DeepFreeze
+
       class << self
         def running_text(scheme:, host:, port:)
           text = String.new("Pakyow › #{Pakyow.env.capitalize}")
@@ -24,7 +27,11 @@ module Pakyow
 
       def run
         Async::Reactor.run do
-          Async::HTTP::Server.new(Pakyow.boot, @endpoint, @protocol, @scheme).run
+          Async::HTTP::Server.new(Pakyow, @endpoint, @protocol, @scheme).run
+
+          if Pakyow.config.freeze_on_boot
+            Pakyow.deep_freeze
+          end
         end
       end
     end

--- a/pakyow-core/lib/pakyow/processes/server.rb
+++ b/pakyow-core/lib/pakyow/processes/server.rb
@@ -31,6 +31,8 @@ module Pakyow
 
           if Pakyow.config.freeze_on_boot
             Pakyow.deep_freeze
+          else
+            Pakyow.deprecated "config.freeze_on_boot", "do not change this setting"
           end
         end
       end

--- a/spec/smoke/frozen_spec.rb
+++ b/spec/smoke/frozen_spec.rb
@@ -1,0 +1,56 @@
+require "smoke_helper"
+
+RSpec.describe "changing application state at runtime", smoke: true do
+  before do
+    File.open(project_path.join("config/application.rb"), "w+") do |file|
+      file.write <<~SOURCE
+        Pakyow.app :smoke_test, only: %i[routing data] do
+          controller "/mutate" do
+            handle FrozenError, as: :internal_server_error do
+              send "frozen"
+            end
+
+            namespace "/environment" do
+              get "/config" do
+                Pakyow.config.secrets << :hacked
+              end
+            end
+
+            namespace "/application" do
+              get "/config" do
+                config.name = :hacked
+              end
+
+              get "/aspect" do
+                connection.app.controller :foo do; end
+              end
+            end
+          end
+        end
+      SOURCE
+    end
+
+    boot
+  end
+
+  context "changing environment config" do
+    it "fails" do
+      response = HTTP.get("http://localhost:#{port}/mutate/environment/config")
+      expect(response.body.to_s).to eq("frozen")
+    end
+  end
+
+  context "changing application config" do
+    it "fails" do
+      response = HTTP.get("http://localhost:#{port}/mutate/application/config")
+      expect(response.body.to_s).to eq("frozen")
+    end
+  end
+
+  context "defining an application aspect" do
+    it "fails" do
+      response = HTTP.get("http://localhost:#{port}/mutate/application/aspect")
+      expect(response.body.to_s).to eq("frozen")
+    end
+  end
+end

--- a/spec/spec_config.rb
+++ b/spec/spec_config.rb
@@ -41,10 +41,6 @@ RSpec.configure do |config|
     Pakyow::Support::CLI.instance_variable_set(:@style, Pastel.new(enabled: true))
 
     if Pakyow.respond_to?(:config)
-      Pakyow.config.freeze_on_boot = false
-    end
-
-    if Pakyow.respond_to?(:config)
       $original_pakyow_config = Pakyow.config
     end
 


### PR DESCRIPTION
This allows all environment/application state to be shared across processes, reducing the overall memory footprint substantially (4x for the pakyow.com app).

Also deprecates the `freeze_on_boot` config option. We don't want to support bad patterns, e.g. use this plugin but make sure not to freeze the environment. This is a crucial security feature.