### PR TITLE
Extension dependencies

### DIFF
--- a/pakyow-support/CHANGELOG.md
+++ b/pakyow-support/CHANGELOG.md
@@ -6,7 +6,7 @@
     - [Pull Request #352][pr-352]
     - [Commit d410904][d410904]
 
-  * `add` **Add `Extension#dependency`.**
+  * `add` **Add `Extension#include_dependency` and `Extension#extend_dependency`.**
 
     *Related links:*
     - [Pull Request #352][pr-352]

--- a/pakyow-support/CHANGELOG.md
+++ b/pakyow-support/CHANGELOG.md
@@ -1,5 +1,7 @@
 # v1.1.0 (unreleased)
 
+  * `add` **Add `Extension#dependency`.**
+
   * `add` **Add `Deprecator#ignore`.**
     - Allows deprecations to be ignored during the execution of a block.
 

--- a/pakyow-support/CHANGELOG.md
+++ b/pakyow-support/CHANGELOG.md
@@ -1,5 +1,7 @@
 # v1.1.0 (unreleased)
 
+  * `chg` **Extension restriction violations now raise `RuntimeError`.**
+
   * `add` **Add `Extension#dependency`.**
 
   * `add` **Add `Deprecator#ignore`.**

--- a/pakyow-support/CHANGELOG.md
+++ b/pakyow-support/CHANGELOG.md
@@ -2,7 +2,15 @@
 
   * `chg` **Extension restriction violations now raise `RuntimeError`.**
 
+    *Related links:*
+    - [Pull Request #352][pr-352]
+    - [Commit d410904][d410904]
+
   * `add` **Add `Extension#dependency`.**
+
+    *Related links:*
+    - [Pull Request #352][pr-352]
+    - [Commit 3edf137][3edf137]
 
   * `add` **Add `Deprecator#ignore`.**
     - Allows deprecations to be ignored during the execution of a block.
@@ -33,10 +41,13 @@
     *Related links:*
     - [Commit 787681d][787681d]
 
+[pr-352]: https://github.com/pakyow/pakyow/pull/352
 [pr-349]: https://github.com/pakyow/pakyow/pull/349
 [pr-343]: https://github.com/pakyow/pakyow/pull/343
 [pr-340]: https://github.com/pakyow/pakyow/pull/340
 [pr-330]: https://github.com/pakyow/pakyow/pull/330
+[d410904]: https://github.com/pakyow/pakyow/commit/d4109047797e8e5d7f4233fe61a42ed472c96cd7
+[3edf137]: https://github.com/pakyow/pakyow/commit/3edf1372869b4a49c4ad83cebc8eb55023f91278
 [59e6efe]: https://github.com/pakyow/pakyow/commit/59e6efe42f1d6f5d48d15359d2e1a63bea9a0600
 [787681d]: https://github.com/pakyow/pakyow/commit/787681dacbbd3ce79f6e38a5672749635903a85b
 

--- a/pakyow-support/lib/pakyow/support/extension.rb
+++ b/pakyow-support/lib/pakyow/support/extension.rb
@@ -2,60 +2,100 @@
 
 module Pakyow
   module Support
-    # Makes it easier to define extensions.
+    # Turns a module into an extension that can define and load complex behavior into objects.
     #
     # @example
+    #   module SomeExtension
+    #     extend Pakyow::Support::Extension
+    #
+    #     apply_extension do
+    #       # This block will be evaluated in context of the including object.
+    #     end
+    #
+    #     class_methods do
+    #       # Define methods to add to the including object's class.
+    #     end
+    #
+    #     prepend_methods do
+    #       # Define methods to prepend to the including object.
+    #     end
+    #
+    #     # Define instance methods for the including object, like with a normal module.
+    #   end
+    #
+    #   module SomeClass
+    #     include SomeExtension
+    #   end
+    #
+    # = Restrictions
+    #
+    # Extensions can be restricted to a particular object type. Loading the extension into an object
+    # of a type other than the restricted type will cause a RuntimeError.
+    #
+    # @example
+    #   class SomeBaseClass
+    #     ...
+    #   end
+    #
+    #   module SomeExtension
+    #     extend Pakyow::Support::Extension
+    #     restrict_extension SomeBaseClass
+    #
+    #     ...
+    #   end
+    #
+    #   class SomeSubClass < SomeBaseClass
+    #     include SomeExtension
+    #
+    #      ...
+    #   end
+    #
+    #   class SomeOtherClass
+    #     include SomeExtension
+    #
+    #     # => RuntimeError: expected `SomeOtherClass' to be `SomeBaseClass'
+    #   end
+    #
+    # = Dependencies
+    #
+    # Extensions can define one or more dependencies to be included or extended into classes that
+    # include the extension. Dependencies are guaranteed to only be included or extended once.
+    #
+    # @example
+    #   module ExtensionDependency
+    #     extend Pakyow::Support::Extension
+    #
+    #     apply_extension do
+    #       perform_some_destructive_setup
+    #     end
+    #
+    #     ...
+    #   end
     #
     #   module SomeExtension
     #     extend Pakyow::Support::Extension
     #
-    #     # only allows the extension to be used on descendants of `SomeBaseClass`
-    #     restrict_extension SomeBaseClass
+    #     include_dependency ExtensionDependency
     #
-    #     # includes the module unless it is already present
-    #     dependency SomeBehavior
-    #
-    #     apply_extension do
-    #       # anything here is evaluated on the object including the extension
-    #     end
-    #
-    #     class_methods do
-    #       # class methods can be defined here
-    #     end
-    #
-    #     prepend_methods do
-    #       # instance methods you wish to prepend can be defined here
-    #     end
-    #
-    #     # define instance-level methods as usual
+    #     ...
     #   end
     #
-    #   class SomeClass < SomeBaseClass
+    #   class SomeClass
+    #     # Causes `perform_some_destructive_setup` to be called.
+    #     #
+    #     include ExtensionDependency
+    #
+    #     # Because `ExtensionDependency` is already included into this class, the
+    #     # `perform_some_destructive_setup` method will not be called again.
+    #     #
     #     include SomeExtension
     #   end
     #
     module Extension
+      # Restrict the extension to a particular object type.
+      #
       def restrict_extension(type)
         @__extension_restriction = type
-      end
-
-      def apply_extension(&block)
-        @__extension_block = block
-      end
-
-      def class_methods(&block)
-        @__extension_extend_module = Module.new(&block)
-      end
-
-      def prepend_methods(&block)
-        @__extension_prepend_module = Module.new(&block)
-      end
-
-      def included(base)
-        enforce_restrictions(base)
-        mixin_extension_dependencies(base)
-        mixin_extension_modules(base)
-        include_extensions(base)
       end
 
       # Register a dependency to be included into classes that include the extension. If the
@@ -74,6 +114,32 @@ module Pakyow
         extension_dependencies << {
           method: :extend, object: dependency
         }
+      end
+
+      # Register a block to be evaluated on the including object.
+      #
+      def apply_extension(&block)
+        @__extension_block = block
+      end
+
+      # Register a block defining class methods to be loaded into the including object.
+      #
+      def class_methods(&block)
+        @__extension_extend_module = Module.new(&block)
+      end
+
+      # Register a block defining methods to be prepended to the including object.
+      #
+      def prepend_methods(&block)
+        @__extension_prepend_module = Module.new(&block)
+      end
+
+      # @api private
+      def included(base)
+        enforce_restrictions(base)
+        mixin_extension_dependencies(base)
+        mixin_extension_modules(base)
+        include_extensions(base)
       end
 
       private

--- a/pakyow-support/lib/pakyow/support/extension.rb
+++ b/pakyow-support/lib/pakyow/support/extension.rb
@@ -53,7 +53,7 @@ module Pakyow
     #   class SomeOtherClass
     #     include SomeExtension
     #
-    #     # => RuntimeError: expected `SomeOtherClass' to be `SomeBaseClass'
+    #     # => RuntimeError: expected `SomeOtherClass' to be a decendent of `SomeBaseClass'
     #   end
     #
     # = Dependencies
@@ -146,7 +146,7 @@ module Pakyow
 
       def enforce_restrictions(base)
         if instance_variable_defined?(:@__extension_restriction) && !base.ancestors.include?(@__extension_restriction)
-          raise StandardError, "expected `#{base}' to be `#{@__extension_restriction}'"
+          raise RuntimeError, "expected `#{base}' to be a decendent of `#{@__extension_restriction}'"
         end
       end
 

--- a/pakyow-support/spec/features/extensions/dependencies_spec.rb
+++ b/pakyow-support/spec/features/extensions/dependencies_spec.rb
@@ -1,0 +1,81 @@
+require "pakyow/support/extension"
+
+RSpec.describe "defining dependencies for an extension" do
+  let(:extension) {
+    local = self
+
+    Module.new {
+      extend Pakyow::Support::Extension
+
+      include_dependency local.dependency
+    }
+  }
+
+  let(:dependency) {
+    local = self
+
+    Module.new {
+      define_singleton_method :included do |_|
+        local.included << :included
+      end
+
+      define_singleton_method :extended do |_|
+        local.extended << :extended
+      end
+    }
+  }
+
+  let(:included) {
+    []
+  }
+
+  let(:extended) {
+    []
+  }
+
+  let!(:klass) {
+    Class.new.tap do |klass|
+      klass.include extension
+    end
+  }
+
+  it "includes the dependency" do
+    expect(klass.ancestors).to include(dependency)
+  end
+
+  context "dependency is already present" do
+    before do
+      klass.include extension
+    end
+
+    it "is not included again" do
+      expect(included.count).to eq(1)
+    end
+  end
+
+  context "dependency is set to extend" do
+    let(:extension) {
+      local = self
+
+      Module.new {
+        extend Pakyow::Support::Extension
+
+        extend_dependency local.dependency
+      }
+    }
+
+    it "extends the dependency" do
+      expect(klass.singleton_class.ancestors).to include(dependency)
+    end
+
+    context "dependency is already present" do
+      before do
+        klass.extend extension
+      end
+
+      it "is not extended again" do
+        expect(extended.count).to eq(1)
+      end
+    end
+  end
+end

--- a/pakyow-support/spec/features/extensions/restrictions_spec.rb
+++ b/pakyow-support/spec/features/extensions/restrictions_spec.rb
@@ -1,0 +1,51 @@
+require "pakyow/support/extension"
+
+RSpec.describe "restricting dependencies to a type" do
+  let(:extension) {
+    local = self
+
+    Module.new {
+      extend Pakyow::Support::Extension
+
+      restrict_extension local.type
+    }
+  }
+
+  let(:type) {
+    Class.new.tap do |type|
+      stub_const "RestrictedType", type
+    end
+  }
+
+  context "including the extension into the type" do
+    it "does not fail" do
+      expect {
+        type.include extension
+      }.not_to raise_error(RuntimeError)
+    end
+  end
+
+  context "including the extension into a subclass of the type" do
+    it "does not fail" do
+      expect {
+        Class.new(type).include extension
+      }.not_to raise_error(RuntimeError)
+    end
+  end
+
+  context "including the extension into a different type" do
+    let(:other_type) {
+      Class.new.tap do |type|
+        stub_const "OtherType", type
+      end
+    }
+
+    it "raises a runtime error" do
+      expect {
+        other_type.include extension
+      }.to raise_error(RuntimeError) do |error|
+        expect(error.message).to eq("expected `OtherType' to be a decendent of `RestrictedType'")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Extensions can now define their dependencies. When the extension is included, its dependencies will be included into or will extend the including class. This is done safely, meaning if the including object already has the dependency it will not be included or extended again.

```ruby
module ExtensionDependency
  extend Pakyow::Support::Extension

  apply_extension do
    perform_some_destructive_setup
  end

  ...
end

module SomeExtension
  extend Pakyow::Support::Extension

  include_dependency ExtensionDependency

  ...
end

class SomeClass
  # Causes `perform_some_destructive_setup` to be called.
  #
  include ExtensionDependency

  # Because `ExtensionDependency` is already included into this class, the
  # `perform_some_destructive_setup` method will not be called again.
  #
  include SomeExtension
end
```