### PR TITLE
Define public readers and private writers for verified operation values

### DIFF
--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # v1.1.0 (unreleased)
 
+  * `add` **Define public readers and private writers for verified operation values.**
+    - This is a bit of an optimization and will allow aspects of an operation's api to be deprecated.
+
+    *Related links:*
+    - [Pull Request #392][pr-392]
+
   * `add` **Introduce class-level verifiers, with the ability to call them from the verifiable instance.**
 
     *Related links:*
@@ -162,6 +168,7 @@
     *Related links:*
     - [Pull Request #338][pr-338]
 
+[pr-392]: https://github.com/pakyow/pakyow/pull/392
 [pr-391]: https://github.com/pakyow/pakyow/pull/391
 [pr-390]: https://github.com/pakyow/pakyow/pull/390
 [pr-388]: https://github.com/pakyow/pakyow/pull/388

--- a/pakyow-core/lib/pakyow/verifier.rb
+++ b/pakyow-core/lib/pakyow/verifier.rb
@@ -83,6 +83,9 @@ module Pakyow
     extend Forwardable
     def_delegators :@validator, :validate
 
+    # @api private
+    attr_reader :allowable_keys
+
     def initialize(key = nil, &block)
       @key = key
       @types = {}

--- a/pakyow-core/spec/features/operation/getters_setters_spec.rb
+++ b/pakyow-core/spec/features/operation/getters_setters_spec.rb
@@ -18,4 +18,95 @@ RSpec.describe "using an operation's getters and setters" do
   it "defines a dynamic getter and setter for each value" do
     expect(app.operations.foo(values).foo).to eq("oof")
   end
+
+  context "setter is explicitly defined" do
+    let(:app_def) {
+      Proc.new {
+        operation :foo do
+          def foo=(value)
+            @foo = value.reverse
+          end
+
+          action do
+            @foo = foo.reverse
+          end
+        end
+      }
+    }
+
+    it "invokes the setter" do
+      expect(app.operations.foo(values).foo).to eq("foo")
+    end
+  end
+
+  describe "real methods for verified values" do
+    let(:app_def) {
+      Proc.new {
+        operation :foo do
+          required :foo
+          optional :bar
+        end
+      }
+    }
+
+    it "defines a real getter for required values" do
+      expect(app.operations.foo(values).class.method_defined?(:foo)).to be(true)
+    end
+
+    it "defines a real getter for optional values" do
+      expect(app.operations.foo(values).class.method_defined?(:bar)).to be(true)
+    end
+
+    it "privately defines a real setter for required values" do
+      expect(app.operations.foo(values).class.private_method_defined?(:foo=)).to be(true)
+    end
+
+    it "privately defines a real setter for optional values" do
+      expect(app.operations.foo(values).class.private_method_defined?(:bar=)).to be(true)
+    end
+
+    context "getters and setters are already defined" do
+      let(:app_def) {
+        Proc.new {
+          operation :foo do
+            def foo=(*)
+              @foo = "123"
+            end
+
+            def foo
+              @foo.reverse
+            end
+
+            required :foo
+          end
+        }
+      }
+
+      it "does not override them" do
+        expect(app.operations.foo(values).foo).to eq("321")
+      end
+    end
+
+    context "private getters and setters are already defined" do
+      let(:app_def) {
+        Proc.new {
+          operation :foo do
+            private def foo=(*)
+              @foo = "123"
+            end
+
+            private def foo
+              @foo.reverse
+            end
+
+            required :foo
+          end
+        }
+      }
+
+      it "does not override them" do
+        expect(app.operations.foo(values).send(:foo)).to eq("321")
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is a bit of an optimization and will allow aspects of an operation's api to be deprecated.