### PR TITLE
Only include values for attributes in relational results

### DIFF
--- a/pakyow-data/CHANGELOG.md
+++ b/pakyow-data/CHANGELOG.md
@@ -1,10 +1,16 @@
-# v1.1.0
+# v1.1.0 (unreleased)
+
+  * `fix` **Only include values for attributes in relational results.**
+
+    *Related links:*
+    - [Pull Request #382][pr-382]
 
   * `fix` **Fix an issue finalizing sqlite databases.**
 
     *Related links:*
     - [Pull Request #381][pr-381]
 
+[pr-382]: https://github.com/pakyow/pakyow/pull/382
 [pr-381]: https://github.com/pakyow/pakyow/pull/381
 
 # v1.0.2

--- a/pakyow-data/lib/pakyow/data/container.rb
+++ b/pakyow-data/lib/pakyow/data/container.rb
@@ -145,7 +145,7 @@ module Pakyow
               source.attribute(
                 association.foreign_key_field,
                 association.foreign_key_type,
-                foreign_key: association.associated_source_name
+                foreign_key: association.associated_source.dataset_table
               )
             end
           end

--- a/pakyow-data/lib/pakyow/data/sources/relational.rb
+++ b/pakyow-data/lib/pakyow/data/sources/relational.rb
@@ -261,7 +261,13 @@ module Pakyow
         private
 
         def finalize(result)
-          wrap(typecast(result))
+          wrap(typecast(filter_to_attributes(result)))
+        end
+
+        def filter_to_attributes(result)
+          result.keep_if { |key, _|
+            self.class.attributes.include?(key) || self.class.association_with_name?(key) || key[0..1] == "__"
+          }
         end
 
         def typecast(result)
@@ -308,7 +314,7 @@ module Pakyow
                   )
                 )
               else
-                aliased = SecureRandom.hex(4).to_sym
+                aliased = "__#{SecureRandom.hex(4)}".to_sym
 
                 if joining_source.class.container.connection == combined_source.class.container.connection
                   # Optimize with joins.


### PR DESCRIPTION
If a data source is connected to a table with lots of columns, only values that the source explicitly defines as attributes will be included in the result set. We don't want unexpected values to leak in!