### PR TITLE
Fix app-relative endpoints

### DIFF
--- a/pakyow-assets/lib/pakyow/application/actions/assets/public.rb
+++ b/pakyow-assets/lib/pakyow/application/actions/assets/public.rb
@@ -17,12 +17,6 @@ module Pakyow
             @asset_paths = app.state(:asset).map(&:public_path) + app.state(:pack).flat_map { |pack|
               [pack.public_css_path, pack.public_js_path]
             }
-
-            @prefix = if app.is_a?(Plugin)
-              Pathname.new(app.class.mount_path)
-            else
-              Pathname.new("/")
-            end
           end
 
           def call(connection)
@@ -51,12 +45,7 @@ module Pakyow
           end
 
           def public_path(connection)
-            File.join(
-              connection.app.config.assets.public_path,
-              String.normalize_path(
-                Pathname.new(connection.path).relative_path_from(@prefix).to_s
-              )
-            )
+            File.join(connection.app.config.assets.public_path, connection.path)
           end
 
           def asset?(connection)

--- a/pakyow-assets/lib/pakyow/application/behavior/assets.rb
+++ b/pakyow-assets/lib/pakyow/application/behavior/assets.rb
@@ -21,17 +21,10 @@ module Pakyow
                 } || File.basename(path).start_with?("_")
 
                 if config.assets.extensions.include?(File.extname(path))
-                  prefix = if is_a?(Plugin)
-                    self.class.mount_path
-                  else
-                    "/"
-                  end
-
                   self.class.asset << Pakyow::Assets::Asset.new_from_path(
                     path,
                     config: config.assets,
                     source_location: assets_path,
-                    prefix: prefix,
                     related: state(:asset)
                   )
                 end

--- a/pakyow-assets/lib/pakyow/application/behavior/assets/packs.rb
+++ b/pakyow-assets/lib/pakyow/application/behavior/assets/packs.rb
@@ -21,13 +21,7 @@ module Pakyow
                 }.map { |pack_path, pack_asset_paths|
                   [accessible_pack_path(pack_path), pack_asset_paths]
                 }.reverse.each do |pack_path, pack_asset_paths|
-                  prefix = if is_a?(Plugin)
-                    self.class.mount_path
-                  else
-                    "/"
-                  end
-
-                  asset_pack = Pakyow::Assets::Pack.new(File.basename(pack_path).to_sym, config.assets, prefix: prefix)
+                  asset_pack = Pakyow::Assets::Pack.new(File.basename(pack_path).to_sym, config.assets)
 
                   pack_asset_paths.each do |pack_asset_path|
                     if config.assets.extensions.include?(File.extname(pack_asset_path))

--- a/pakyow-assets/lib/pakyow/application/config/assets.rb
+++ b/pakyow-assets/lib/pakyow/application/config/assets.rb
@@ -48,7 +48,12 @@ module Pakyow
             end
 
             setting :compile_path do
-              config.assets.public_path
+              case self
+              when Plugin
+                File.join(top.config.assets.public_path, mount_path)
+              else
+                config.assets.public_path
+              end
             end
 
             setting :version do

--- a/pakyow-assets/lib/pakyow/assets/asset.rb
+++ b/pakyow-assets/lib/pakyow/assets/asset.rb
@@ -132,6 +132,8 @@ module Pakyow
       end
 
       def each(&block)
+        return enum_for(:each) unless block_given?
+
         ensure_content do |content|
           StringIO.new(post_process(content)).each(&block)
         end

--- a/pakyow-assets/lib/pakyow/assets/pack.rb
+++ b/pakyow-assets/lib/pakyow/assets/pack.rb
@@ -118,6 +118,8 @@ module Pakyow
       end
 
       def each(&block)
+        return enum_for(:each) unless block_given?
+
         @assets.each do |asset|
           asset.each(&block)
         end

--- a/pakyow-assets/spec/features/plugins/precompiling_spec.rb
+++ b/pakyow-assets/spec/features/plugins/precompiling_spec.rb
@@ -32,6 +32,14 @@ RSpec.describe "precompiling assets from a plugin" do
       )
     )
 
+    FileUtils.rm_r(
+      File.join(
+        running_app.config.assets.compile_path,
+        "foo",
+        running_app.config.assets.prefix
+      )
+    )
+
     # Put back the assets that are needed for other tests.
     #
     FileUtils.mkdir_p(
@@ -81,8 +89,9 @@ RSpec.describe "precompiling assets from a plugin" do
       File.exist?(
         File.join(
           running_app.config.assets.compile_path,
+          "foo",
           running_app.config.assets.prefix,
-          "foo/plugin.css"
+          "plugin.css"
         )
       )
     ).to be(true)
@@ -105,8 +114,9 @@ RSpec.describe "precompiling assets from a plugin" do
       File.exist?(
         File.join(
           running_app.config.assets.compile_path,
+          "foo",
           running_app.config.assets.prefix,
-          "foo/packs/plugin-pack.js"
+          "packs/plugin-pack.js"
         )
       )
     ).to be(true)

--- a/pakyow-assets/spec/features/plugins/serving_spec.rb
+++ b/pakyow-assets/spec/features/plugins/serving_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe "serving assets from a plugin" do
 
   let :app_def do
     Proc.new do
-      plug :testable
       plug :testable, at: "/foo", as: :foo
+      plug :testable
     end
   end
 
@@ -20,7 +20,7 @@ RSpec.describe "serving assets from a plugin" do
   end
 
   it "serves plugin assets at a specific mount path" do
-    expect(call("/assets/foo/plugin.css")[0]).to eq(200)
+    expect(call("/foo/assets/plugin.css")[0]).to eq(200)
   end
 
   it "serves plugin packs at the default mount path" do
@@ -28,7 +28,7 @@ RSpec.describe "serving assets from a plugin" do
   end
 
   it "serves plugin packs at a specific mount path" do
-    expect(call("/assets/foo/packs/plugin-pack.js")[0]).to eq(200)
+    expect(call("/foo/assets/packs/plugin-pack.js")[0]).to eq(200)
   end
 
   it "serves plugin public files at the default mount path" do

--- a/pakyow-assets/spec/unit/types/sass_spec.rb
+++ b/pakyow-assets/spec/unit/types/sass_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Pakyow::Assets::Types::Sass do
       expect(::SassC::Engine).to receive(:new) do |_, options|
         @syntax = options[:syntax]
       end.and_return(double.as_null_object)
-      instance.each
+      instance.each {}
 
       expect(@syntax).to eq(:sass)
     end
@@ -38,7 +38,7 @@ RSpec.describe Pakyow::Assets::Types::Sass do
       expect(::SassC::Engine).to receive(:new) do |_, options|
         @cache = options[:cache]
       end.and_return(double.as_null_object)
-      instance.each
+      instance.each {}
 
       expect(@cache).to eq(false)
     end
@@ -48,7 +48,7 @@ RSpec.describe Pakyow::Assets::Types::Sass do
         expect(::SassC::Engine).to receive(:new) do |_, options|
           @load_paths = options[:load_paths]
         end.and_return(double.as_null_object)
-        instance.each
+        instance.each {}
       end
 
       it "includes the containing directory" do

--- a/pakyow-assets/spec/unit/types/scss_spec.rb
+++ b/pakyow-assets/spec/unit/types/scss_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Pakyow::Assets::Types::Scss do
       expect(::SassC::Engine).to receive(:new) do |_, options|
         @syntax = options[:syntax]
       end.and_return(double.as_null_object)
-      instance.each
+      instance.each {}
 
       expect(@syntax).to eq(:scss)
     end
@@ -38,7 +38,7 @@ RSpec.describe Pakyow::Assets::Types::Scss do
       expect(::SassC::Engine).to receive(:new) do |_, options|
         @cache = options[:cache]
       end.and_return(double.as_null_object)
-      instance.each
+      instance.each {}
 
       expect(@cache).to eq(false)
     end
@@ -48,7 +48,7 @@ RSpec.describe Pakyow::Assets::Types::Scss do
         expect(::SassC::Engine).to receive(:new) do |_, options|
           @load_paths = options[:load_paths]
         end.and_return(double.as_null_object)
-        instance.each
+        instance.each {}
       end
 
       it "includes the containing directory" do

--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # v1.1.0 (unreleased)
 
+  * `chg` **Build endpoints explicitly, relative to app mount path.**
+
   * `chg` **Boot the environment once, prior to forking child processes.**
 
     *Related links:*

--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
   * `chg` **Build endpoints explicitly, relative to app mount path.**
 
+    *Related links:*
+    - [Pull Request #374][pr-374]
+    - [Commit d7ef764][d7ef764]
+
   * `chg` **Boot the environment once, prior to forking child processes.**
 
     *Related links:*
@@ -98,6 +102,10 @@
 
   * `Pakyow::Endpoints#load` is deprecated in favor of registering endpoints explicitly with `Pakyow::Endpoints#build`.
 
+    *Related links:*
+    - [Pull Request #374][pr-374]
+    - [Commit 649cb97][649cb97]
+
   * The environment's `freeze_on_boot` config option is deprecated and will be removed.
 
     *Related links:*
@@ -121,6 +129,7 @@
     *Related links:*
     - [Pull Request #338][pr-338]
 
+[pr-374]: https://github.com/pakyow/pakyow/pull/374
 [pr-348]: https://github.com/pakyow/pakyow/pull/348
 [pr-347]: https://github.com/pakyow/pakyow/pull/347
 [pr-344]: https://github.com/pakyow/pakyow/pull/344
@@ -135,6 +144,8 @@
 [pr-301]: https://github.com/pakyow/pakyow/pull/301
 [is-298]: https://github.com/pakyow/pakyow/issues/298
 [pr-297]: https://github.com/pakyow/pakyow/pull/297
+[649cb97]: https://github.com/pakyow/pakyow/commit/649cb97cf747c3ab6bbe197ba63c554f4d05a76e
+[d7ef764]: https://github.com/pakyow/pakyow/commit/d7ef76437f4c8948ac09d9b5be77bc02a44caa06
 [641fd12]: https://github.com/pakyow/pakyow/commit/641fd12b5abee8558621caf857cec47d38814c8a
 [12de611]: https://github.com/pakyow/pakyow/commit/12de611e480fb9224f1e0bdaf9bd902448dd69e3
 [991f3dd]: https://github.com/pakyow/pakyow/commit/991f3ddd589edc9d08370c4f020e2ef0297433c7

--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -96,6 +96,8 @@
 
 ## Deprecations
 
+  * `Pakyow::Endpoints#load` is deprecated in favor of registering endpoints explicitly with `Pakyow::Endpoints#build`.
+
   * The environment's `freeze_on_boot` config option is deprecated and will be removed.
 
     *Related links:*

--- a/pakyow-core/lib/pakyow/application/behavior/endpoints.rb
+++ b/pakyow-core/lib/pakyow/application/behavior/endpoints.rb
@@ -11,32 +11,14 @@ module Pakyow
         extend Support::Extension
 
         apply_extension do
-          after "initialize" do
-            load_endpoints
-          end
-        end
-
-        prepend_methods do
-          def initialize(*)
-            @endpoints = ::Pakyow::Endpoints.new
-
-            super
+          on "initialize" do
+            @endpoints = ::Pakyow::Endpoints.new(prefix: mount_path)
           end
         end
 
         # Instance of {Endpoints} for path building.
         #
         attr_reader :endpoints
-
-        private
-
-        def load_endpoints
-          state.values.each do |state_object|
-            state_object.instances.each do |state_instance|
-              @endpoints.load(state_instance)
-            end
-          end
-        end
       end
     end
   end

--- a/pakyow-core/lib/pakyow/endpoints.rb
+++ b/pakyow-core/lib/pakyow/endpoints.rb
@@ -2,6 +2,8 @@
 
 require "forwardable"
 
+require "pakyow/support/deprecatable"
+
 module Pakyow
   # Lookup for endpoints.
   #
@@ -11,8 +13,15 @@ module Pakyow
     extend Forwardable
     def_delegator :@endpoints, :each
 
-    def initialize
+    extend Support::Deprecatable
+
+    def initialize(prefix: "/")
+      @prefix = prefix
       @endpoints = []
+    end
+
+    def build(name:, method:, builder:, prefix: "/")
+      self << Endpoint.new(name: name, method: method, builder: builder, prefix: File.join(@prefix, prefix))
     end
 
     def find(name:)
@@ -77,18 +86,24 @@ module Pakyow
     end
   end
 
+  require "pakyow/support/core_refinements/string/normalization"
+
   class Endpoint
+    using Support::Refinements::String::Normalization
+
     extend Forwardable
     def_delegators :@builder, :params, :source_location
 
-    attr_reader :name, :method, :builder
+    attr_reader :name, :method, :builder, :prefix
 
-    def initialize(name:, method:, builder:)
-      @name, @method, @builder = name.to_sym, method.to_sym, builder
+    def initialize(name:, method:, builder:, prefix: "/")
+      @name, @method, @builder, @prefix = name.to_sym, method.to_sym, builder, prefix
     end
 
     def path(hashlike_object = nil, **params)
-      @builder.call(**(hashlike_object || params).to_h)
+      String.normalize_path(
+        File.join(@prefix, @builder.call(**(hashlike_object || params).to_h).to_s)
+      )
     end
   end
 end

--- a/pakyow-core/lib/pakyow/endpoints.rb
+++ b/pakyow-core/lib/pakyow/endpoints.rb
@@ -43,6 +43,7 @@ module Pakyow
         end
       end
     end
+    deprecate :load, solution: "build endpoints explicitly"
 
     # Builds the path to a named route.
     #

--- a/pakyow-core/lib/pakyow/plugin/state.rb
+++ b/pakyow-core/lib/pakyow/plugin/state.rb
@@ -22,9 +22,6 @@ module Pakyow
         @plugin.state(:templates) << Presenter::Templates.new(
           @plugin.config.name,
           frontend_path,
-          config: {
-            prefix: @plugin.class.mount_path
-          },
           processor: Presenter::ProcessorCaller.new(
             @plugin.parent.state(:processor).map { |processor|
               processor.new(@plugin.parent)
@@ -42,7 +39,7 @@ module Pakyow
                 plugin_info[:partials].merge!(app_templates.includes)
               end
 
-              if app_info = app_templates.info(path)
+              if app_info = app_templates.info(File.join(@plugin.mount_path, path))
                 # Define the plugin view as the `plug` partial so that it can be included.
                 #
                 plugin_info[:partials][:plug] = Presenter::Views::Partial.from_object(

--- a/pakyow-core/spec/features/plugins/helpers_spec.rb
+++ b/pakyow-core/spec/features/plugins/helpers_spec.rb
@@ -15,10 +15,8 @@ RSpec.describe "accessing helpers within the plugin" do
 
       action :test
       def test(connection)
-        if connection.path == File.join(self.class.mount_path, "test-plugin/helpers")
-          connection.body = StringIO.new(@object.new(connection).test_helper)
-          connection.halt
-        end
+        connection.body = StringIO.new(@object.new(connection).test_helper)
+        connection.halt
       end
     end
   end
@@ -27,8 +25,8 @@ RSpec.describe "accessing helpers within the plugin" do
 
   let :app_def do
     Proc.new do
-      plug :testable, at: "/"
       plug :testable, at: "/foo", as: :foo
+      plug :testable, at: "/"
     end
   end
 

--- a/pakyow-core/spec/unit/endpoints_spec.rb
+++ b/pakyow-core/spec/unit/endpoints_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Pakyow::Endpoints do
       name: :foo_bar,
       method: :get,
       builder: Proc.new { |**params|
-        [self, params]
+        [self.class, params.inspect].join("__")
       }
     )
   end
@@ -15,12 +15,12 @@ RSpec.describe Pakyow::Endpoints do
 
   describe "#path" do
     it "builds a path to the named endpoint" do
-      expect(instance.path(:foo_bar)).to eq([self, {}])
+      expect(instance.path(:foo_bar)).to eq("/" + [self.class, {}.inspect].join("__"))
     end
 
     context "passed a hash" do
       it "builds a path to the named endpoint with the values" do
-        expect(instance.path(:foo_bar, foo: :bar)).to eq([self, { foo: :bar }])
+        expect(instance.path(:foo_bar, foo: :bar)).to eq("/" + [self.class, { foo: :bar }.inspect].join("__"))
       end
     end
 
@@ -36,7 +36,7 @@ RSpec.describe Pakyow::Endpoints do
           end
         end
 
-        expect(instance.path(:foo_bar, klass.new(foo: :bar))).to eq([self, { foo: :bar }])
+        expect(instance.path(:foo_bar, klass.new(foo: :bar))).to eq("/" + [self.class, { foo: :bar }.inspect].join("__"))
       end
     end
 

--- a/pakyow-presenter/lib/pakyow/plugin/helpers/presenter/rendering.rb
+++ b/pakyow-presenter/lib/pakyow/plugin/helpers/presenter/rendering.rb
@@ -11,7 +11,7 @@ module Pakyow
 
           prepend_methods do
             def render(view_path = nil, as: nil, modes: [:default])
-              super(File.join(@connection.app.class.mount_path, view_path), as: as, modes: modes)
+              super(view_path, as: as, modes: modes)
             rescue Pakyow::Presenter::UnknownPage
               # Try rendering the view from the app.
               #

--- a/pakyow-presenter/lib/pakyow/presenter/renderer.rb
+++ b/pakyow-presenter/lib/pakyow/presenter/renderer.rb
@@ -122,10 +122,6 @@ module Pakyow
             view_path.dup
           end
 
-          if connection.app.is_a?(Plugin) && connection.app.class.mount_path != "/"
-            presenter_path.gsub!(/^#{connection.app.class.mount_path}/, "")
-          end
-
           presenter = find_presenter(connection.app, presenter_path)
 
           expose!(connection)

--- a/pakyow-presenter/spec/features/endpoints/anchor_spec.rb
+++ b/pakyow-presenter/spec/features/endpoints/anchor_spec.rb
@@ -52,4 +52,18 @@ RSpec.describe "presenting a view that defines an anchor endpoint" do
       )
     end
   end
+
+  context "app is mounted at a non-root path" do
+    let :mount_path do
+      "/foo"
+    end
+
+    it "sets the href" do
+      expect(call("/foo/presentation/endpoints/anchor")[2]).to eq_sans_whitespace(
+        <<~HTML
+          <a href="/foo/posts" data-e="posts_list"></a>
+        HTML
+      )
+    end
+  end
 end

--- a/pakyow-presenter/spec/features/forms/csrf_spec.rb
+++ b/pakyow-presenter/spec/features/forms/csrf_spec.rb
@@ -73,7 +73,6 @@ RSpec.describe "forms csrf" do
         response_body = response[2]
         expect(response_body).to include("input type=\"hidden\" name=\"pw-authenticity-token\"")
 
-        pp response_body.match(/name=\"pw-authenticity-token\" value=\"([^\"]+)\"/)[1]
         authenticity_client_id, authenticity_digest = response_body.match(/name=\"pw-authenticity-token\" value=\"([^\"]+)\"/)[1].split("~")
         computed_digest = Pakyow::Support::MessageVerifier.digest(Base64.decode64(authenticity_client_id), key: $connection_verifier_key)
 

--- a/pakyow-routing/CHANGELOG.md
+++ b/pakyow-routing/CHANGELOG.md
@@ -2,6 +2,13 @@
 
   * `fix` **Build endpoints relative to the app mount path.**
 
+    *Related links:*
+    - [Pull Request #374][pr-374]
+    - [Commit d7ef764][d7ef764]
+
+[pr-374]: https://github.com/pakyow/pakyow/pull/374
+[d7ef764]: https://github.com/pakyow/pakyow/commit/d7ef76437f4c8948ac09d9b5be77bc02a44caa06
+
 # v1.0.2
 
   * `fix` **Incorrect connection path after reroute.**

--- a/pakyow-routing/CHANGELOG.md
+++ b/pakyow-routing/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.1.0 (unreleased)
+
+  * `fix` **Build endpoints relative to the app mount path.**
+
 # v1.0.2
 
   * `fix` **Incorrect connection path after reroute.**

--- a/pakyow-routing/lib/pakyow/routing/framework.rb
+++ b/pakyow-routing/lib/pakyow/routing/framework.rb
@@ -28,15 +28,7 @@ module Pakyow
 
           # Make controllers definable on the app.
           #
-          stateful :controller, isolated(:Controller) do |args, _opts|
-            if self.ancestors.include?(Plugin)
-              # When using plugins, prefix controller paths with the mount path.
-              #
-              name, matcher = Controller.send(:parse_name_and_matcher_from_args, *args)
-              path = File.join(@mount_path, Controller.send(:path_from_matcher, matcher).to_s)
-              args.replace([name, path])
-            end
-          end
+          stateful :controller, isolated(:Controller)
 
           # Load controllers for the app.
           #

--- a/pakyow-routing/lib/pakyow/routing/framework.rb
+++ b/pakyow-routing/lib/pakyow/routing/framework.rb
@@ -60,6 +60,16 @@ module Pakyow
             @global_controller = isolated(:Controller).new(self)
           end
 
+          # Register routes as endpoints.
+          #
+          after "initialize" do
+            unless Pakyow.env?(:prototype)
+              state(:controller).each do |controller|
+                controller.build_endpoints(endpoints)
+              end
+            end
+          end
+
           # Register controllers as pipeline actions.
           #
           after "initialize" do

--- a/pakyow-routing/spec/features/path_building_spec.rb
+++ b/pakyow-routing/spec/features/path_building_spec.rb
@@ -1,6 +1,63 @@
 RSpec.describe "path building" do
+  shared_examples :path_building do
+    it "returns nil when no path found" do
+      expect(call(File.join(mount_path, "/path/missing"))[2]).to eq("")
+    end
+
+    it "builds path to a default route" do
+      expect(call(File.join(mount_path, "/path/main_default"))[2]).to eq(mount_path)
+    end
+
+    it "builds path to a named route" do
+      expect(call(File.join(mount_path, "/path/main_foo"))[2]).to eq(File.join(mount_path, "/foo"))
+    end
+
+    it "builds path to a named route with params" do
+      expect(call(File.join(mount_path, "/path/main_bar"), params: { id: "123" })[2]).to eq(File.join(mount_path, "/bar/123"))
+    end
+
+    it "builds path to a grouped route" do
+      expect(call(File.join(mount_path, "/path/main_grouped_default"))[2]).to eq(mount_path)
+    end
+
+    it "builds path to a namespaced route" do
+      expect(call(File.join(mount_path, "/path/main_namespaced_default"))[2]).to eq(File.join(mount_path, "/ns"))
+    end
+
+    it "builds path to a deeply nested route" do
+      expect(call(File.join(mount_path, "/path/main_namespaced_deep_default"))[2]).to eq(File.join(mount_path, "/ns/deep"))
+    end
+
+    it "builds path to a resource route" do
+      expect(call(File.join(mount_path, "/path/posts_list"))[2]).to eq(File.join(mount_path, "/posts"))
+    end
+
+    it "builds path to a nested resource route" do
+      expect(call(File.join(mount_path, "/path/posts_comments_list"), params: { post_id: "123" })[2]).to eq(File.join(mount_path, "/posts/123/comments"))
+    end
+
+    it "builds path to a named internal route" do
+      expect(call(File.join(mount_path, "/path/main_internal_static"))[2]).to eq(File.join(mount_path, "/internal#foo"))
+    end
+
+    it "builds path to a named internal route with params" do
+      expect(call(File.join(mount_path, "/path/main_internal_params"), params: { id: "123" })[2]).to eq(File.join(mount_path, "/internal#123"))
+    end
+
+    it "builds path to a collection route within a resource" do
+      expect(call(File.join(mount_path, "/path/posts_meta"), params: { id: "123" })[2]).to eq(File.join(mount_path, "/posts/meta"))
+    end
+
+    it "builds path to a route within an unnamed controller" do
+      expect(call(File.join(mount_path, "/path/unnamed"))[2]).to eq(File.join(mount_path, "/unnamed"))
+    end
+
+    it "builds path to a route to a route with a hash" do
+      expect(call(File.join(mount_path, "/path/main_slug"), params: { slug: "foo" })[2]).to eq(File.join(mount_path, "#foo"))
+    end
+  end
+
   include_context "app"
-  using Pakyow::Support::DeepDup
 
   let :app_init do
     Proc.new {
@@ -59,59 +116,13 @@ RSpec.describe "path building" do
     }
   end
 
-  it "returns nil when no path found" do
-    expect(call("/path/missing")[2]).to eq("")
-  end
+  include_examples :path_building
 
-  it "builds path to a default route" do
-    expect(call("/path/main_default")[2]).to eq("/")
-  end
+  context "app is mounted at a non-root path" do
+    let :mount_path do
+      "/mounted"
+    end
 
-  it "builds path to a named route" do
-    expect(call("/path/main_foo")[2]).to eq("/foo")
-  end
-
-  it "builds path to a named route with params" do
-    expect(call("/path/main_bar", params: { id: "123" })[2]).to eq("/bar/123")
-  end
-
-  it "builds path to a grouped route" do
-    expect(call("/path/main_grouped_default")[2]).to eq("/")
-  end
-
-  it "builds path to a namespaced route" do
-    expect(call("/path/main_namespaced_default")[2]).to eq("/ns")
-  end
-
-  it "builds path to a deeply nested route" do
-    expect(call("/path/main_namespaced_deep_default")[2]).to eq("/ns/deep")
-  end
-
-  it "builds path to a resource route" do
-    expect(call("/path/posts_list")[2]).to eq("/posts")
-  end
-
-  it "builds path to a nested resource route" do
-    expect(call("/path/posts_comments_list", params: { post_id: "123" })[2]).to eq("/posts/123/comments")
-  end
-
-  it "builds path to a named internal route" do
-    expect(call("/path/main_internal_static")[2]).to eq("/internal#foo")
-  end
-
-  it "builds path to a named internal route with params" do
-    expect(call("/path/main_internal_params", params: { id: "123" })[2]).to eq("/internal#123")
-  end
-
-  it "builds path to a collection route within a resource" do
-    expect(call("/path/posts_meta", params: { id: "123" })[2]).to eq("/posts/meta")
-  end
-
-  it "builds path to a route within an unnamed controller" do
-    expect(call("/path/unnamed")[2]).to eq("/unnamed")
-  end
-
-  it "builds path to a route to a route with a hash" do
-    expect(call("/path/main_slug", params: { slug: "foo" })[2]).to eq("#foo")
+    include_examples :path_building
   end
 end

--- a/pakyow-routing/spec/features/redirecting_spec.rb
+++ b/pakyow-routing/spec/features/redirecting_spec.rb
@@ -47,4 +47,14 @@ RSpec.describe "redirecting requests" do
       expect(call("/redirect_with_custom_status")[0]).to eq(301)
     end
   end
+
+  context "app is mounted at a non-root path" do
+    let :mount_path do
+      "/foo"
+    end
+
+    it "redirects to a route" do
+      expect(call("/foo/redirect_to_route")[1]["location"]).to eq("/foo/destination")
+    end
+  end
 end

--- a/pakyow-routing/spec/features/rerouting_spec.rb
+++ b/pakyow-routing/spec/features/rerouting_spec.rb
@@ -184,4 +184,16 @@ RSpec.describe "rerouting requests" do
       end
     end
   end
+
+  context "app is mounted at a non-root path" do
+    let :mount_path do
+      "/foo"
+    end
+
+    it "reroutes to a route" do
+      res = call("/foo/reroute_to_route")
+      expect(res[0]).to eq(200)
+      expect(res[2]).to eq("destination")
+    end
+  end
 end

--- a/pakyow-routing/spec/features/security/redirecting_spec.rb
+++ b/pakyow-routing/spec/features/security/redirecting_spec.rb
@@ -3,14 +3,6 @@ RSpec.describe "securely redirecting requests" do
 
   let :app_def do
     Proc.new do
-      after :load do
-        @endpoints << Pakyow::Endpoint.new(
-          name: :remote, method: :get, builder: -> (*) {
-            "http://foo.com/destination"
-          }
-        )
-      end
-
       controller :redirect do
         get "/redirect" do
           redirect "/destination"
@@ -22,14 +14,6 @@ RSpec.describe "securely redirecting requests" do
 
         get "/redirect/remote/trusted" do
           redirect "http://foo.com/destination", trusted: true
-        end
-
-        get "/redirect/remote/endpoint" do
-          redirect :remote
-        end
-
-        get "/redirect/remote/endpoint/trusted" do
-          redirect :remote, trusted: true
         end
       end
     end
@@ -59,28 +43,6 @@ RSpec.describe "securely redirecting requests" do
     context "redirect is trusted" do
       it "redirects" do
         expect(call("/redirect/remote/trusted")[1]["location"]).to eq("http://foo.com/destination")
-      end
-    end
-  end
-
-  describe "redirecting to a remote endpoint" do
-    let :allow_request_failures do
-      true
-    end
-
-    it "does not redirect" do
-      expect(call("/redirect/remote/endpoint")[1]["location"]).to be(nil)
-    end
-
-    it "raises an error" do
-      call("/redirect/remote/endpoint")
-      expect(connection.error).to be_instance_of(Pakyow::Security::InsecureRedirect)
-      expect(connection.error.message).to eq("Cannot redirect to remote, untrusted location `http://foo.com/destination'")
-    end
-
-    context "redirect is trusted" do
-      it "redirects" do
-        expect(call("/redirect/remote/endpoint/trusted")[1]["location"]).to eq("http://foo.com/destination")
       end
     end
   end


### PR DESCRIPTION
Endpoints for apps mounted at non-root paths are now exposed correctly. 

Note that because this fix requires a significant change to how endpoints are registered (including a deprecation) it won't be backported to v1.0 and will be released with v1.1.