### PR TITLE
Introduce Deprecatable

### DIFF
--- a/pakyow-core/lib/pakyow/environment.rb
+++ b/pakyow-core/lib/pakyow/environment.rb
@@ -14,6 +14,7 @@ require "pakyow/support/deep_dup"
 require "pakyow/support/deep_freeze"
 require "pakyow/support/pipeline"
 require "pakyow/support/inflector"
+require "pakyow/support/deprecatable"
 
 require "pakyow/config"
 require "pakyow/behavior/deprecations"
@@ -137,6 +138,8 @@ module Pakyow
   class_state :setup_error, default: nil
 
   class << self
+    extend Support::Deprecatable
+
     # Name of the environment
     #
     attr_reader :env
@@ -163,10 +166,9 @@ module Pakyow
     # @deprecated Use {output} instead.
     #
     def global_logger
-      deprecated :global_logger, "use `output'"
-
       output
     end
+    deprecate :global_logger, solution: "use `output'"
 
     # Logger instance for the environment.
     #

--- a/pakyow-core/lib/pakyow/logger.rb
+++ b/pakyow-core/lib/pakyow/logger.rb
@@ -4,6 +4,8 @@ require "securerandom"
 
 require "console/filter"
 
+require "pakyow/support/deprecatable"
+
 module Pakyow
   # Logs messages throughout the lifetime of an environment, connection, etc.
   #
@@ -11,6 +13,8 @@ module Pakyow
   # `epilogue` for a connection, as well as a `houston` method for logging errors.
   #
   class Logger < Console::Filter[internal: 0, debug: 1, info: 2, warn: 3, error: 4, fatal: 5, unknown: 6]
+    extend Support::Deprecatable
+
     require "pakyow/logger/colorizer"
     require "pakyow/logger/timekeeper"
 
@@ -52,14 +56,13 @@ module Pakyow
     # @deprecated Use {Pakyow::Logger::ThreadLocal#silence} instead.
     #
     def silence(temporary_level = :error)
-      Pakyow.deprecated self, :silence, "use `Pakyow::Logger::ThreadLocal#silence'"
-
       original_level = @level
       self.level = self.class.const_get(:LEVELS)[temporary_level]
       yield
     ensure
       self.level = original_level
     end
+    deprecate :silence, solution: "use `Pakyow::Logger::ThreadLocal#silence'"
 
     LEVELS.keys.each do |method|
       class_eval <<~CODE, __FILE__, __LINE__ + 1

--- a/pakyow-core/lib/pakyow/logger/thread_local.rb
+++ b/pakyow-core/lib/pakyow/logger/thread_local.rb
@@ -11,7 +11,8 @@ module Pakyow
     class ThreadLocal
       def initialize(default_logger, key: nil)
         if key.nil?
-          Pakyow.deprecated "default value for `#{self.class}' argument `key'", "pass value for `key'"
+          Pakyow.deprecated "default value for `#{self.class}' argument `key'", solution: "pass value for `key'"
+
           key = :pakyow_logger
         end
 

--- a/pakyow-core/lib/pakyow/process_manager.rb
+++ b/pakyow-core/lib/pakyow/process_manager.rb
@@ -18,7 +18,7 @@ module Pakyow
     #
     def add(process)
       if process.is_a?(Hash)
-        Pakyow.deprecated "passing a `Hash' to `Pakyow::ProcessManager#add'", "pass a `Pakyow::Process' instance"
+        Pakyow.deprecated "passing a `Hash' to `Pakyow::ProcessManager#add'", solution: "pass a `Pakyow::Process' instance"
 
         process = build_process(process)
       end

--- a/pakyow-core/lib/pakyow/processes/proxy.rb
+++ b/pakyow-core/lib/pakyow/processes/proxy.rb
@@ -41,7 +41,7 @@ module Pakyow
           if Pakyow.config.freeze_on_boot
             Pakyow.deep_freeze
           else
-            Pakyow.deprecated "config.freeze_on_boot", "do not change this setting"
+            Pakyow.deprecated "config.freeze_on_boot", solution: "do not change this setting"
           end
         end
       end

--- a/pakyow-core/lib/pakyow/processes/server.rb
+++ b/pakyow-core/lib/pakyow/processes/server.rb
@@ -32,7 +32,7 @@ module Pakyow
           if Pakyow.config.freeze_on_boot
             Pakyow.deep_freeze
           else
-            Pakyow.deprecated "config.freeze_on_boot", "do not change this setting"
+            Pakyow.deprecated "config.freeze_on_boot", solution: "do not change this setting"
           end
         end
       end

--- a/pakyow-core/spec/features/deprecations_spec.rb
+++ b/pakyow-core/spec/features/deprecations_spec.rb
@@ -133,8 +133,8 @@ RSpec.describe "reporting deprecations through the environment" do
   include_context "app"
 
   it "reports deprecations" do
-    expect(Pakyow.deprecator).to receive(:deprecated).with(:foo)
-    Pakyow.deprecated(:foo)
+    expect(Pakyow.deprecator).to receive(:deprecated).with(:foo, solution: "use `bar'")
+    Pakyow.deprecated(:foo, solution: "use `bar'")
   end
 end
 
@@ -142,7 +142,7 @@ RSpec.describe "reporting deprecations through the global deprecator" do
   include_context "app"
 
   it "forwards to the environment deprecator" do
-    expect(Pakyow.deprecator).to receive(:deprecated).with(:foo)
-    Pakyow::Support::Deprecator.global.deprecated(:foo)
+    expect(Pakyow.deprecator).to receive(:deprecated).with(:foo, solution: "use `bar'")
+    Pakyow::Support::Deprecator.global.deprecated(:foo, solution: "use `bar'")
   end
 end

--- a/pakyow-core/spec/unit/environment_spec.rb
+++ b/pakyow-core/spec/unit/environment_spec.rb
@@ -658,7 +658,9 @@ RSpec.describe Pakyow do
 
   describe "::global_logger" do
     it "is deprecated" do
-      expect(Pakyow).to receive(:deprecated).with(:global_logger, "use `output'")
+      expect(Pakyow::Support::Deprecator.global).to receive(:deprecated).with(
+        Pakyow, :global_logger, "use `output'"
+      )
 
       Pakyow.global_logger
     end

--- a/pakyow-core/spec/unit/environment_spec.rb
+++ b/pakyow-core/spec/unit/environment_spec.rb
@@ -659,7 +659,7 @@ RSpec.describe Pakyow do
   describe "::global_logger" do
     it "is deprecated" do
       expect(Pakyow::Support::Deprecator.global).to receive(:deprecated).with(
-        Pakyow, :global_logger, "use `output'"
+        Pakyow, :global_logger, solution: "use `output'"
       )
 
       Pakyow.global_logger

--- a/pakyow-core/spec/unit/logger/thread_local_spec.rb
+++ b/pakyow-core/spec/unit/logger/thread_local_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Pakyow::Logger::ThreadLocal do
       it "is deprecated" do
         expect(Pakyow).to receive(:deprecated).with(
           "default value for `Pakyow::Logger::ThreadLocal' argument `key'",
-          "pass value for `key'"
+          solution: "pass value for `key'"
         )
 
         instance

--- a/pakyow-core/spec/unit/logger_spec.rb
+++ b/pakyow-core/spec/unit/logger_spec.rb
@@ -197,7 +197,9 @@ RSpec.describe Pakyow::Logger do
     end
 
     it "is deprecated" do
-      expect(Pakyow).to receive(:deprecated).with(instance, :silence, "use `Pakyow::Logger::ThreadLocal#silence'")
+      expect(Pakyow::Support::Deprecator.global).to receive(:deprecated).with(
+        instance, :silence, "use `Pakyow::Logger::ThreadLocal#silence'"
+      )
 
       instance.silence do; end
     end

--- a/pakyow-core/spec/unit/logger_spec.rb
+++ b/pakyow-core/spec/unit/logger_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe Pakyow::Logger do
 
     it "is deprecated" do
       expect(Pakyow::Support::Deprecator.global).to receive(:deprecated).with(
-        instance, :silence, "use `Pakyow::Logger::ThreadLocal#silence'"
+        instance, :silence, solution: "use `Pakyow::Logger::ThreadLocal#silence'"
       )
 
       instance.silence do; end

--- a/pakyow-core/spec/unit/process_manager_spec.rb
+++ b/pakyow-core/spec/unit/process_manager_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Pakyow::ProcessManager do
       it "is deprecated" do
         expect(Pakyow).to receive(:deprecated).with(
           "passing a `Hash' to `Pakyow::ProcessManager#add'",
-          "pass a `Pakyow::Process' instance"
+          solution: "pass a `Pakyow::Process' instance"
         )
 
         instance.add(process)

--- a/pakyow-support/CHANGELOG.md
+++ b/pakyow-support/CHANGELOG.md
@@ -2,6 +2,9 @@
 
   * `add` **Introduce `Deprecatable`.**
 
+    *Related links:*
+    - [Pull Request #351][pr-351]
+
   * `add` **Add `Deprecator#ignore`.**
     - Allows deprecations to be ignored during the execution of a block.
 
@@ -31,6 +34,7 @@
     *Related links:*
     - [Commit 787681d][787681d]
 
+[pr-351]: https://github.com/pakyow/pakyow/pull/351
 [pr-349]: https://github.com/pakyow/pakyow/pull/349
 [pr-343]: https://github.com/pakyow/pakyow/pull/343
 [pr-340]: https://github.com/pakyow/pakyow/pull/340

--- a/pakyow-support/CHANGELOG.md
+++ b/pakyow-support/CHANGELOG.md
@@ -1,5 +1,7 @@
 # v1.1.0 (unreleased)
 
+  * `add` **Introduce `Deprecatable`.**
+
   * `add` **Add `Deprecator#ignore`.**
     - Allows deprecations to be ignored during the execution of a block.
 

--- a/pakyow-support/lib/pakyow/support/deep_freeze.rb
+++ b/pakyow-support/lib/pakyow/support/deep_freeze.rb
@@ -5,10 +5,13 @@ require "socket"
 
 require "pakyow/support/class_state"
 require "pakyow/support/deprecator"
+require "pakyow/support/deprecatable"
 
 module Pakyow
   module Support
     module DeepFreeze
+      extend Deprecatable
+
       def self.extended(base)
         base.extend ClassState
         base.class_state :__insulated_variables, inheritable: true, default: []
@@ -23,10 +26,9 @@ module Pakyow
       end
 
       def unfreezable(*instance_variables)
-        Deprecator.global.deprecated :unfreezable, "use `insulate'"
-
         insulate(*instance_variables)
       end
+      deprecate :unfreezable, solution: "use `insulate'"
 
       [Object, Delegator].each do |klass|
         refine klass do

--- a/pakyow-support/lib/pakyow/support/deprecatable.rb
+++ b/pakyow-support/lib/pakyow/support/deprecatable.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "pakyow/support/deprecator"
+
+module Pakyow
+  module Support
+    # Makes an object deprecatable.
+    #
+    # @example
+    #   class DeprecatedClass
+    #     extend Pakyow::Support::Deprecatable
+    #
+    #     deprecate
+    #   end
+    #
+    #   DeprecatedClass.new
+    #   => [deprecation] `DeprecatedClass' is deprecated; solution: do not use
+    #
+    module Deprecatable
+      # Deprecates a target (class, module, or method) with a solution. A deprecation is reported to
+      # `Pakyow::Support::Deprecator.global` when the target is used:
+      #
+      #   * Class: deprecation reported when initialized
+      #   * Module: deprecation reported when included or extended
+      #   * Method: deprecation reported when the method is called
+      #
+      def deprecate(target = self, solution: "do not use")
+        case target
+        when Class
+          apply_deprecation_module(target, build_deprecated_initializer(target, solution: solution))
+        when Module
+          apply_deprecation_module(target.singleton_class, build_deprecated_extender_includer(target, solution: solution))
+        else
+          deprecation_module = build_deprecated_method(target, solution: solution)
+
+          if respond_to?(target.to_s)
+            apply_deprecation_module(singleton_class, deprecation_module)
+          else
+            apply_deprecation_module(self, deprecation_module)
+          end
+        end
+      end
+
+      private def apply_deprecation_module(target, deprecation_module)
+        target.prepend(deprecation_module)
+      end
+
+      private def build_deprecated_initializer(target, solution:)
+        build_module_for_deprecation <<~CODE
+          def initialize(*)
+            Deprecator.global.deprecated #{target}, #{solution.inspect}
+
+            super
+          end
+        CODE
+      end
+
+      private def build_deprecated_extender_includer(target, solution:)
+        build_module_for_deprecation <<~CODE
+          def extended(*)
+            Deprecator.global.deprecated #{target}, #{solution.inspect}
+
+            super
+          end
+
+          def included(*)
+            Deprecator.global.deprecated #{target}, #{solution.inspect}
+
+            super
+          end
+        CODE
+      end
+
+      private def build_deprecated_method(target, solution:)
+        target = target.to_s
+
+        unless respond_to?(target) || instance_methods.include?(target.to_sym)
+          raise RuntimeError, "could not find method `#{target}' to deprecate"
+        end
+
+        build_module_for_deprecation <<~CODE
+          def #{target}(*)
+            Deprecator.global.deprecated self, #{target.to_sym.inspect}, #{solution.inspect}
+
+            super
+          end
+        CODE
+      end
+
+      private def build_module_for_deprecation(code)
+        Module.new.tap do |prependable|
+          prependable.module_eval(code)
+        end
+      end
+    end
+  end
+end

--- a/pakyow-support/lib/pakyow/support/deprecatable.rb
+++ b/pakyow-support/lib/pakyow/support/deprecatable.rb
@@ -48,7 +48,7 @@ module Pakyow
       private def build_deprecated_initializer(target, solution:)
         build_module_for_deprecation <<~CODE
           def initialize(*)
-            Deprecator.global.deprecated #{target}, #{solution.inspect}
+            Deprecator.global.deprecated #{target}, solution: #{solution.inspect}
 
             super
           end
@@ -58,13 +58,13 @@ module Pakyow
       private def build_deprecated_extender_includer(target, solution:)
         build_module_for_deprecation <<~CODE
           def extended(*)
-            Deprecator.global.deprecated #{target}, #{solution.inspect}
+            Deprecator.global.deprecated #{target}, solution: #{solution.inspect}
 
             super
           end
 
           def included(*)
-            Deprecator.global.deprecated #{target}, #{solution.inspect}
+            Deprecator.global.deprecated #{target}, solution: #{solution.inspect}
 
             super
           end
@@ -80,7 +80,7 @@ module Pakyow
 
         build_module_for_deprecation <<~CODE
           def #{target}(*)
-            Deprecator.global.deprecated self, #{target.to_sym.inspect}, #{solution.inspect}
+            Deprecator.global.deprecated self, #{target.to_sym.inspect}, solution: #{solution.inspect}
 
             super
           end

--- a/pakyow-support/lib/pakyow/support/deprecator.rb
+++ b/pakyow-support/lib/pakyow/support/deprecator.rb
@@ -21,7 +21,7 @@ module Pakyow
     #     )
     #   )
     #
-    #   deprecator.deprecated :foo, "use `bar'"
+    #   deprecator.deprecated :foo, solution: "use `bar'"
     #   => [deprecation] `foo' is deprecated; solution: use `bar'
     #
     # = Creating a reporter
@@ -52,16 +52,16 @@ module Pakyow
       #     Pakyow::Support::Deprecator::Reporters::Log(logger: Pakyow.logger)
       #   )
       #
-      #   deprecator.deprecated Foo, :bar, "use `baz'"
+      #   deprecator.deprecated Foo, :bar, solution: "use `baz'"
       #   => [deprecation] `Foo::bar' is deprecated; solution: use `baz'
       #
-      #   deprecator.deprecated Foo.new, :bar, "use `baz'"
+      #   deprecator.deprecated Foo.new, :bar, solution: "use `baz'"
       #   => [deprecation] `Foo#bar' is deprecated; solution: use `baz'
       #
-      #   deprecator.deprecated "`foo.rb' is deprecated", "rename to `bar.rb'"
+      #   deprecator.deprecated "`foo.rb' is deprecated", solution: "rename to `bar.rb'"
       #   => [deprecation] `foo.rb' is deprecated; solution: rename to `baz.rb'
       #
-      def deprecated(*targets, solution)
+      def deprecated(*targets, solution:)
         reporter.report do
           Deprecation.new(*targets, solution: solution)
         end
@@ -102,7 +102,7 @@ module Pakyow
         # assumptions about the broader environment.
         #
         # @example
-        #   Pakyow::Support::Deprecator.global.deprecated :foo, "use `bar'"
+        #   Pakyow::Support::Deprecator.global.deprecated :foo, solution: "use `bar'"
         #   => warning: [deprecation] `foo' is deprecated; solution: use `bar'
         #
         # = Forwarding
@@ -112,7 +112,7 @@ module Pakyow
         #
         # @example
         #   Pakyow::Support::Deprecator.global >> Pakyow::Support::Deprecator::Reporters::Null
-        #   Pakyow::Support::Deprecator.global.deprecated :foo, "use `bar'"
+        #   Pakyow::Support::Deprecator.global.deprecated :foo, solution: "use `bar'"
         #
         def global
           unless defined?(@global)

--- a/pakyow-support/lib/pakyow/support/deprecator/reporters/log.rb
+++ b/pakyow-support/lib/pakyow/support/deprecator/reporters/log.rb
@@ -13,7 +13,7 @@ module Pakyow
         #     )
         #   )
         #
-        #   deprecator.deprecated :foo, "use `bar'"
+        #   deprecator.deprecated :foo, solution: "use `bar'"
         #   => [deprecation] `foo' is deprecated; solution: use `bar'
         #
         class Log

--- a/pakyow-support/lib/pakyow/support/deprecator/reporters/null.rb
+++ b/pakyow-support/lib/pakyow/support/deprecator/reporters/null.rb
@@ -11,7 +11,7 @@ module Pakyow
         #     reporter: Pakyow::Support::Deprecator::Reporters::Null
         #   )
         #
-        #   deprecator.deprecated :foo, "use `bar'"
+        #   deprecator.deprecated :foo, solution: "use `bar'"
         #   # nothing happens
         #
         class Null

--- a/pakyow-support/lib/pakyow/support/deprecator/reporters/warn.rb
+++ b/pakyow-support/lib/pakyow/support/deprecator/reporters/warn.rb
@@ -11,7 +11,7 @@ module Pakyow
         #     reporter: Pakyow::Support::Deprecator::Reporters::Warn
         #   )
         #
-        #   deprecator.deprecated :foo, "use `bar'"
+        #   deprecator.deprecated :foo, solution: "use `bar'"
         #   => warning: [deprecation] `foo' is deprecated; solution: use `bar'
         #
         class Warn

--- a/pakyow-support/spec/features/deprecatable/class_spec.rb
+++ b/pakyow-support/spec/features/deprecatable/class_spec.rb
@@ -1,0 +1,101 @@
+require "pakyow/support/deprecatable"
+
+RSpec.describe "deprecating a class" do
+  let(:deprecatable) {
+    Class.new {
+      extend Pakyow::Support::Deprecatable
+    }.tap do |deprecatable|
+      stub_const "DeprecatableClass", deprecatable
+    end
+  }
+
+  before do
+    allow(Pakyow::Support::Deprecator.global).to receive(:deprecated)
+
+    deprecatable.class_eval do
+      deprecate
+    end
+  end
+
+  it "does not report the deprecation immediately" do
+    expect(Pakyow::Support::Deprecator.global).not_to have_received(:deprecated)
+  end
+
+  context "class is initialized" do
+    before do
+      deprecatable.new
+    end
+
+    it "reports the deprecation" do
+      expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(deprecatable, "do not use")
+    end
+  end
+
+  context "deprecated class has an initializer" do
+    let(:deprecatable) {
+      super().tap do |deprecatable|
+        deprecatable.class_eval do
+          attr_reader :args, :kwargs, :block
+
+          def initialize(*args, **kwargs, &block)
+            @args, @kwargs, @block = args, kwargs, block
+          end
+        end
+      end
+    }
+
+    context "class is initialized" do
+      let!(:instance) {
+        deprecatable.new(:foo, :bar, baz: :qux) do
+          :test
+        end
+      }
+
+      it "reports the deprecation" do
+        expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(deprecatable, "do not use")
+      end
+
+      it "calls the original initializer" do
+        expect(instance.args).to eq([:foo, :bar])
+        expect(instance.kwargs).to eq(baz: :qux)
+        expect(instance.block.call).to eq(:test)
+      end
+    end
+  end
+
+  context "solution is specified" do
+    before do
+      deprecatable.class_eval do
+        deprecate solution: "use something else"
+      end
+    end
+
+    context "class is initialized" do
+      before do
+        deprecatable.new
+      end
+
+      it "reports the deprecation" do
+        expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(deprecatable, "use something else")
+      end
+    end
+  end
+
+  context "solution is specified with quotes" do
+    before do
+      deprecatable.class_eval do
+        deprecate solution: 'use "foo"'
+      end
+    end
+
+    context "class is initialized" do
+      before do
+        deprecatable.new
+      end
+
+      it "reports the deprecation" do
+        expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(deprecatable, 'use "foo"')
+      end
+    end
+  end
+end

--- a/pakyow-support/spec/features/deprecatable/class_spec.rb
+++ b/pakyow-support/spec/features/deprecatable/class_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "deprecating a class" do
     end
 
     it "reports the deprecation" do
-      expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(deprecatable, "do not use")
+      expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(deprecatable, solution: "do not use")
     end
   end
 
@@ -52,7 +52,7 @@ RSpec.describe "deprecating a class" do
       }
 
       it "reports the deprecation" do
-        expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(deprecatable, "do not use")
+        expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(deprecatable, solution: "do not use")
       end
 
       it "calls the original initializer" do
@@ -76,7 +76,7 @@ RSpec.describe "deprecating a class" do
       end
 
       it "reports the deprecation" do
-        expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(deprecatable, "use something else")
+        expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(deprecatable, solution: "use something else")
       end
     end
   end
@@ -94,7 +94,7 @@ RSpec.describe "deprecating a class" do
       end
 
       it "reports the deprecation" do
-        expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(deprecatable, 'use "foo"')
+        expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(deprecatable, solution: 'use "foo"')
       end
     end
   end

--- a/pakyow-support/spec/features/deprecatable/method_spec.rb
+++ b/pakyow-support/spec/features/deprecatable/method_spec.rb
@@ -1,0 +1,208 @@
+require "pakyow/support/deprecatable"
+
+RSpec.describe "deprecating a method" do
+  before do
+    allow(Pakyow::Support::Deprecator.global).to receive(:deprecated)
+  end
+
+  context "method is an instance method" do
+    let!(:deprecatable) {
+      Class.new {
+        extend Pakyow::Support::Deprecatable
+      }.tap do |deprecatable|
+        stub_const "DeprecatableClass", deprecatable
+
+        deprecatable.class_eval do
+          attr_reader :args, :kwargs, :block
+
+          def foo(*args, **kwargs, &block)
+            @args, @kwargs, @block = args, kwargs, block
+          end
+
+          deprecate :foo
+        end
+      end
+    }
+
+    it "does not report the deprecation immediately" do
+      expect(Pakyow::Support::Deprecator.global).not_to have_received(:deprecated)
+    end
+
+    context "class is initialized" do
+      let!(:instance) {
+        deprecatable.new
+      }
+
+      it "does not report the deprecation" do
+        expect(Pakyow::Support::Deprecator.global).not_to have_received(:deprecated)
+      end
+
+      context "method is called" do
+        before do
+          instance.foo(:foo, :bar, baz: :qux) do
+            :test
+          end
+        end
+
+        it "reports the deprecation" do
+          expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(instance, :foo, "do not use")
+        end
+
+        it "calls the original initializer" do
+          expect(instance.args).to eq([:foo, :bar])
+          expect(instance.kwargs).to eq(baz: :qux)
+          expect(instance.block.call).to eq(:test)
+        end
+      end
+    end
+  end
+
+  context "method is a class method" do
+    let!(:deprecatable) {
+      Class.new.tap do |deprecatable|
+        stub_const "DeprecatableClass", deprecatable
+
+        deprecatable.class_eval do
+          class << self
+            extend Pakyow::Support::Deprecatable
+
+            attr_reader :args, :kwargs, :block
+
+            def foo(*args, **kwargs, &block)
+              @args, @kwargs, @block = args, kwargs, block
+            end
+
+            deprecate :foo
+          end
+        end
+      end
+    }
+
+    it "does not report the deprecation immediately" do
+      expect(Pakyow::Support::Deprecator.global).not_to have_received(:deprecated)
+    end
+
+    context "method is called" do
+      before do
+        deprecatable.foo(:foo, :bar, baz: :qux) do
+          :test
+        end
+      end
+
+      it "reports the deprecation" do
+        expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(deprecatable, :foo, "do not use")
+      end
+
+      it "calls the original initializer" do
+        expect(deprecatable.args).to eq([:foo, :bar])
+        expect(deprecatable.kwargs).to eq(baz: :qux)
+        expect(deprecatable.block.call).to eq(:test)
+      end
+    end
+  end
+
+  context "method is a mixin" do
+    let!(:deprecatable) {
+      Module.new.tap do |deprecatable|
+        stub_const "DeprecatableModule", deprecatable
+
+        deprecatable.module_eval do
+          attr_reader :args, :kwargs, :block
+
+          def foo(*args, **kwargs, &block)
+            @args, @kwargs, @block = args, kwargs, block
+          end
+
+          extend Pakyow::Support::Deprecatable
+          deprecate :foo
+        end
+      end
+    }
+
+    it "does not report the deprecation immediately" do
+      expect(Pakyow::Support::Deprecator.global).not_to have_received(:deprecated)
+    end
+
+    context "method is called" do
+      before do
+        instance.foo(:foo, :bar, baz: :qux) do
+          :test
+        end
+      end
+
+      let(:instance) {
+        Class.new {
+          include DeprecatableModule
+        }.new
+      }
+
+      it "reports the deprecation" do
+        expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(deprecatable, :foo, "do not use")
+      end
+
+      it "calls the original initializer" do
+        expect(instance.args).to eq([:foo, :bar])
+        expect(instance.kwargs).to eq(baz: :qux)
+        expect(instance.block.call).to eq(:test)
+      end
+    end
+  end
+
+  context "method is a module function" do
+    let!(:deprecatable) {
+      Module.new.tap do |deprecatable|
+        stub_const "DeprecatableModule", deprecatable
+
+        deprecatable.module_eval do
+          class << self
+            attr_reader :args, :kwargs, :block
+          end
+
+          def foo(*args, **kwargs, &block)
+            @args, @kwargs, @block = args, kwargs, block
+          end
+          module_function :foo
+
+          extend Pakyow::Support::Deprecatable
+          deprecate :foo
+        end
+      end
+    }
+
+    it "does not report the deprecation immediately" do
+      expect(Pakyow::Support::Deprecator.global).not_to have_received(:deprecated)
+    end
+
+    context "method is called" do
+      before do
+        deprecatable.foo(:foo, :bar, baz: :qux) do
+          :test
+        end
+      end
+
+      it "reports the deprecation" do
+        expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(deprecatable, :foo, "do not use")
+      end
+
+      it "calls the original initializer" do
+        expect(deprecatable.args).to eq([:foo, :bar])
+        expect(deprecatable.kwargs).to eq(baz: :qux)
+        expect(deprecatable.block.call).to eq(:test)
+      end
+    end
+  end
+
+  context "method is not found" do
+    it "raises an error" do
+      expect {
+        Class.new do
+          extend Pakyow::Support::Deprecatable
+
+          deprecate :foo
+        end
+      }.to raise_error(RuntimeError) do |error|
+        expect(error.message).to eq("could not find method `foo' to deprecate")
+      end
+    end
+  end
+end

--- a/pakyow-support/spec/features/deprecatable/method_spec.rb
+++ b/pakyow-support/spec/features/deprecatable/method_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "deprecating a method" do
         end
 
         it "reports the deprecation" do
-          expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(instance, :foo, "do not use")
+          expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(instance, :foo, solution: "do not use")
         end
 
         it "calls the original initializer" do
@@ -90,7 +90,7 @@ RSpec.describe "deprecating a method" do
       end
 
       it "reports the deprecation" do
-        expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(deprecatable, :foo, "do not use")
+        expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(deprecatable, :foo, solution: "do not use")
       end
 
       it "calls the original initializer" do
@@ -137,7 +137,7 @@ RSpec.describe "deprecating a method" do
       }
 
       it "reports the deprecation" do
-        expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(deprecatable, :foo, "do not use")
+        expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(deprecatable, :foo, solution: "do not use")
       end
 
       it "calls the original initializer" do
@@ -181,7 +181,7 @@ RSpec.describe "deprecating a method" do
       end
 
       it "reports the deprecation" do
-        expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(deprecatable, :foo, "do not use")
+        expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(deprecatable, :foo, solution: "do not use")
       end
 
       it "calls the original initializer" do

--- a/pakyow-support/spec/features/deprecatable/module_spec.rb
+++ b/pakyow-support/spec/features/deprecatable/module_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "deprecating a module" do
     end
 
     it "reports the deprecation" do
-      expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(deprecatable, "do not use")
+      expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(deprecatable, solution: "do not use")
     end
   end
 
@@ -37,7 +37,7 @@ RSpec.describe "deprecating a module" do
     end
 
     it "reports the deprecation" do
-      expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(deprecatable, "do not use")
+      expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(deprecatable, solution: "do not use")
     end
   end
 
@@ -63,7 +63,7 @@ RSpec.describe "deprecating a module" do
       }
 
       it "reports the deprecation" do
-        expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(deprecatable, "do not use")
+        expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(deprecatable, solution: "do not use")
       end
 
       it "calls the original included method" do
@@ -94,7 +94,7 @@ RSpec.describe "deprecating a module" do
       }
 
       it "reports the deprecation" do
-        expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(deprecatable, "do not use")
+        expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(deprecatable, solution: "do not use")
       end
 
       it "calls the original extended method" do

--- a/pakyow-support/spec/features/deprecatable/module_spec.rb
+++ b/pakyow-support/spec/features/deprecatable/module_spec.rb
@@ -1,0 +1,105 @@
+require "pakyow/support/deprecatable"
+
+RSpec.describe "deprecating a module" do
+  let(:deprecatable) {
+    Module.new {
+      extend Pakyow::Support::Deprecatable
+    }.tap do |deprecatable|
+      stub_const "DeprecatableModule", deprecatable
+    end
+  }
+
+  before do
+    allow(Pakyow::Support::Deprecator.global).to receive(:deprecated)
+
+    deprecatable.module_eval do
+      deprecate
+    end
+  end
+
+  it "does not report the deprecation immediately" do
+    expect(Pakyow::Support::Deprecator.global).not_to have_received(:deprecated)
+  end
+
+  context "module is included" do
+    before do
+      Class.new.include deprecatable
+    end
+
+    it "reports the deprecation" do
+      expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(deprecatable, "do not use")
+    end
+  end
+
+  context "module extends a class" do
+    before do
+      Class.new.extend deprecatable
+    end
+
+    it "reports the deprecation" do
+      expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(deprecatable, "do not use")
+    end
+  end
+
+  context "module already has an included method" do
+    let(:deprecatable) {
+      local = self
+      super().tap do |deprecatable|
+        deprecatable.module_eval do
+          def self.included(base)
+            base.instance_variable_set(:@included, true)
+          end
+        end
+      end
+    }
+
+    context "module is included" do
+      before do
+        klass.include deprecatable
+      end
+
+      let(:klass) {
+        Class.new
+      }
+
+      it "reports the deprecation" do
+        expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(deprecatable, "do not use")
+      end
+
+      it "calls the original included method" do
+        expect(klass.instance_variable_get(:@included)).to be(true)
+      end
+    end
+  end
+
+  context "module already has an extended method" do
+    let(:deprecatable) {
+      local = self
+      super().tap do |deprecatable|
+        deprecatable.module_eval do
+          def self.extended(base)
+            base.instance_variable_set(:@extended, true)
+          end
+        end
+      end
+    }
+
+    context "module extends a class" do
+      before do
+        klass.extend deprecatable
+      end
+
+      let(:klass) {
+        Class.new
+      }
+
+      it "reports the deprecation" do
+        expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(deprecatable, "do not use")
+      end
+
+      it "calls the original extended method" do
+        expect(klass.instance_variable_get(:@extended)).to be(true)
+      end
+    end
+  end
+end

--- a/pakyow-support/spec/features/deprecator_spec.rb
+++ b/pakyow-support/spec/features/deprecator_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "using a deprecator" do
         expect(block.call).to eq("[deprecation] `foo' is deprecated; solution: use `bar'")
       end
 
-      instance.deprecated :foo, "use `bar'"
+      instance.deprecated :foo, solution: "use `bar'"
     end
 
     context "with an explicit level" do
@@ -38,7 +38,7 @@ RSpec.describe "using a deprecator" do
       it "logs with the level" do
         expect(logger).to receive(:debug)
 
-        instance.deprecated :foo, "use `bar'"
+        instance.deprecated :foo, solution: "use `bar'"
       end
     end
   end

--- a/pakyow-support/spec/unit/deep_freeze_spec.rb
+++ b/pakyow-support/spec/unit/deep_freeze_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe Pakyow::Support::DeepFreeze do
     it "is deprecated" do
       expect(
         Pakyow::Support::Deprecator.global
-      ).to receive(:deprecated).with(unfreezable_class, :unfreezable, "use `insulate'")
+      ).to receive(:deprecated).with(unfreezable_class, :unfreezable, solution: "use `insulate'")
 
       unfreezable_class.unfreezable :foo
     end

--- a/pakyow-support/spec/unit/deep_freeze_spec.rb
+++ b/pakyow-support/spec/unit/deep_freeze_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe Pakyow::Support::DeepFreeze do
     it "is deprecated" do
       expect(
         Pakyow::Support::Deprecator.global
-      ).to receive(:deprecated).with(:unfreezable, "use `insulate'")
+      ).to receive(:deprecated).with(unfreezable_class, :unfreezable, "use `insulate'")
 
       unfreezable_class.unfreezable :foo
     end

--- a/pakyow-support/spec/unit/deprecator_spec.rb
+++ b/pakyow-support/spec/unit/deprecator_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Pakyow::Support::Deprecator do
         require "pakyow/support/deprecator/reporters/warn"
         expect(described_class::Reporters::Warn).to receive(:report)
 
-        global.deprecated :foo, "use `bar'"
+        global.deprecated :foo, solution: "use `bar'"
       end
 
       it "does not appear to be forwarding" do
@@ -62,17 +62,17 @@ RSpec.describe Pakyow::Support::Deprecator do
 
       it "reports to the other instances" do
         deprecators.each do |deprecator|
-          expect(deprecator).to receive(:deprecated).with(:foo, "use `bar'")
+          expect(deprecator).to receive(:deprecated).with(:foo, solution: "use `bar'")
         end
 
-        global.deprecated :foo, "use `bar'"
+        global.deprecated :foo, solution: "use `bar'"
       end
 
       it "does not report to its own reporter" do
         require "pakyow/support/deprecator/reporters/warn"
         expect(described_class::Reporters::Warn).not_to receive(:report)
 
-        global.deprecated :foo, "use `bar'"
+        global.deprecated :foo, solution: "use `bar'"
       end
 
       it "appears to be forwarding" do
@@ -92,7 +92,7 @@ RSpec.describe Pakyow::Support::Deprecator do
 
     it "does not build a deprecation" do
       expect(Pakyow::Support::Deprecation).not_to receive(:new)
-      instance.deprecated :foo, "use `bar'"
+      instance.deprecated :foo, solution: "use `bar'"
     end
 
     context "reporter yields" do
@@ -105,7 +105,7 @@ RSpec.describe Pakyow::Support::Deprecator do
           Pakyow::Support::Deprecation
         ).to receive(:new).with(:foo, solution: "use `bar'")
 
-        instance.deprecated(:foo, "use `bar'")
+        instance.deprecated(:foo, solution: "use `bar'")
       end
     end
   end
@@ -123,7 +123,7 @@ RSpec.describe Pakyow::Support::Deprecator do
       expect(reporter).not_to receive(:report)
 
       instance.ignore do
-        instance.deprecated :foo, "use `bar'"
+        instance.deprecated :foo, solution: "use `bar'"
       end
     end
 
@@ -131,10 +131,10 @@ RSpec.describe Pakyow::Support::Deprecator do
       expect(reporter).to receive(:report).once
 
       instance.ignore do
-        instance.deprecated :foo, "use `bar'"
+        instance.deprecated :foo, solution: "use `bar'"
       end
 
-      instance.deprecated :foo, "use `bar'"
+      instance.deprecated :foo, solution: "use `bar'"
     end
 
     context "block fails" do
@@ -148,7 +148,7 @@ RSpec.describe Pakyow::Support::Deprecator do
         rescue
         end
 
-        instance.deprecated :foo, "use `bar'"
+        instance.deprecated :foo, solution: "use `bar'"
       end
     end
 
@@ -163,7 +163,7 @@ RSpec.describe Pakyow::Support::Deprecator do
         end
 
         thread2 = Thread.new do
-          instance.deprecated :foo, "use `bar'"
+          instance.deprecated :foo, solution: "use `bar'"
         end
 
         thread2.join


### PR DESCRIPTION
`Pakyow::Support::Deprecatable` makes it easier to deprecate a class, module, or method.

```ruby
class DeprecatedClass
  extend Pakyow::Support::Deprecatable

  deprecate
end

DeprecatedClass.new
=> [deprecation] `DeprecatedClass' is deprecated; solution: do not use
```

Just like using `Deprecator#deprecated` directly, a custom solution can be passed:

```ruby
class DeprecatedClass
  extend Pakyow::Support::Deprecatable

  deprecate solution: "use `OtherClass'"
end

DeprecatedClass.new
=> [deprecation] `DeprecatedClass' is deprecated; solution: use `OtherClass'
```

For clarity, this PR also changes the method signature of `Deprecator#deprecated` to accept `solution` as an explicit, required keyword argument.