### PR TITLE
Introduce config deprecations

### DIFF
--- a/pakyow-core/lib/pakyow/config.rb
+++ b/pakyow-core/lib/pakyow/config.rb
@@ -10,8 +10,9 @@ module Pakyow
     extend Support::Extension
 
     apply_extension do
+      deprecated_setting :freeze_on_boot, true
+
       setting :default_env, :development
-      setting :freeze_on_boot, true
       setting :exit_on_boot_failure, true
       setting :timezone, :utc
       setting :secrets, ["pakyow"]

--- a/pakyow-core/lib/pakyow/processes/proxy.rb
+++ b/pakyow-core/lib/pakyow/processes/proxy.rb
@@ -38,10 +38,10 @@ module Pakyow
             )
           end
 
-          if Pakyow.config.freeze_on_boot
-            Pakyow.deep_freeze
-          else
-            Pakyow.deprecated "config.freeze_on_boot", "do not change this setting"
+          Pakyow.deprecator.ignore do
+            if Pakyow.config.freeze_on_boot
+              Pakyow.deep_freeze
+            end
           end
         end
       end

--- a/pakyow-core/lib/pakyow/processes/server.rb
+++ b/pakyow-core/lib/pakyow/processes/server.rb
@@ -29,10 +29,10 @@ module Pakyow
         Async::Reactor.run do
           Async::HTTP::Server.new(Pakyow, @endpoint, @protocol, @scheme).run
 
-          if Pakyow.config.freeze_on_boot
-            Pakyow.deep_freeze
-          else
-            Pakyow.deprecated "config.freeze_on_boot", "do not change this setting"
+          Pakyow.deprecator.ignore do
+            if Pakyow.config.freeze_on_boot
+              Pakyow.deep_freeze
+            end
           end
         end
       end

--- a/pakyow-support/CHANGELOG.md
+++ b/pakyow-support/CHANGELOG.md
@@ -2,6 +2,9 @@
 
   * `add` **Introduce config deprecations.**
 
+    *Related links:*
+    - [Pull Request #350][pr-350]
+
   * `add` **Add `Deprecator#ignore`.**
     - Allows deprecations to be ignored during the execution of a block.
 
@@ -31,6 +34,7 @@
     *Related links:*
     - [Commit 787681d][787681d]
 
+[pr-350]: https://github.com/pakyow/pakyow/pull/350
 [pr-349]: https://github.com/pakyow/pakyow/pull/349
 [pr-343]: https://github.com/pakyow/pakyow/pull/343
 [pr-340]: https://github.com/pakyow/pakyow/pull/340

--- a/pakyow-support/CHANGELOG.md
+++ b/pakyow-support/CHANGELOG.md
@@ -1,5 +1,7 @@
 # v1.1.0 (unreleased)
 
+  * `add` **Introduce config deprecations.**
+
   * `add` **Add `Deprecator#ignore`.**
     - Allows deprecations to be ignored during the execution of a block.
 

--- a/pakyow-support/lib/pakyow/support/configurable.rb
+++ b/pakyow-support/lib/pakyow/support/configurable.rb
@@ -85,7 +85,7 @@ module Pakyow
 
       module CommonMethods
         extend Forwardable
-        def_delegators :@__config, :setting, :defaults, :configurable
+        def_delegators :@__config, :setting, :deprecated_setting, :defaults, :configurable, :deprecated_configurable
 
         def config
           @__config

--- a/pakyow-support/lib/pakyow/support/configurable/config.rb
+++ b/pakyow-support/lib/pakyow/support/configurable/config.rb
@@ -20,8 +20,10 @@ module Pakyow
         # @api private
         attr_reader :__settings, :__defaults, :__groups, :__name
 
-        def initialize(configurable, name: nil, path: [], deprecated: false)
-          @configurable, @__name, @__path, @__deprecated = configurable, name, path, deprecated
+        DEFAULT_SOLUTION = "do not use"
+
+        def initialize(configurable, name: nil, path: [], deprecated: false, solution: DEFAULT_SOLUTION)
+          @configurable, @__name, @__path, @__deprecated, @__solution = configurable, name, path, deprecated, solution
 
           @__settings = Concurrent::Hash.new
           @__defaults = Concurrent::Hash.new
@@ -47,16 +49,16 @@ module Pakyow
         def setting(name, default = default_omitted = true, &block)
           tap do
             if @__deprecated
-              deprecated_setting(name, default, &block)
+              deprecated_setting(name, default, @__solution, &block)
             else
               build_setting(name, default, default_omitted, block)
             end
           end
         end
 
-        def deprecated_setting(name, default = default_omitted = true, &block)
+        def deprecated_setting(name, default = default_omitted = true, solution = Setting::DEFAULT_SOLUTION, &block)
           tap do
-            build_setting(name, default, default_omitted, block, deprecated: true)
+            build_setting(name, default, default_omitted, block, deprecated: true, solution: solution)
           end
         end
 
@@ -70,8 +72,8 @@ module Pakyow
           build_configurable(group, block)
         end
 
-        def deprecated_configurable(group, &block)
-          build_configurable(group, block, deprecated: true)
+        def deprecated_configurable(group, solution = DEFAULT_SOLUTION, &block)
+          build_configurable(group, block, deprecated: true, solution: solution)
         end
 
         def configure_defaults!(configured_environment)

--- a/pakyow-support/lib/pakyow/support/configurable/setting.rb
+++ b/pakyow-support/lib/pakyow/support/configurable/setting.rb
@@ -10,8 +10,10 @@ module Pakyow
       class Setting
         using DeepDup
 
-        def initialize(name:, path:, default:, configurable:, deprecated: false, &block)
-          @name, @path, @default, @configurable, @deprecated, @block = name, path, default, configurable, deprecated, block
+        DEFAULT_SOLUTION = "do not use"
+
+        def initialize(name:, path:, default:, configurable:, deprecated: false, solution: DEFAULT_SOLUTION, &block)
+          @name, @path, @default, @configurable, @deprecated, @solution, @block = name, path, default, configurable, deprecated, solution, block
         end
 
         def initialize_copy(_)
@@ -62,7 +64,7 @@ module Pakyow
 
         private def maybe_report_deprecation
           if @deprecated
-            Support::Deprecator.global.deprecated deprecation_message, "do not use"
+            Support::Deprecator.global.deprecated deprecation_message, @solution
           end
         end
       end

--- a/pakyow-support/spec/integration/configurable/deprecating_spec.rb
+++ b/pakyow-support/spec/integration/configurable/deprecating_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe "deprecating a group of settings" do
 
     it "reports the deprecation" do
       expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(
-        "config.group.name", "do not use"
+        "config.group", "do not use"
       )
     end
 
@@ -178,7 +178,7 @@ RSpec.describe "deprecating a group of settings" do
 
     it "reports the deprecation" do
       expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(
-        "config.group.name", "do not use"
+        "config.group", "do not use"
       )
     end
 
@@ -208,7 +208,7 @@ RSpec.describe "deprecating a group of settings" do
 
     it "reports the given solution" do
       expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(
-        "config.group.name", "use `other_group'"
+        "config.group", "use `other_group'"
       )
     end
   end

--- a/pakyow-support/spec/integration/configurable/deprecating_spec.rb
+++ b/pakyow-support/spec/integration/configurable/deprecating_spec.rb
@@ -1,0 +1,165 @@
+require "pakyow/support/configurable"
+
+RSpec.describe "deprecating a setting" do
+  before do
+    allow(Pakyow::Support::Deprecator.global).to receive(:deprecated)
+  end
+
+  let(:object) {
+    Class.new do
+      include Pakyow::Support::Configurable
+
+      deprecated_setting :name, :default
+    end
+  }
+
+  context "writing the setting" do
+    before do
+      object.configure do
+        config.name = :changed
+      end
+
+      object.configure!
+    end
+
+    it "reports the deprecation" do
+      expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(
+        "config.name", "do not use"
+      )
+    end
+
+    it "writes the setting" do
+      expect(object.config.name).to eq(:changed)
+    end
+  end
+
+  context "reading the setting" do
+    before do
+      object.configure!
+    end
+
+    let!(:value) {
+      object.config.name
+    }
+
+    it "reports the deprecation" do
+      expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(
+        "config.name", "do not use"
+      )
+    end
+
+    it "returns the value" do
+      expect(value).to eq(:default)
+    end
+  end
+
+  context "setting is in a group" do
+    let(:object) {
+      Class.new do
+        include Pakyow::Support::Configurable
+
+        configurable :group do
+          deprecated_setting :name, :default
+        end
+      end
+    }
+
+    before do
+      object.configure do
+        config.group.name = :changed
+      end
+
+      object.configure!
+    end
+
+    it "reports the correct name" do
+      expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(
+        "config.group.name", "do not use"
+      )
+    end
+  end
+
+  context "setting is in a nested group" do
+    let(:object) {
+      Class.new do
+        include Pakyow::Support::Configurable
+
+        configurable :group1 do
+          configurable :group2 do
+            deprecated_setting :name, :default
+          end
+        end
+      end
+    }
+
+    before do
+      object.configure do
+        config.group1.group2.name = :changed
+      end
+
+      object.configure!
+    end
+
+    it "reports the correct name" do
+      expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(
+        "config.group1.group2.name", "do not use"
+      )
+    end
+  end
+end
+
+RSpec.describe "deprecating a group of settings" do
+  before do
+    allow(Pakyow::Support::Deprecator.global).to receive(:deprecated)
+  end
+
+  let(:object) {
+    Class.new do
+      include Pakyow::Support::Configurable
+
+      deprecated_configurable :group do
+        setting :name, :default
+      end
+    end
+  }
+
+  context "writing a setting in the group" do
+    before do
+      object.configure do
+        config.group.name = :changed
+      end
+
+      object.configure!
+    end
+
+    it "reports the deprecation" do
+      expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(
+        "config.group.name", "do not use"
+      )
+    end
+
+    it "writes the setting" do
+      expect(object.config.group.name).to eq(:changed)
+    end
+  end
+
+  context "reading a setting in the group" do
+    before do
+      object.configure!
+    end
+
+    let!(:value) {
+      object.config.group.name
+    }
+
+    it "reports the deprecation" do
+      expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(
+        "config.group.name", "do not use"
+      )
+    end
+
+    it "returns the value" do
+      expect(value).to eq(:default)
+    end
+  end
+end

--- a/pakyow-support/spec/integration/configurable/deprecating_spec.rb
+++ b/pakyow-support/spec/integration/configurable/deprecating_spec.rb
@@ -106,6 +106,30 @@ RSpec.describe "deprecating a setting" do
       )
     end
   end
+
+  describe "providing a solution" do
+    let(:object) {
+      Class.new do
+        include Pakyow::Support::Configurable
+
+        deprecated_setting :name, :default, "use `other_name'"
+      end
+    }
+
+    before do
+      object.configure!
+    end
+
+    let!(:value) {
+      object.config.name
+    }
+
+    it "reports the given solution" do
+      expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(
+        "config.name", "use `other_name'"
+      )
+    end
+  end
 end
 
 RSpec.describe "deprecating a group of settings" do
@@ -160,6 +184,32 @@ RSpec.describe "deprecating a group of settings" do
 
     it "returns the value" do
       expect(value).to eq(:default)
+    end
+  end
+
+  describe "providing a solution" do
+    let(:object) {
+      Class.new do
+        include Pakyow::Support::Configurable
+
+        deprecated_configurable :group, "use `other_group'" do
+          setting :name, :default
+        end
+      end
+    }
+
+    before do
+      object.configure!
+    end
+
+    let!(:value) {
+      object.config.group.name
+    }
+
+    it "reports the given solution" do
+      expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(
+        "config.group.name", "use `other_group'"
+      )
     end
   end
 end


### PR DESCRIPTION
Allows config groups and settings to be deprecated. Reading/Writing the value of a deprecated setting, or a setting within a deprecated group, will report a deprecation to the global deprecator.