### PR TITLE
Avoid deep duping during verification

### DIFF
--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `fix` **Avoid deep duping during verification.**
+
+    *Related links:*
+    - [Pull Request #386][pr-386]
+
   * `chg` **Setup applications on the class rather than the instance.**
 
     *Related links:*
@@ -135,6 +140,7 @@
     *Related links:*
     - [Pull Request #338][pr-338]
 
+[pr-386]: https://github.com/pakyow/pakyow/pull/386
 [pr-380]: https://github.com/pakyow/pakyow/pull/380
 [pr-374]: https://github.com/pakyow/pakyow/pull/374
 [pr-348]: https://github.com/pakyow/pakyow/pull/348

--- a/pakyow-core/lib/pakyow/behavior/verification.rb
+++ b/pakyow-core/lib/pakyow/behavior/verification.rb
@@ -1,17 +1,14 @@
 # frozen_string_literal: true
 
 require "pakyow/support/class_state"
-require "pakyow/support/deep_dup"
 require "pakyow/support/extension"
 
-require "pakyow/errors"
 require "pakyow/verifier"
 
 module Pakyow
   module Behavior
     module Verification
       extend Support::Extension
-      using Support::DeepDup
 
       def verify(values = nil, &block)
         unless values
@@ -22,14 +19,7 @@ module Pakyow
           end
         end
 
-        original_values = values.deep_dup
-        result = Pakyow::Verifier.new(&block).call(values, context: self)
-
-        unless result.verified?
-          error = InvalidData.new_with_message(:verification)
-          error.context = { object: original_values, result: result }
-          raise error
-        end
+        Pakyow::Verifier.new(&block).call!(values, context: self)
       end
 
       apply_extension do


### PR DESCRIPTION
This was terribly inefficient and, as it turns out, unnecessary.