### PR TITLE
Uninspectable

### DIFF
--- a/pakyow-support/CHANGELOG.md
+++ b/pakyow-support/CHANGELOG.md
@@ -1,5 +1,7 @@
 # v1.1.0 (unreleased)
 
+  * `chg` **`Inspectable` objects now inspect all instance state by default.**
+
   * `chg` **Build config classes for configurable objects.**
 
     *Related links:*

--- a/pakyow-support/CHANGELOG.md
+++ b/pakyow-support/CHANGELOG.md
@@ -2,7 +2,15 @@
 
   * `add` **Introduce `Inspectable::uninspectable` for opting out of inspecting specific object state.**
 
+    *Related links:*
+    - [Pull Request #387][pr-387]
+    - [Commit 8eefc4a][8eefc4a]
+
   * `chg` **`Inspectable` objects now inspect all instance state by default.**
+
+    *Related links:*
+    - [Pull Request #387][pr-387]
+    - [Commit 244d4f6][244d4f6]
 
   * `chg` **Build config classes for configurable objects.**
 
@@ -175,6 +183,7 @@
     *Related links:*
     - [Pull Request #364][pr-364]
 
+[pr-387]: https://github.com/pakyow/pakyow/pull/387
 [pr-384]: https://github.com/pakyow/pakyow/pull/384
 [pr-383]: https://github.com/pakyow/pakyow/pull/383
 [pr-379]: https://github.com/pakyow/pakyow/pull/379
@@ -202,6 +211,8 @@
 [pr-343]: https://github.com/pakyow/pakyow/pull/343
 [pr-340]: https://github.com/pakyow/pakyow/pull/340
 [pr-330]: https://github.com/pakyow/pakyow/pull/330
+[9ef221b]: https://github.com/pakyow/pakyow/commit/8eefc4ac6b6c04c0899471a12bc68e4edbc30f46
+[244d4f6]: https://github.com/pakyow/pakyow/commit/244d4f6d2e5f18a38bf20cd4a4fcf8e3913137b3
 [9ef221b]: https://github.com/pakyow/pakyow/commit/9ef221bcd671f37700d123fe852d0b316216f0d8
 [59d983b]: https://github.com/pakyow/pakyow/commit/59d983b3cc31fd92d4ed8616f25c9a20d15da27b
 [d410904]: https://github.com/pakyow/pakyow/commit/d4109047797e8e5d7f4233fe61a42ed472c96cd7

--- a/pakyow-support/CHANGELOG.md
+++ b/pakyow-support/CHANGELOG.md
@@ -1,5 +1,7 @@
 # v1.1.0 (unreleased)
 
+  * `add` **Introduce `Inspectable::uninspectable` for opting out of inspecting specific object state.**
+
   * `chg` **`Inspectable` objects now inspect all instance state by default.**
 
   * `chg` **Build config classes for configurable objects.**

--- a/pakyow-support/lib/pakyow/support/inspectable.rb
+++ b/pakyow-support/lib/pakyow/support/inspectable.rb
@@ -53,8 +53,8 @@ module Pakyow
         if recursive_inspect?
           "#{inspection} ...>"
         else
-          prevent_inspect_recursion do
-            if self.class.__inspectables.any?
+          if self.class.__inspectables.any?
+            prevent_inspect_recursion do
               inspection << " " + self.class.__inspectables.map { |inspectable|
                 value = if inspectable.to_s.start_with?("@")
                   instance_variable_get(inspectable)
@@ -64,9 +64,11 @@ module Pakyow
 
                 "#{inspectable}=#{value.inspect}"
               }.join(", ")
-            end
 
-            inspection.strip << ">"
+              inspection.strip << ">"
+            end
+          else
+            super
           end
         end
       end

--- a/pakyow-support/lib/pakyow/support/inspectable.rb
+++ b/pakyow-support/lib/pakyow/support/inspectable.rb
@@ -5,25 +5,43 @@ require "pakyow/support/extension"
 
 module Pakyow
   module Support
-    # Customize the inspector for an object.
+    # Customized inspection for any object.
     #
-    # @example
-    #   class FooBar
-    #     include Pakyow::Support::Inspectable
-    #     inspectable :@foo, :baz
+    # There are two modes:
     #
-    #     def initialize
-    #       @foo = :foo
-    #       @bar = :bar
-    #     end
+    #   1) Inspecting specific instance variables and methods.
     #
-    #     def baz
-    #       :baz
-    #     end
-    #   end
+    #      class FooBar
+    #        include Pakyow::Support::Inspectable
+    #        inspectable :@foo, :baz
     #
-    #   FooBar.instance.inspect
-    #   => #<FooBar:0x007fd3330248c0 @foo=:foo baz=:baz>
+    #        def initialize
+    #          @foo = :foo
+    #          @bar = :bar
+    #        end
+    #
+    #        def baz
+    #         :baz
+    #        end
+    #      end
+    #
+    #      FooBar.instance.inspect
+    #      => #<FooBar:0x007fd3330248c0 @foo=:foo baz=:baz>
+    #
+    #   2) Inspecting everything *except* one or more instance variables.
+    #
+    #      class FooBar
+    #        include Pakyow::Support::Inspectable
+    #        uninspectable :@foo
+    #
+    #        def initialize
+    #          @foo = :foo
+    #          @bar = :bar
+    #        end
+    #      end
+    #
+    #      FooBar.instance.inspect
+    #      => #<FooBar:0x007fd3330248c0 @bar=:bar>
     #
     module Inspectable
       extend Extension
@@ -32,6 +50,7 @@ module Pakyow
 
       apply_extension do
         class_state :__inspectables, inheritable: true, default: []
+        class_state :__uninspectables, inheritable: true, default: []
       end
 
       class_methods do
@@ -42,38 +61,56 @@ module Pakyow
         def inspectable(*inspectables)
           @__inspectables = inspectables.map(&:to_sym)
         end
+
+        # Sets the instance vars and public methods that should *not* be part of the inspection.
+        #
+        # @param uninspectables [Array<Symbol>] The list of instance variables and public methods.
+        #
+        def uninspectable(*uninspectables)
+          @__uninspectables = uninspectables.map(&:to_sym)
+        end
       end
 
       # Recursion protection based on:
       #   https://stackoverflow.com/a/5772445
       #
       def inspect
-        inspection = String.new("#<#{self.class}:#{self.object_id}")
+        inspection = String.new("#<#{self.class}:#{object_id}")
 
         if recursive_inspect?
           "#{inspection} ...>"
         else
-          if self.class.__inspectables.any?
-            prevent_inspect_recursion do
-              inspection << " " + self.class.__inspectables.map { |inspectable|
-                value = if inspectable.to_s.start_with?("@")
-                  instance_variable_get(inspectable)
-                else
-                  send(inspectable)
-                end
+          prevent_inspect_recursion do
+            each_inspectable do |inspectable|
+              value = if inspectable.to_s.start_with?("@")
+                instance_variable_get(inspectable)
+              else
+                send(inspectable)
+              end
 
-                "#{inspectable}=#{value.inspect}"
-              }.join(", ")
-
-              inspection.strip << ">"
+              inspection << ", #{inspectable}=#{value.inspect}"
             end
-          else
-            super
+
+            inspection.strip << ">"
           end
         end
       end
 
       private
+
+      def each_inspectable
+        inspectables = if self.class.__inspectables.any?
+          self.class.__inspectables
+        else
+          instance_variables
+        end
+
+        inspectables.each do |inspectable|
+          unless self.class.__uninspectables.include?(inspectable)
+            yield inspectable
+          end
+        end
+      end
 
       def inspected_objects
         Thread.current[:inspected_objects] ||= {}

--- a/pakyow-support/spec/unit/inspectable_spec.rb
+++ b/pakyow-support/spec/unit/inspectable_spec.rb
@@ -90,4 +90,23 @@ RSpec.describe Pakyow::Support::Inspectable do
       expect(instance.inspect).to include("...")
     end
   end
+
+  describe "opting out of inspection" do
+    let(:inspectable) {
+      Class.new {
+        include Pakyow::Support::Inspectable
+        uninspectable :@ivar_one
+
+        def initialize
+          @ivar_one = :one
+          @ivar_two = :two
+        end
+      }
+    }
+
+    it "inspects" do
+      expect(instance.inspect).to include("@ivar_two=:two")
+      expect(instance.inspect).not_to include("@ivar_one=:one")
+    end
+  end
 end

--- a/pakyow-support/spec/unit/inspectable_spec.rb
+++ b/pakyow-support/spec/unit/inspectable_spec.rb
@@ -41,6 +41,22 @@ RSpec.describe Pakyow::Support::Inspectable do
     expect(instance.inspect).to_not include("@ivar_two=:two")
   end
 
+  context "nothing is set as inspectable" do
+    let(:inspectable) {
+      Class.new {
+        include Pakyow::Support::Inspectable
+
+        def initialize
+          @ivar_one = :one
+        end
+      }
+    }
+
+    it "does a normal inspection" do
+      expect(instance.inspect).to include("@ivar_one=:one")
+    end
+  end
+
   context "inspecting a private method" do
     let :inspectable do
       Class.new do


### PR DESCRIPTION
Gives `Inspectable` objects a way to opt out of inspecting specific object state. To support this, `Inspectable` objects now inspect all instance variables by default (matching `Kernel#inspect`).