### PR TITLE
Introduce config deprecations

### DIFF
--- a/pakyow-core/lib/pakyow/config.rb
+++ b/pakyow-core/lib/pakyow/config.rb
@@ -45,6 +45,8 @@ module Pakyow
         setting :secrets, [ENV["SECRET"].to_s.strip]
       end
 
+      config.deprecate :freeze_on_boot
+
       configurable :server do
         setting :host, "localhost"
         setting :port, 3000

--- a/pakyow-core/lib/pakyow/processes/proxy.rb
+++ b/pakyow-core/lib/pakyow/processes/proxy.rb
@@ -38,10 +38,10 @@ module Pakyow
             )
           end
 
-          if Pakyow.config.freeze_on_boot
-            Pakyow.deep_freeze
-          else
-            Pakyow.deprecated "config.freeze_on_boot", solution: "do not change this setting"
+          Pakyow.deprecator.ignore do
+            if Pakyow.config.freeze_on_boot
+              Pakyow.deep_freeze
+            end
           end
         end
       end

--- a/pakyow-core/lib/pakyow/processes/server.rb
+++ b/pakyow-core/lib/pakyow/processes/server.rb
@@ -29,10 +29,10 @@ module Pakyow
         Async::Reactor.run do
           Async::HTTP::Server.new(Pakyow, @endpoint, @protocol, @scheme).run
 
-          if Pakyow.config.freeze_on_boot
-            Pakyow.deep_freeze
-          else
-            Pakyow.deprecated "config.freeze_on_boot", solution: "do not change this setting"
+          Pakyow.deprecator.ignore do
+            if Pakyow.config.freeze_on_boot
+              Pakyow.deep_freeze
+            end
           end
         end
       end

--- a/pakyow-core/spec/deprecations/environment/config/freeze_on_boot_spec.rb
+++ b/pakyow-core/spec/deprecations/environment/config/freeze_on_boot_spec.rb
@@ -1,0 +1,7 @@
+RSpec.describe "Pakyow.config.freeze_on_boot deprecation" do
+  it "is deprecated" do
+    expect(Pakyow::Support::Deprecator.global).to receive(:deprecated).with("Pakyow.config.freeze_on_boot", solution: "do not use")
+
+    Pakyow.config.freeze_on_boot
+  end
+end

--- a/pakyow-support/CHANGELOG.md
+++ b/pakyow-support/CHANGELOG.md
@@ -1,5 +1,7 @@
 # v1.1.0 (unreleased)
 
+  * `add` **Introduce config deprecations.**
+
   * `chg` **Support deprecating dynamic instance methods defined on a singleton.**
 
     *Related links:*

--- a/pakyow-support/CHANGELOG.md
+++ b/pakyow-support/CHANGELOG.md
@@ -2,6 +2,9 @@
 
   * `add` **Introduce config deprecations.**
 
+    *Related links:*
+    - [Pull Request #379][pr-379]
+
   * `chg` **Support deprecating dynamic instance methods defined on a singleton.**
 
     *Related links:*
@@ -151,6 +154,7 @@
     *Related links:*
     - [Pull Request #364][pr-364]
 
+[pr-379]: https://github.com/pakyow/pakyow/pull/379
 [pr-378]: https://github.com/pakyow/pakyow/pull/378
 [pr-377]: https://github.com/pakyow/pakyow/pull/377
 [pr-376]: https://github.com/pakyow/pakyow/pull/376

--- a/pakyow-support/spec/integration/configurable/deprecating_spec.rb
+++ b/pakyow-support/spec/integration/configurable/deprecating_spec.rb
@@ -1,0 +1,257 @@
+require "pakyow/support/configurable"
+
+RSpec.describe "deprecating a setting" do
+  before do
+    allow(Pakyow::Support::Deprecator.global).to receive(:deprecated)
+  end
+
+  let(:object) {
+    Class.new {
+      include Pakyow::Support::Configurable
+      setting :name, :default
+
+      config.deprecate :name
+    }.tap do |object|
+      stub_const "Configurable", object
+    end
+  }
+
+  context "writing the setting" do
+    before do
+      object.configure do
+        config.name = :changed
+      end
+
+      object.configure!
+    end
+
+    it "reports the deprecation" do
+      expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(
+        "Configurable.config.name", solution: "do not use"
+      )
+    end
+
+    it "writes the setting" do
+      expect(object.config.name).to eq(:changed)
+    end
+  end
+
+  context "reading the setting" do
+    before do
+      object.configure!
+    end
+
+    let!(:value) {
+      object.config.name
+    }
+
+    it "reports the deprecation" do
+      expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(
+        "Configurable.config.name", solution: "do not use"
+      )
+    end
+
+    it "returns the value" do
+      expect(value).to eq(:default)
+    end
+  end
+
+  context "config is for an anonymous class" do
+    let(:object) {
+      Class.new {
+        include Pakyow::Support::Configurable
+        setting :name, :default
+
+        config.deprecate :name
+      }
+    }
+
+    before do
+      object.configure!
+      object.config.name
+    end
+
+    it "reports the deprecation" do
+      expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(
+        "config.name", solution: "do not use"
+      )
+    end
+  end
+
+  context "setting is in a group" do
+    let(:object) {
+      Class.new {
+        include Pakyow::Support::Configurable
+
+        configurable :group do
+          setting :name, :default
+          deprecate :name
+        end
+      }.tap do |object|
+        stub_const "Configurable", object
+      end
+    }
+
+    before do
+      object.configure do
+        config.group.name = :changed
+      end
+
+      object.configure!
+    end
+
+    it "reports the correct name" do
+      expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(
+        "Configurable.config.group.name", solution: "do not use"
+      )
+    end
+  end
+
+  context "setting is in a nested group" do
+    let(:object) {
+      Class.new {
+        include Pakyow::Support::Configurable
+
+        configurable :group1 do
+          configurable :group2 do
+            setting :name, :default
+            deprecate :name
+          end
+        end
+      }.tap do |object|
+        stub_const "Configurable", object
+      end
+    }
+
+    before do
+      object.configure do
+        config.group1.group2.name = :changed
+      end
+
+      object.configure!
+    end
+
+    it "reports the correct name" do
+      expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(
+        "Configurable.config.group1.group2.name", solution: "do not use"
+      )
+    end
+  end
+
+  describe "providing a solution" do
+    let(:object) {
+      Class.new {
+        include Pakyow::Support::Configurable
+
+        setting :name, :default
+        config.deprecate :name, solution: "use `other_name'"
+      }.tap do |object|
+        stub_const "Configurable", object
+      end
+    }
+
+    before do
+      object.configure!
+    end
+
+    let!(:value) {
+      object.config.name
+    }
+
+    it "reports the given solution" do
+      expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(
+        "Configurable.config.name", solution: "use `other_name'"
+      )
+    end
+  end
+end
+
+RSpec.describe "deprecating a group of settings" do
+  before do
+    allow(Pakyow::Support::Deprecator.global).to receive(:deprecated)
+  end
+
+  let(:object) {
+    Class.new {
+      include Pakyow::Support::Configurable
+
+      configurable :group do
+        setting :name, :default
+      end
+
+      config.deprecate :group
+    }.tap do |object|
+      stub_const "Configurable", object
+    end
+  }
+
+  context "writing a setting in the group" do
+    before do
+      object.configure do
+        config.group.name = :changed
+      end
+
+      object.configure!
+    end
+
+    it "reports the deprecation" do
+      expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(
+        "Configurable.config.group", solution: "do not use"
+      )
+    end
+
+    it "writes the setting" do
+      expect(object.config.group.name).to eq(:changed)
+    end
+  end
+
+  context "reading a setting in the group" do
+    before do
+      object.configure!
+    end
+
+    let!(:value) {
+      object.config.group.name
+    }
+
+    it "reports the deprecation" do
+      expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(
+        "Configurable.config.group", solution: "do not use"
+      )
+    end
+
+    it "returns the value" do
+      expect(value).to eq(:default)
+    end
+  end
+
+  describe "providing a solution" do
+    let(:object) {
+      Class.new {
+        include Pakyow::Support::Configurable
+
+        configurable :group do
+          setting :name, :default
+        end
+
+        config.deprecate :group, solution: "use `other_group'"
+      }.tap do |object|
+        stub_const "Configurable", object
+      end
+    }
+
+    before do
+      object.configure!
+    end
+
+    let!(:value) {
+      object.config.group.name
+    }
+
+    it "reports the given solution" do
+      expect(Pakyow::Support::Deprecator.global).to have_received(:deprecated).with(
+        "Configurable.config.group", solution: "use `other_group'"
+      )
+    end
+  end
+end


### PR DESCRIPTION
Allows config groups and settings to be deprecated. Reading/Writing the value of a deprecated setting, or a setting within a deprecated group, will report a deprecation to the global deprecator.

Replaces #350.