### PR TITLE
Typecast header values to strings

### DIFF
--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -228,6 +228,16 @@
 [d55e932]: https://github.com/pakyow/pakyow/commit/d55e9320dcca51ac7d12d8eef4f7f8aaf8faaa4f
 [26f586d]: https://github.com/pakyow/pakyow/commit/26f586d35c5fa0611cac6914fb2f249e3798ec79
 
+# v1.0.4 (unreleased)
+
+  * `fix` **Typecast header values to strings.**
+    - Resolves an incompatibility with `protocol-http`.
+
+    *Related links:*
+    - [Pull Request #400][pr-400]
+
+[pr-400]: https://github.com/pakyow/pakyow/pull/400
+
 # v1.0.3
 
   * `fix` **Resolve several issues with respawns, restarts.**

--- a/pakyow-core/lib/pakyow/connection.rb
+++ b/pakyow-core/lib/pakyow/connection.rb
@@ -90,7 +90,7 @@ module Pakyow
     end
 
     def set_header(key, value)
-      @headers[normalize_header(key)] = value
+      @headers[normalize_header(key)] = normalize_header_value(value)
     end
 
     def set_headers(headers)
@@ -395,6 +395,15 @@ module Pakyow
 
     def normalize_header(key)
       key.to_s.downcase.gsub("_", "-")
+    end
+
+    def normalize_header_value(value)
+      case value
+      when Array
+        value.map(&:to_s)
+      else
+        value.to_s
+      end
     end
 
     DELETE_COOKIE = {

--- a/pakyow-core/lib/pakyow/rack/compatibility.rb
+++ b/pakyow-core/lib/pakyow/rack/compatibility.rb
@@ -21,7 +21,7 @@ module Pakyow
       end
 
       def request_header(key)
-        normalize_header_value(key, @request.get_header(normalize_header(key)))
+        normalize_header_key_value(key, @request.get_header(normalize_header(key)))
       end
 
       def request_header?(key)
@@ -56,7 +56,7 @@ module Pakyow
         key.to_s.upcase.gsub("-", "_")
       end
 
-      def normalize_header_value(key, value)
+      def normalize_header_key_value(key, value)
         if value && policy = Protocol::HTTP::Headers::MERGE_POLICY[key.to_s.downcase.gsub("_", "-")]
           policy.new(value.to_s)
         else

--- a/pakyow-core/spec/unit/connection/shared_examples/headers.rb
+++ b/pakyow-core/spec/unit/connection/shared_examples/headers.rb
@@ -107,6 +107,20 @@ RSpec.shared_examples :connection_headers do
         expect(connection.header("foo-bar")).to eq("baz")
       end
     end
+
+    context "passed a non-string value" do
+      it "typecasts to a string" do
+        connection.set_header("content-length", 5)
+        expect(connection.header("content-length")).to eq("5")
+      end
+    end
+
+    context "passed an array of non-string values" do
+      it "typecasts each value to a string" do
+        connection.set_header("content-length", [1, 2, 3])
+        expect(connection.header("content-length")).to eq(["1", "2", "3"])
+      end
+    end
   end
 
   describe "#set_headers" do

--- a/pakyow-routing/spec/features/routing_spec.rb
+++ b/pakyow-routing/spec/features/routing_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "routing requests" do
     end
 
     it "responds with a valid content length header" do
-      expect(call("/", method: :head)[1]).to include("content-length" => 5)
+      expect(call("/", method: :head)[1]).to include("content-length" => "5")
     end
   end
 


### PR DESCRIPTION
Provides a workaround for https://github.com/socketry/protocol-http1/issues/5.