### PR TITLE
Introduce class-level verifiers

### DIFF
--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # v1.1.0 (unreleased)
 
+  * `add` **Introduce class-level verifiers, with the ability to call them from the verifiable instance.**
+
   * `add` **Specify default values from optional verified values.**
 
     *Related links:*

--- a/pakyow-core/lib/pakyow/operation.rb
+++ b/pakyow-core/lib/pakyow/operation.rb
@@ -19,15 +19,14 @@ module Pakyow
     include Support::Pipeline::Object
 
     include Behavior::Verification
-    verifies :__values
 
     extend Support::Deprecatable
 
     attr_reader :__values
 
     def initialize(**values)
+      verify(values)
       @__values = values
-
       values.each_pair do |key, value|
         instance_variable_set(:"@#{key}", value)
       end
@@ -78,18 +77,6 @@ module Pakyow
     deprecate :values, solution: "prefer value methods"
 
     class << self
-      # Perform input verification before performing the operation
-      #
-      # @see Pakyow::Verifier
-      #
-      def verify(&block)
-        define_method :__verify do
-          verify(&block)
-        end
-
-        action :__verify
-      end
-
       def handle(error = nil, &block)
         @__handlers[error || :global] = block
       end

--- a/pakyow-core/spec/features/verification/class_level_spec.rb
+++ b/pakyow-core/spec/features/verification/class_level_spec.rb
@@ -1,0 +1,230 @@
+require "pakyow/behavior/verification"
+
+RSpec.describe "defining and using class-level verifiers" do
+  let(:verifiable) {
+    Class.new do
+      include Pakyow::Behavior::Verification
+
+      verify do
+        optional :foo
+        optional :baz
+      end
+
+      verify :other do
+        optional :bar
+        optional :qux
+      end
+    end
+  }
+
+  let(:target) {
+    verifiable.new
+  }
+
+  describe "default verifier" do
+    context "verifiable object is not defined" do
+      context "values are passed" do
+        let(:values) {
+          {
+            foo: "foo",
+            bar: "bar",
+          }
+        }
+
+        before do
+          target.verify values
+        end
+
+        it "verifies the passed values" do
+          expect(values).to eq(foo: "foo")
+        end
+      end
+
+      context "values are not passed" do
+        it "raises an error" do
+          expect {
+            target.verify
+          }.to raise_error(RuntimeError) do |error|
+            expect(error.message).to eq("Expected values to be passed")
+          end
+        end
+      end
+    end
+
+    context "verifiable object is defined" do
+      let(:params) {
+        {
+          baz: "baz",
+          qux: "qux"
+        }
+      }
+
+      before do
+        local = self
+        verifiable.class_eval do
+          define_method :params do
+            local.params
+          end
+        end
+
+        verifiable.verifies :params
+      end
+
+      context "values are passed" do
+        let(:values) {
+          {
+            foo: "foo",
+            bar: "bar",
+          }
+        }
+
+        before do
+          target.verify values
+        end
+
+        it "verifies the passed values" do
+          expect(values).to eq(foo: "foo")
+        end
+
+        it "does not verify the verifiable object" do
+          expect(params).to eq(baz: "baz", qux: "qux")
+        end
+      end
+
+      context "values are not passed" do
+        before do
+          target.verify
+        end
+
+        it "verifies the verifiable object" do
+          expect(params).to eq(baz: "baz")
+        end
+      end
+    end
+  end
+
+  describe "named verifier" do
+    context "verifiable object is not defined" do
+      context "values are passed" do
+        let(:values) {
+          {
+            foo: "foo",
+            bar: "bar",
+          }
+        }
+
+        before do
+          target.verify :other, values
+        end
+
+        it "verifies the passed values" do
+          expect(values).to eq(bar: "bar")
+        end
+      end
+
+      context "values are not passed" do
+        it "raises an error" do
+          expect {
+            target.verify :other
+          }.to raise_error(RuntimeError) do |error|
+            expect(error.message).to eq("Expected values to be passed")
+          end
+        end
+      end
+    end
+
+    context "verifiable object is defined" do
+      let(:params) {
+        {
+          baz: "baz",
+          qux: "qux"
+        }
+      }
+
+      before do
+        local = self
+        verifiable.class_eval do
+          define_method :params do
+            local.params
+          end
+        end
+
+        verifiable.verifies :params
+      end
+
+      context "values are passed" do
+        let(:values) {
+          {
+            foo: "foo",
+            bar: "bar",
+          }
+        }
+
+        before do
+          target.verify :other, values
+        end
+
+        it "verifies the passed values" do
+          expect(values).to eq(bar: "bar")
+        end
+
+        it "does not verify the verifiable object" do
+          expect(params).to eq(baz: "baz", qux: "qux")
+        end
+      end
+
+      context "values are not passed" do
+        before do
+          target.verify :other
+        end
+
+        it "verifies the verifiable object" do
+          expect(params).to eq(qux: "qux")
+        end
+      end
+    end
+  end
+
+  describe "verifying with no default or named verifiers" do
+    let(:verifiable) {
+      Class.new do
+        include Pakyow::Behavior::Verification
+      end
+    }
+
+    let(:values) {
+      { foo: "foo" }
+    }
+
+    before do
+      target.verify values
+    end
+
+    it "does not fail" do
+      expect(values).to eq(foo: "foo")
+    end
+  end
+
+  describe "delegating to the default verifier" do
+    let(:verifiable) {
+      Class.new do
+        include Pakyow::Behavior::Verification
+
+        required :foo
+        optional :bar, default: "bar"
+      end
+    }
+
+    let(:values) {
+      { foo: "foo", baz: "baz" }
+    }
+
+    before do
+      target.verify values
+    end
+
+    it "delegates successfully" do
+      expect(values).to eq(foo: "foo", bar: "bar")
+    end
+  end
+end


### PR DESCRIPTION
Introduces class-level verifiers, making it possible to define verifiers on a verifiable class and perform verification on an instance of the verifiable class. Here's an example:

```ruby
class SomeObject
  include Pakyow::Behavior::Verification

  # Define the method to pull values from, if none are provided to the verifier (optional).
  #
  verifies :values

  # Define rules on the top-level, default verifier.
  #
  required :foo

  # Define a named verified with its own rules.
  #
  verify :permissive do
    optional :foo
  end

  attr_reader :values

  def initialize(type = :strict, **values)
    @values = values

    case type
    when :strict
      verify
    else
      verify type
    end
  end
end

SomeObject.new(foo: "foo", bar: "bar").values
=> { foo: "foo" }

SomeObject.new(bar: "bar")
=> Pakyow::InvalidData

SomeObject.new(:permissive, bar: "bar").values
=> {}
```

**Operations, Controllers**

This PR also makes Operations and Controllers compatible with this pattern. Controllers should see a performance improvement since controller-level verifiers are now defined at runtime instead of request time. This prevents us from having to build a verifier on every request.