### PR TITLE
Add a common methods pattern to extensions

### DIFF
--- a/pakyow-support/CHANGELOG.md
+++ b/pakyow-support/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `add` **Add a `common_methods` pattern to extensions.**
+
+    *Related links:*
+    - [Pull Request #361][pr-361]
+
   * `add` **Expose `source_location`.**
 
     *Related links:*
@@ -61,6 +66,7 @@
     *Related links:*
     - [Commit 787681d][787681d]
 
+[pr-361]: https://github.com/pakyow/pakyow/pull/361
 [pr-359]: https://github.com/pakyow/pakyow/pull/359
 [pr-358]: https://github.com/pakyow/pakyow/pull/358
 [pr-357]: https://github.com/pakyow/pakyow/pull/357

--- a/pakyow-support/lib/pakyow/support/extension.rb
+++ b/pakyow-support/lib/pakyow/support/extension.rb
@@ -20,6 +20,10 @@ module Pakyow
     #       # Define methods to prepend to the including object.
     #     end
     #
+    #     common_methods do
+    #       # Define methods to add both to the including object and its class.
+    #     end
+    #
     #     # Define instance methods for the including object, like with a normal module.
     #   end
     #
@@ -134,6 +138,12 @@ module Pakyow
         @__extension_prepend_module = Module.new(&block)
       end
 
+      # Register a block defining methods to be loaded into the including object and its class.
+      #
+      def common_methods(&block)
+        @__extension_common_module = Module.new(&block)
+      end
+
       # @api private
       def included(base)
         enforce_restrictions(base)
@@ -157,6 +167,11 @@ module Pakyow
 
         if instance_variable_defined?(:@__extension_prepend_module)
           base.prepend @__extension_prepend_module
+        end
+
+        if instance_variable_defined?(:@__extension_common_module)
+          base.extend @__extension_common_module
+          base.include @__extension_common_module
         end
       end
 

--- a/pakyow-support/spec/features/extensions/common_methods_spec.rb
+++ b/pakyow-support/spec/features/extensions/common_methods_spec.rb
@@ -1,0 +1,31 @@
+require "pakyow/support/extension"
+
+RSpec.describe "defining common methods in an extension" do
+  let(:extension) {
+    local = self
+
+    Module.new {
+      extend Pakyow::Support::Extension
+
+      common_methods do
+        def foo
+          :foo
+        end
+      end
+    }
+  }
+
+  let!(:klass) {
+    Class.new.tap do |klass|
+      klass.include extension
+    end
+  }
+
+  it "extends the method" do
+    expect(klass.foo).to eq(:foo)
+  end
+
+  it "includes the method" do
+    expect(klass.new.foo).to eq(:foo)
+  end
+end


### PR DESCRIPTION
Lets extensions define methods both on the including object and its class.

```ruby
module SomeExtension
  extend Pakyow::Support::Extension

  common_methods do
    def foo
      "foo"
    end
  end
end

class SomeClass
  include SomeExtension
end

SomeClass.foo
=> "foo"

SomeClass.new.foo
=> "foo"
```