### PR TITLE
Add Deprecator#ignore

### DIFF
--- a/pakyow-support/CHANGELOG.md
+++ b/pakyow-support/CHANGELOG.md
@@ -1,5 +1,11 @@
 # v1.1.0 (unreleased)
 
+  * `add` **Add `Deprecator#ignore`.**
+    - Allows deprecations to be ignored during the execution of a block.
+
+    *Related links:*
+    - [Pull Request #349][pr-349]
+
   * `add` **Insulate `Socket`/`IO` from deep freezing.**
 
     *Related links:*
@@ -23,6 +29,7 @@
     *Related links:*
     - [Commit 787681d][787681d]
 
+[pr-349]: https://github.com/pakyow/pakyow/pull/349
 [pr-343]: https://github.com/pakyow/pakyow/pull/343
 [pr-340]: https://github.com/pakyow/pakyow/pull/340
 [pr-330]: https://github.com/pakyow/pakyow/pull/330

--- a/pakyow-support/lib/pakyow/support/deprecator.rb
+++ b/pakyow-support/lib/pakyow/support/deprecator.rb
@@ -49,7 +49,7 @@ module Pakyow
       #
       # @example
       #   deprecator = Pakyow::Support::Deprecator.new(
-      #     Pakyow::Support::Deprecator::Reporters::Null(logger: Pakyow.logger)
+      #     Pakyow::Support::Deprecator::Reporters::Log(logger: Pakyow.logger)
       #   )
       #
       #   deprecator.deprecated Foo, :bar, "use `baz'"
@@ -71,7 +71,7 @@ module Pakyow
       #
       # @example
       #   deprecator = Pakyow::Support::Deprecator.new(
-      #     Pakyow::Support::Deprecator::Reporters::Null(logger: Pakyow.logger)
+      #     Pakyow::Support::Deprecator::Reporters::Log(logger: Pakyow.logger)
       #   )
       #
       #   deprecator.ignore do

--- a/pakyow-support/lib/pakyow/support/deprecator.rb
+++ b/pakyow-support/lib/pakyow/support/deprecator.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "pakyow/support/deprecation"
+require "pakyow/support/deprecator/reporters/null"
+
 
 module Pakyow
   module Support
@@ -60,9 +62,38 @@ module Pakyow
       #   => [deprecation] `foo.rb' is deprecated; solution: rename to `baz.rb'
       #
       def deprecated(*targets, solution)
-        @reporter.report do
+        reporter.report do
           Deprecation.new(*targets, solution: solution)
         end
+      end
+
+      # Ignores deprecations reported for the given block.
+      #
+      # @example
+      #   deprecator = Pakyow::Support::Deprecator.new(
+      #     Pakyow::Support::Deprecator::Reporters::Null(logger: Pakyow.logger)
+      #   )
+      #
+      #   deprecator.ignore do
+      #     deprecator.deprecated Foo.new, :bar, "use `baz'"
+      #   end
+      #
+      def ignore
+        replace(Reporters::Null); yield
+      ensure
+        replace(nil)
+      end
+
+      private def reporter
+        Thread.current[thread_local_key] || @reporter
+      end
+
+      private def replace(reporter)
+        Thread.current[thread_local_key] = reporter
+      end
+
+      private def thread_local_key
+        @thread_local_key ||= :"pakyow_deprecator_#{object_id}_reporter"
       end
 
       class << self


### PR DESCRIPTION
Allows deprecations to be ignored during the execution of a block:

```ruby
deprecator = Pakyow::Support::Deprecator.new(
  Pakyow::Support::Deprecator::Reporters::Log(logger: Pakyow.logger)
)

deprecator.ignore do
  deprecator.deprecated Foo.new, :bar, "use `baz'"
end
```

Implemented in a thread safe manner.