### PR TITLE
Introduce Isolable, properly isolate helpers, operations

### DIFF
--- a/pakyow-core/lib/pakyow/application/behavior/helpers.rb
+++ b/pakyow-core/lib/pakyow/application/behavior/helpers.rb
@@ -54,7 +54,9 @@ module Pakyow
           # Define helpers as stateful after an app is made.
           #
           after "make", priority: :high do
-            stateful :helper, Helper
+            isolate Helper
+
+            stateful :helper, isolated(:Helper)
           end
         end
 

--- a/pakyow-core/lib/pakyow/application/behavior/isolating.rb
+++ b/pakyow-core/lib/pakyow/application/behavior/isolating.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-require "pakyow/support/extension"
-require "pakyow/support/inflector"
+require "pakyow/support/isolable"
 
 module Pakyow
   class Application
@@ -11,59 +10,8 @@ module Pakyow
       module Isolating
         extend Support::Extension
 
-        class_methods do
-          # Creates a subclass within the app's namespace.
-          #
-          # @example
-          #   class MyApplication < Pakyow::Application
-          #     isolate Pakyow::Controller do
-          #       def self.special_behavior
-          #         puts "it works"
-          #       end
-          #     end
-          #   end
-          #
-          #   MyApplication::Controller.special_behavior
-          #   => it works
-          #
-          #   Pakyow::Controller
-          #   => NoMethodError (undefined method `special_behavior' for Pakyow::Controller:Class)
-          #
-          def isolate(class_to_isolate, &block)
-            isolated_class_name = Support.inflector.demodulize(class_to_isolate.to_s).to_sym
-
-            unless const_defined?(isolated_class_name, false)
-              const_set(isolated_class_name, Class.new(class_to_isolate))
-            end
-
-            isolated(isolated_class_name).tap do |defined_subclass|
-              defined_subclass.class_eval(&block) if block_given?
-            end
-          end
-
-          # Returns true if the class name is isolated.
-          #
-          def isolated?(class_name)
-            const_defined?(class_name)
-          end
-
-          # Returns the isolated class, evaluating the block (if provided).
-          #
-          def isolated(class_name, &block)
-            if isolated?(class_name)
-              const_get(class_name).tap do |isolated_class|
-                isolated_class.class_eval(&block) if block_given?
-              end
-            else
-              nil
-            end
-          end
-        end
-
-        # Convenience method for +Pakyow::Application::subclass+.
-        #
-        def isolated(*args, &block)
-          self.class.isolated(*args, &block)
+        apply_extension do
+          include Support::Isolable
         end
       end
     end

--- a/pakyow-core/lib/pakyow/application/behavior/operations.rb
+++ b/pakyow-core/lib/pakyow/application/behavior/operations.rb
@@ -27,7 +27,6 @@ module Pakyow
             load_aspect(:operations)
           end
 
-          attr_reader :operations
           after "initialize" do
             @operations = Lookup.new(operations: state(:operation), app: self)
           end
@@ -38,11 +37,15 @@ module Pakyow
           #
           # @api private
           def make(*)
+            isolate Operation
+
             super.tap do |new_class|
-              new_class.stateful :operation, Operation
+              new_class.stateful :operation, isolated(:Operation)
             end
           end
         end
+
+        attr_reader :operations
       end
     end
   end

--- a/pakyow-core/lib/pakyow/helper.rb
+++ b/pakyow-core/lib/pakyow/helper.rb
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
+require "pakyow/support/extension"
 require "pakyow/support/makeable"
 
 module Pakyow
   module Helper
-    extend Support::Makeable
+    extend Support::Extension
+
+    # This is a bit nuanced, but this will cause isolated the helper module to be makeable.
+    #
+    extend_dependency Support::Makeable
   end
 end

--- a/pakyow-support/CHANGELOG.md
+++ b/pakyow-support/CHANGELOG.md
@@ -1,4 +1,6 @@
 # v1.1.0 (unreleased)
+  * `add` **Introduce `Isolable`.**
+    - [Pull Request #363][pr-363]
 
   * `add` **Add a `common_methods` pattern to extensions.**
 
@@ -66,6 +68,7 @@
     *Related links:*
     - [Commit 787681d][787681d]
 
+[pr-363]: https://github.com/pakyow/pakyow/pull/363
 [pr-361]: https://github.com/pakyow/pakyow/pull/361
 [pr-359]: https://github.com/pakyow/pakyow/pull/359
 [pr-358]: https://github.com/pakyow/pakyow/pull/358

--- a/pakyow-support/lib/pakyow/support/isolable.rb
+++ b/pakyow-support/lib/pakyow/support/isolable.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require "pakyow/support/extension"
+require "pakyow/support/inflector"
+require "pakyow/support/object_namespace"
+
+module Pakyow
+  module Support
+    # Create isolated classes and modules within an object.
+    #
+    # @example
+    #   class Controller
+    #     ...
+    #   end
+    #
+    #   class Application
+    #     include Pakyow::Support::Isolable
+    #
+    #     isolate Controller do
+    #       def self.some_behavior
+    #         puts "it works"
+    #       end
+    #     end
+    #   end
+    #
+    #   # Isolated objects are subclasses.
+    #   #
+    #   Application::Controller.ancestors.include?(Controller)
+    #   => true
+    #
+    #   # Like any subclass, isolated objects can extend the parent.
+    #   #
+    #   Application::Controller.some_behavior
+    #   => it works
+    #
+    #   # Parent objects are unmodified.
+    #   #
+    #   Controller.some_behavior
+    #   => NoMethodError (undefined method `some_behavior' for Controller:Class)
+    #
+    module Isolable
+      extend Extension
+
+      class_methods do
+        # Isolates `object_to_isolate` within `self` or `binding`, evaluating the given block in context.
+        #
+        def isolate(*namespace, object_to_isolate, binding: self, &block)
+          object_to_isolate = ensure_object(object_to_isolate)
+
+          isolated_class_name = Support.inflector.demodulize(object_to_isolate.to_s).to_sym
+
+          isolation_target = ensure_isolatable_namespace(*namespace).inject(binding) { |target_for_part, object_name_part|
+            constant_name = Support.inflector.camelize(object_name_part.to_s)
+
+            unless target_for_part.const_defined?(constant_name, false)
+              target_for_part.const_set(constant_name, Module.new)
+            end
+
+            target_for_part.const_get(constant_name)
+          }
+
+          unless isolation_target.const_defined?(isolated_class_name, false)
+            isolation_target.const_set(isolated_class_name, define_isolated_object(object_to_isolate))
+          end
+
+          isolated(*namespace, isolated_class_name, binding: binding).tap do |defined_subclass|
+            defined_subclass.class_eval(&block) if block_given?
+          end
+        end
+
+        # Returns true if `class_name` is isolated within `self` or `binding`.
+        #
+        def isolated?(*namespace, class_name, binding: self)
+          isolation_target = ensure_isolatable_namespace(*namespace).inject(binding) { |target_for_part, object_name_part|
+            target_for_part.const_get(Support.inflector.camelize(object_name_part.to_s))
+          }
+
+          isolation_target.const_defined?(Support.inflector.camelize(class_name.to_s))
+        end
+
+        # Returns the isolated class for `class_name`, evaluating the given block in context.
+        #
+        def isolated(*namespace, class_name, binding: self, &block)
+          class_name = Support.inflector.camelize(class_name.to_s)
+
+          isolation_target = ensure_isolatable_namespace(*namespace).inject(binding) { |target_for_part, object_name_part|
+            target_for_part.const_get(Support.inflector.camelize(object_name_part.to_s))
+          }
+
+          if isolated?(class_name, binding: isolation_target)
+            isolation_target.const_get(class_name).tap do |isolated_class|
+              isolated_class.class_eval(&block) if block_given?
+            end
+          else
+            nil
+          end
+        end
+
+        private def define_isolated_object(object)
+          case object
+          when Class
+            Class.new(object)
+          when Module
+            Module.new do
+              include object
+            end
+          end
+        end
+
+        private def ensure_object(object)
+          unless object.is_a?(Class) || object.is_a?(Module)
+            object = const_get(Support.inflector.camelize(object.to_s))
+          end
+
+          object
+        end
+
+        private def ensure_isolatable_namespace(*namespace)
+          if namespace.first.is_a?(ObjectNamespace)
+            namespace.first.parts
+          else
+            namespace
+          end
+        end
+      end
+
+      # Convenience method for getting an isolated object through an instance.
+      #
+      def isolated(*namespace, class_name, binding: self.class, &block)
+        self.class.isolated(class_name, binding: binding, &block)
+      end
+    end
+  end
+end

--- a/pakyow-support/spec/features/isolable_spec.rb
+++ b/pakyow-support/spec/features/isolable_spec.rb
@@ -1,0 +1,255 @@
+require "pakyow/support/isolable"
+
+RSpec.describe "isolating objects" do
+  shared_examples "isolable" do
+    let(:isolable) {
+      Class.new do
+        include Pakyow::Support::Isolable
+      end
+    }
+
+    let(:isolated_state_name) {
+      "State"
+    }
+
+    before do
+      stub_const "IsolableObject", isolable
+      stub_const isolated_state_name, object
+    end
+
+    it "isolates the object" do
+      expect(isolable.isolate(State)).to be(IsolableObject::State)
+    end
+
+    context "object is already defined" do
+      before do
+        stub_const "IsolableObject::State", existing_object
+      end
+
+      let(:existing_object) {
+        Module.new do
+          def self.is_existing_object?
+            true
+          end
+        end
+      }
+
+      it "does not redefine the object" do
+        isolable.isolate(State)
+
+        expect(IsolableObject::State.is_existing_object?).to be(true)
+      end
+    end
+
+    describe "passing a symbol representing the isolated const" do
+      it "isolates the object" do
+        expect(isolable.isolate(:state)).to be(IsolableObject::State)
+      end
+    end
+
+    describe "isolating with a block" do
+      before do
+        isolable.isolate(State) do
+          def self.some_extended_behavior; end
+        end
+      end
+
+      it "extends the isolated object with the block" do
+        expect(isolable.isolated(:State)).to respond_to(:some_extended_behavior)
+      end
+
+      it "does not change the parent object" do
+        expect(State).not_to respond_to(:some_extended_behavior)
+      end
+    end
+
+    describe "isolating within another binding" do
+      before do
+        stub_const "FooBarBaz", Module.new
+      end
+
+      it "isolates the object" do
+        expect(isolable.isolate(State, binding: FooBarBaz)).to be(FooBarBaz::State)
+      end
+    end
+
+    describe "isolating a namespaced object" do
+      let(:isolated_state_name) {
+        "Foo::Bar::State"
+      }
+
+      it "isolates the object" do
+        expect(isolable.isolate(Foo::Bar::State)).to be(IsolableObject::State)
+      end
+    end
+
+    describe "isolating an object within a namespace" do
+      it "isolates the object" do
+        expect(isolable.isolate(:foo, :bar, State)).to be(IsolableObject::Foo::Bar::State)
+      end
+
+      context "namespace is an ObjectNamespace" do
+        it "isolates the object" do
+          expect(isolable.isolate(Pakyow::Support::ObjectNamespace.new(:foo, :bar), State)).to be(IsolableObject::Foo::Bar::State)
+        end
+      end
+    end
+
+    describe "getting the isolated object" do
+      shared_examples "gettable" do
+        def isolate_object
+          isolable.isolate(State)
+        end
+
+        def get_isolated_object
+          context.isolated(:State)
+        end
+
+        let(:context) {
+          isolable
+        }
+
+        it "gets the isolated object" do
+          isolate_object
+
+          expect(get_isolated_object).to be(IsolableObject::State)
+        end
+
+        context "block is passed" do
+          def isolate_object
+            isolable.isolate(State) do
+              def self.extended_through_isolated; end
+            end
+          end
+
+          it "extends the isolated object" do
+            isolate_object
+
+            expect(get_isolated_object).to respond_to(:extended_through_isolated)
+          end
+        end
+
+        context "isolated within a binding" do
+          before do
+            stub_const "FooBarBaz", Module.new
+          end
+
+          def isolate_object
+            isolable.isolate(State, binding: FooBarBaz)
+          end
+
+          def get_isolated_object
+            context.isolated(:State, binding: FooBarBaz)
+          end
+
+          it "gets the isolated object" do
+            isolate_object
+
+            expect(get_isolated_object).to be(FooBarBaz::State)
+          end
+        end
+      end
+
+      it_behaves_like "gettable"
+
+      context "through the instance" do
+        it_behaves_like "gettable" do
+          let(:context) {
+            isolable.new
+          }
+        end
+      end
+    end
+
+    describe "checking if an object is isolated" do
+      before do
+        isolate
+      end
+
+      def isolate
+        isolable.isolate(State)
+      end
+
+      it "detects the isolated object" do
+        expect(isolable.isolated?(:State)).to be(true)
+      end
+
+      context "with a downcased symbol" do
+        it "detects the isolated object" do
+          expect(isolable.isolated?(:state)).to be(true)
+        end
+      end
+
+      context "isolated within another binding" do
+        def isolate
+          stub_const "FooBarBaz", Module.new
+          isolable.isolate(State, binding: FooBarBaz)
+        end
+
+        it "detects the isolated object" do
+          expect(isolable.isolated?(:State, binding: FooBarBaz)).to be(true)
+        end
+      end
+
+      context "isolating a namespaced object" do
+        let(:isolated_state_name) {
+          "Foo::Bar::State"
+        }
+
+        def isolate
+          isolable.isolate(Foo::Bar::State)
+        end
+
+        it "detects the isolated object" do
+          expect(isolable.isolated?(:State)).to be(true)
+        end
+      end
+
+      context "isolating an object within a namespace" do
+        def isolate
+          isolable.isolate(:foo, :bar, State)
+        end
+
+        it "detects the isolated object" do
+          expect(isolable.isolated?(:foo, :bar, State)).to be(true)
+        end
+
+        context "namespace is an ObjectNamespace" do
+          def isolate
+            isolable.isolate(Pakyow::Support::ObjectNamespace.new(:foo, :bar), State)
+          end
+
+          it "detects the isolated object" do
+            expect(isolable.isolated?(Pakyow::Support::ObjectNamespace.new(:foo, :bar), State)).to be(true)
+          end
+        end
+      end
+    end
+  end
+
+  context "object is a class" do
+    let(:object) {
+      Class.new
+    }
+
+    it_behaves_like "isolable"
+  end
+
+  context "object is a module" do
+    let(:object) {
+      Module.new do
+        extend Pakyow::Support::Extension
+
+        class_methods do
+          def foo; end
+        end
+      end
+    }
+
+    it_behaves_like "isolable" do
+      it "includes the original module into the isolated object" do
+        expect(isolable.isolate(State)).to respond_to(:foo)
+      end
+    end
+  end
+end


### PR DESCRIPTION
`Pakyow::Support::Isolable` lets you create isolated classes and modules within an object.

```ruby
class Controller
...
end

class Application
  include Pakyow::Support::Isolable

  isolate Controller do
    def self.some_behavior
      puts "it works"
    end
  end
end

# Isolated objects are subclasses.
#
Application::Controller.ancestors.include?(Controller)
=> true

# Like any subclass, isolated objects can extend the parent.
#
Application::Controller.some_behavior
=> it works

# Parent objects are unmodified.
#
Controller.some_behavior
=> NoMethodError (undefined method `some_behavior' for Controller:Class)
```