### PR TITLE
Remove Enumerable from Hookable

### DIFF
--- a/pakyow-support/CHANGELOG.md
+++ b/pakyow-support/CHANGELOG.md
@@ -155,6 +155,15 @@
 [59e6efe]: https://github.com/pakyow/pakyow/commit/59e6efe42f1d6f5d48d15359d2e1a63bea9a0600
 [787681d]: https://github.com/pakyow/pakyow/commit/787681dacbbd3ce79f6e38a5672749635903a85b
 
+# v1.0.3 (unreleased)
+
+  * `fix` **Hookable no longer makes including objects Enumerable**
+
+    *Related links:*
+    - [Pull Request #375][pr-375]
+
+[pr-375]: https://github.com/pakyow/pakyow/pull/375
+
 # v1.0.2
 
   * `fix` **Message verification no longer fails when the digest contains `--`.**

--- a/pakyow-support/lib/pakyow/support/hookable.rb
+++ b/pakyow-support/lib/pakyow/support/hookable.rb
@@ -134,8 +134,6 @@ module Pakyow
           end
         end
 
-        include Enumerable
-
         # @api private
         def each_hook(type, event, &block)
           return enum_for(:each_hook, type, event) unless block_given?


### PR DESCRIPTION
This had the unintended side-effect of making any hookable object enumerable, which can cause downstream issues.