### PR TITLE
Register pipeline actions during initialization

### DIFF
--- a/pakyow-core/lib/pakyow/application/behavior/pipeline.rb
+++ b/pakyow-core/lib/pakyow/application/behavior/pipeline.rb
@@ -15,10 +15,7 @@ module Pakyow
           # state that should be loaded into the pipeline (e.g. controllers).
           #
           after "initialize", "initialize.pipeline", priority: -10 do
-            self.class.__pipeline.dup.tap do |pipeline|
-              load_pipeline_defaults(pipeline)
-              @__pipeline = pipeline.callable(self)
-            end
+            load_pipeline_defaults(@__pipeline)
           end
         end
 

--- a/pakyow-support/CHANGELOG.md
+++ b/pakyow-support/CHANGELOG.md
@@ -1,5 +1,8 @@
 # v1.1.0 (unreleased)
 
+  * `chg` **Register pipeline actions during initialization.**
+    - [Pull Request #365][pr-365]
+
   * `add` **Introduce `Pipeline::Extension`.**
     - [Pull Request #364][pr-364]
 
@@ -80,6 +83,7 @@
     *Related links:*
     - [Pull Request #364][pr-364]
 
+[pr-365]: https://github.com/pakyow/pakyow/pull/365
 [pr-364]: https://github.com/pakyow/pakyow/pull/364
 [pr-363]: https://github.com/pakyow/pakyow/pull/363
 [pr-361]: https://github.com/pakyow/pakyow/pull/361

--- a/pakyow-support/lib/pakyow/support/pipeline.rb
+++ b/pakyow-support/lib/pakyow/support/pipeline.rb
@@ -78,9 +78,11 @@ module Pakyow
 
       prepend_methods do
         def initialize(*)
-          @__pipeline = self.class.__pipeline.callable(self)
+          @__pipeline = self.class.__pipeline.dup
 
           super
+
+          @__pipeline = @__pipeline.callable(self)
         end
 
         def initialize_copy(_)
@@ -96,6 +98,14 @@ module Pakyow
               action
             end
           }
+        end
+
+        def action(*args, &block)
+          if @__pipeline.is_a?(Internal)
+            @__pipeline.action(*args, &block)
+          else
+            raise RuntimeError, "cannot define action on a finalized pipeline"
+          end
         end
       end
 


### PR DESCRIPTION
Allows pipeline actions to be defined when initializing a pipelined object, but not after.