### PR TITLE
Remove the proxy pattern

### DIFF
--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -166,6 +166,10 @@
 
 ## Deprecations
 
+  * The environment's `server.proxy` config option is deprecated with no replacement.
+
+  * `Pakyow::Processes::Proxy` and `Pakyow::Processes::Proxy::Server` are deprecated with no replacement.
+
   * `Pakyow::Task` is deprecated in favor of `Pakyow::Command`.
 
     *Related links:*

--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
   * `fix` **Resolve several bugs related to the response body, `content-length` header, and `HEAD` requests.**
 
+    *Related links:*
+    - [Pull Request #402][pr-402]
+    - [Commit 45c89dd][45c89dd]
+
   * `fix` **Failing commands now exit with an error status.**
 
     *Related links:*
@@ -170,9 +174,21 @@
 
   * `Pakyow::Processes::Proxy::find_local_port` is deprecated, replaced with `Pakyow::Support::System::available_port`.
 
+    *Related links:*
+    - [Pull Request #402][pr-402]
+    - [Commit be0e450][be0e450]
+
   * The environment's `server.proxy` config option is deprecated with no replacement.
 
+    *Related links:*
+    - [Pull Request #402][pr-402]
+    - [Commit 7c9850c][7c9850c]
+
   * `Pakyow::Processes::Proxy` and `Pakyow::Processes::Proxy::Server` are deprecated with no replacement.
+
+    *Related links:*
+    - [Pull Request #402][pr-402]
+    - [Commit 7c9850c][7c9850c]
 
   * `Pakyow::Task` is deprecated in favor of `Pakyow::Command`.
 
@@ -214,6 +230,7 @@
     *Related links:*
     - [Pull Request #338][pr-338]
 
+[pr-402]: https://github.com/pakyow/pakyow/pull/402
 [pr-401]: https://github.com/pakyow/pakyow/pull/401
 [pr-399]: https://github.com/pakyow/pakyow/pull/399
 [pr-398]: https://github.com/pakyow/pakyow/pull/398
@@ -241,6 +258,9 @@
 [pr-301]: https://github.com/pakyow/pakyow/pull/301
 [is-298]: https://github.com/pakyow/pakyow/issues/298
 [pr-297]: https://github.com/pakyow/pakyow/pull/297
+[45c89dd]: https://github.com/pakyow/pakyow/commit/45c89ddb3f3ecdef61524eedfa08c3bc8e16696d
+[be0e450]: https://github.com/pakyow/pakyow/commit/be0e45092f31f038c10dc287cc96a887e092d146
+[7c9850c]: https://github.com/pakyow/pakyow/commit/7c9850ce123a5bf714ad91b485e180ee60a014c2
 [7f0df61]: https://github.com/pakyow/pakyow/commit/7f0df61a917b948030b0c44243bdb434e76c999c
 [3268e57]: https://github.com/pakyow/pakyow/commit/3268e57203e13c3c448f67585d29e3e2f67fe462
 [92f795e]: https://github.com/pakyow/pakyow/commit/92f795e88e1ca3106394d0581d51f17cf1a883ad

--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -166,6 +166,8 @@
 
 ## Deprecations
 
+  * `Pakyow::Processes::Proxy::find_local_port` is deprecated, replaced with `Pakyow::Support::System::available_port`.
+
   * The environment's `server.proxy` config option is deprecated with no replacement.
 
   * `Pakyow::Processes::Proxy` and `Pakyow::Processes::Proxy::Server` are deprecated with no replacement.

--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # v1.1.0 (unreleased)
 
+  * `fix` **Resolve several bugs related to the response body, `content-length` header, and `HEAD` requests.**
+
   * `fix` **Failing commands now exit with an error status.**
 
     *Related links:*

--- a/pakyow-core/lib/pakyow/commands/boot.rb
+++ b/pakyow-core/lib/pakyow/commands/boot.rb
@@ -11,11 +11,6 @@ command :boot, boot: false do
   action do
     Pakyow.config.server.host = @host
     Pakyow.config.server.port = @port
-
-    if @standalone
-      Pakyow.config.server.proxy = false
-    end
-
     Pakyow.run
   end
 end

--- a/pakyow-core/lib/pakyow/environment.rb
+++ b/pakyow-core/lib/pakyow/environment.rb
@@ -147,7 +147,9 @@ module Pakyow
     setting :host, "localhost"
     setting :port, 3000
     setting :count, 1
+
     setting :proxy, true
+    deprecate :proxy
 
     defaults :production do
       setting :proxy, false

--- a/pakyow-core/lib/pakyow/processes/proxy.rb
+++ b/pakyow-core/lib/pakyow/processes/proxy.rb
@@ -15,12 +15,13 @@ module Pakyow
       using Support::DeepFreeze
 
       class << self
+        extend Support::Deprecatable
+
         def find_local_port
-          server = TCPServer.new("127.0.0.1", 0)
-          port = server.addr[1]
-          server.close
-          port
+          Support::System.available_port
         end
+
+        deprecate :find_local_port, solution: "use `Pakyow::Support::System::available_port'"
       end
 
       def initialize(host:, port:, proxy_port:)

--- a/pakyow-core/lib/pakyow/processes/proxy.rb
+++ b/pakyow-core/lib/pakyow/processes/proxy.rb
@@ -1,10 +1,17 @@
 # frozen_string_literal: true
 
 require "pakyow/support/deep_freeze"
+require "pakyow/support/deprecatable"
+require "pakyow/support/system"
 
 module Pakyow
   module Processes
+    # @deprecated No longer used (will be removed in v2.0).
+    #
     class Proxy
+      extend Support::Deprecatable
+      deprecate
+
       using Support::DeepFreeze
 
       class << self
@@ -46,7 +53,12 @@ module Pakyow
         end
       end
 
+      # @deprecated No longer used (will be removed in v2.0).
+      #
       class Server
+        extend Support::Deprecatable
+        deprecate
+
         def initialize(port:, host:, forwarded:)
           @port, @host, @forwarded = port, host, forwarded
           @destination = "#{@host}:#{@port}"

--- a/pakyow-core/lib/pakyow/processes/server.rb
+++ b/pakyow-core/lib/pakyow/processes/server.rb
@@ -27,13 +27,13 @@ module Pakyow
 
       def run
         Async::Reactor.run do
-          Async::HTTP::Server.new(Pakyow, @endpoint, @protocol, @scheme).run
-
           Pakyow.deprecator.ignore do
             if Pakyow.config.freeze_on_boot
               Pakyow.deep_freeze
             end
           end
+
+          Async::HTTP::Server.new(Pakyow, @endpoint, @protocol, @scheme).run
         end
       end
     end

--- a/pakyow-core/spec/features/commands/boot_spec.rb
+++ b/pakyow-core/spec/features/commands/boot_spec.rb
@@ -41,10 +41,7 @@ RSpec.describe "cli: boot" do
     end
 
     context "running in standalone mode" do
-      it "boots in standalone mode" do
-        run_command(command, standalone: true, project: true)
-        expect(Pakyow.config.server.proxy).to eq(false)
-      end
+      it "needs tests once restartability is added back"
     end
   end
 end

--- a/pakyow-core/spec/features/requests_spec.rb
+++ b/pakyow-core/spec/features/requests_spec.rb
@@ -56,10 +56,6 @@ RSpec.describe "calling the environment with a request" do
       expect(call("/" + SecureRandom.hex(8), method: :head)[0]).to eq(200)
     end
 
-    it "responds with an empty body" do
-      expect(call("/" + SecureRandom.hex(8), method: :head)[2].length).to eq(0)
-    end
-
     it "responds with the connection headers" do
       expect(call("/" + SecureRandom.hex(8), method: :head)[1]).to include("foo" => ["bar"])
     end

--- a/pakyow-core/spec/integration/running/async_spec.rb
+++ b/pakyow-core/spec/integration/running/async_spec.rb
@@ -1,6 +1,10 @@
+require "pakyow/support/system"
+
 RSpec.describe "running an async task within the environment" do
   before do
+    Pakyow.setup(env: :test)
     Pakyow.config.server.host = "0.0.0.0"
+    Pakyow.config.server.port = Pakyow::Support::System.available_port
     allow(Pakyow).to receive(:start_processes).and_return(thread)
 
     local = self

--- a/pakyow-core/spec/integration/running/hooks_spec.rb
+++ b/pakyow-core/spec/integration/running/hooks_spec.rb
@@ -1,6 +1,10 @@
+require "pakyow/support/system"
+
 RSpec.describe "run hooks" do
   before do
+    Pakyow.setup(env: :test)
     Pakyow.config.server.host = "0.0.0.0"
+    Pakyow.config.server.port = Pakyow::Support::System.available_port
     allow(Pakyow).to receive(:start_processes).and_return(thread)
   end
 

--- a/pakyow-core/spec/unit/app_spec.rb
+++ b/pakyow-core/spec/unit/app_spec.rb
@@ -54,11 +54,7 @@ RSpec.describe Pakyow::Application do
 
         expect(connection.status).to eq(500)
 
-        response_body = String.new
-        while content = connection.body.read
-          response_body << content
-        end
-
+        response_body = connection.body.read
         expect(response_body).to include("failed to initialize")
         expect(response_body).to include("testing rescue mode")
         expect(response_body).to include("pakyow-core/spec/unit/app_spec.rb")
@@ -83,11 +79,7 @@ RSpec.describe Pakyow::Application do
 
         expect(connection.status).to eq(500)
 
-        response_body = String.new
-        while content = connection.body.read
-          response_body << content
-        end
-
+        response_body = connection.body.read
         expect(response_body).to include("failed to initialize")
         expect(response_body).to include("syntax error, unexpected end-of-input")
         expect(response_body).to include("pakyow-core/spec/unit/app_spec.rb")
@@ -155,11 +147,7 @@ RSpec.describe Pakyow::Application do
 
         expect(connection.status).to eq(500)
 
-        response_body = String.new
-        while content = connection.body.read
-          response_body << content
-        end
-
+        response_body = connection.body.read
         expect(response_body).to include("failed to initialize")
         expect(response_body).to include("testing rescue mode")
         expect(response_body).to include("pakyow-core/spec/unit/app_spec.rb")
@@ -184,11 +172,7 @@ RSpec.describe Pakyow::Application do
 
         expect(connection.status).to eq(500)
 
-        response_body = String.new
-        while content = connection.body.read
-          response_body << content
-        end
-
+        response_body = connection.body.read
         expect(response_body).to include("failed to initialize")
         expect(response_body).to include("syntax error, unexpected end-of-input")
         expect(response_body).to include("pakyow-core/spec/unit/app_spec.rb")

--- a/pakyow-core/spec/unit/connection/shared_examples/body.rb
+++ b/pakyow-core/spec/unit/connection/shared_examples/body.rb
@@ -21,8 +21,8 @@ RSpec.shared_examples :connection_body do
       connection.body = StringIO.new("foo")
     end
 
-    it "wraps the body" do
-      expect(connection.body).to be_instance_of(Async::HTTP::Body::Buffered)
+    it "sets the body" do
+      expect(connection.body).to be_instance_of(StringIO)
       expect(connection.body.read).to eq("foo")
     end
 

--- a/pakyow-core/spec/unit/connection_spec.rb
+++ b/pakyow-core/spec/unit/connection_spec.rb
@@ -204,9 +204,6 @@ RSpec.shared_examples :connection do
         expect(connection).to receive(:request_method).and_return("HEAD")
       end
 
-      it "closes the body"
-      it "replaces the body with an empty body"
-
       context "streaming" do
         it "stops the streaming tasks before closing" do
           Async::Reactor.run {
@@ -218,13 +215,12 @@ RSpec.shared_examples :connection do
               expect(stream).to receive(:stop)
             end
 
-            expect(connection.body).to receive(:close) do
-              expect(connection.streaming?).to be(false)
-            end
-
             expect(connection.streaming?).to be(true)
+
             connection.finalize
           }.wait
+
+          expect(connection.streaming?).to be(false)
         end
       end
     end

--- a/pakyow-core/spec/unit/environment/config_spec.rb
+++ b/pakyow-core/spec/unit/environment/config_spec.rb
@@ -96,6 +96,14 @@ RSpec.describe Pakyow do
         expect(Pakyow.config.server.proxy).to eq(true)
       end
 
+      it "is deprecated" do
+        expect(Pakyow::Support::Deprecator.global).to receive(:deprecated).with(
+          "Pakyow.config.server.proxy", { solution: "do not use" }
+        )
+
+        Pakyow.config.server.proxy
+      end
+
       context "in production" do
         before do
           Pakyow.configure!(:production)

--- a/pakyow-core/spec/unit/processes/proxy/server_spec.rb
+++ b/pakyow-core/spec/unit/processes/proxy/server_spec.rb
@@ -1,13 +1,14 @@
 RSpec.describe Pakyow::Processes::Proxy::Server do
-  it "initializes with a port, host, and forwarded for value"
+  before do
+    allow(Async::HTTP::Client).to receive(:new)
+    allow(Async::HTTP::Endpoint).to receive(:parse)
+  end
 
-  describe "#call" do
-    it "passes the request to the client"
-    it "adds x-forwarded-to header to the request"
+  it "is deprecated" do
+    expect(Pakyow::Support::Deprecator.global).to receive(:deprecated).with(
+      described_class, { solution: "do not use" }
+    )
 
-    context "request fails" do
-      it "sleeps then retries"
-      it "retries for 15s"
-    end
+    described_class.new(port: 3000, host: "localhost", forwarded: nil)
   end
 end

--- a/pakyow-core/spec/unit/processes/proxy_spec.rb
+++ b/pakyow-core/spec/unit/processes/proxy_spec.rb
@@ -6,4 +6,20 @@ RSpec.describe Pakyow::Processes::Proxy do
 
     described_class.new(port: 3000, host: "localhost", proxy_port: 3001)
   end
+
+  describe "::find_local_port" do
+    it "is deprecated" do
+      expect(Pakyow::Support::Deprecator.global).to receive(:deprecated).with(
+        described_class, :find_local_port, { solution: "use `Pakyow::Support::System::available_port'" }
+      )
+
+      described_class.find_local_port
+    end
+
+    it "returns an available port" do
+      allow(Pakyow::Support::System).to receive(:available_port).and_return(4242)
+
+      expect(described_class.find_local_port).to eq(4242)
+    end
+  end
 end

--- a/pakyow-core/spec/unit/processes/proxy_spec.rb
+++ b/pakyow-core/spec/unit/processes/proxy_spec.rb
@@ -1,12 +1,9 @@
 RSpec.describe Pakyow::Processes::Proxy do
-  it "initializes with a host, port, and proxy port"
+  it "is deprecated" do
+    expect(Pakyow::Support::Deprecator.global).to receive(:deprecated).with(
+      described_class, { solution: "do not use" }
+    )
 
-  describe "#run" do
-    it "runs the server in an async reactor"
-    it "prints the running text"
-
-    context "respawned" do
-      it "does not print the running text"
-    end
+    described_class.new(port: 3000, host: "localhost", proxy_port: 3001)
   end
 end

--- a/pakyow-presenter/spec/features/auto_render_spec.rb
+++ b/pakyow-presenter/spec/features/auto_render_spec.rb
@@ -32,18 +32,6 @@ RSpec.describe "automatically rendering when no controller is called" do
       end
     end
 
-    context "request method is head" do
-      it "responds with an empty body" do
-        response = call("/other", method: :head)
-        expect(response[0]).to eq(200)
-        expect(response[2].length).to eq(0)
-      end
-
-      it "sets the content length and content type headers to the expected value" do
-        expect(call("/other", method: :head)[1]).to include("content-type" => "text/html")
-      end
-    end
-
     context "request format is not html" do
       it "returns a 404" do
         expect(call("/other.json")[0]).to eq(404)

--- a/pakyow-presenter/spec/features/implicit_render_spec.rb
+++ b/pakyow-presenter/spec/features/implicit_render_spec.rb
@@ -40,18 +40,6 @@ RSpec.describe "implicitly rendering when a controller is called but does not re
       end
     end
 
-    context "request method is head" do
-      it "responds with an empty body" do
-        response = call("/other", method: :head)
-        expect(response[0]).to eq(200)
-        expect(response[2].length).to eq(0)
-      end
-
-      it "sets the content length and content type headers to the expected value" do
-        expect(call("/other", method: :head)[1]).to include("content-type" => "text/html")
-      end
-    end
-
     context "request format is not html" do
       it "returns a 404" do
         expect(call("/other.json")[0]).to eq(404)

--- a/pakyow-realtime/lib/pakyow/presenter/renderer/behavior/realtime/install_websocket.rb
+++ b/pakyow-realtime/lib/pakyow/presenter/renderer/behavior/realtime/install_websocket.rb
@@ -29,17 +29,10 @@ module Pakyow
                     Pakyow::Presenter::View.from_object(node)
                   end
                 } do
-                  endpoint = app.config.realtime.endpoint
-
-                  unless endpoint
-                    endpoint = if Pakyow.config.server.proxy
-                      # Connect directly to the app in development, since the proxy does not support websocket connections.
-                      #
-                      File.join("ws://#{Pakyow.config.server.host}:#{Pakyow.config.server.port}", app.config.realtime.path)
-                    else
-                      File.join("#{presentables[:__ws_protocol]}://#{presentables[:__ws_authority]}", app.config.realtime.path)
-                    end
-                  end
+                  endpoint = app.config.realtime.endpoint || File.join(
+                    "#{presentables[:__ws_protocol]}://#{presentables[:__ws_authority]}",
+                    app.config.realtime.path
+                  )
 
                   attributes["data-ui"] = "socket(global: true, endpoint: #{endpoint}?id=#{presentables[:__verifier].sign(presentables[:__socket_client_id])})"
                 end

--- a/pakyow-realtime/spec/features/installing_spec.rb
+++ b/pakyow-realtime/spec/features/installing_spec.rb
@@ -3,7 +3,6 @@ RSpec.describe "installing the socket" do
 
   before do
     allow(Pakyow::Support::MessageVerifier).to receive(:key).and_return("12321")
-    Pakyow.config.server.proxy = false
   end
 
   it "installs the socket" do
@@ -12,20 +11,6 @@ RSpec.describe "installing the socket" do
         <meta name="pw-socket" data-ui="socket(global: true, endpoint: ws://localhost/pw-socket?id=MTIzMjE=~FGhnpS-4JBlFz4V-78zKBAIr0m7e-Mf1mryud9JZt0U=)">
       HTML
     )
-  end
-
-  context "running in proxy mode" do
-    before do
-      Pakyow.config.server.proxy = true
-    end
-
-    it "configures the socket to connect directly to the app" do
-      expect(call("/")[2]).to include_sans_whitespace(
-        <<~HTML
-          <meta name="pw-socket" data-ui="socket(global: true, endpoint: ws://localhost:3000/pw-socket?id=MTIzMjE=~FGhnpS-4JBlFz4V-78zKBAIr0m7e-Mf1mryud9JZt0U=)">
-        HTML
-      )
-    end
   end
 
   context "secure request" do

--- a/pakyow-routing/lib/pakyow/routing/controller.rb
+++ b/pakyow-routing/lib/pakyow/routing/controller.rb
@@ -423,13 +423,11 @@ module Pakyow
           data = file_or_data
 
           if file_or_data.is_a?(File)
-            @connection.set_header("content-length", file_or_data.size)
             type ||= MiniMime.lookup_by_filename(file_or_data.path)&.content_type.to_s
           end
 
           @connection.set_header("content-type", type || DEFAULT_SEND_TYPE)
         elsif file_or_data.is_a?(String)
-          @connection.set_header("content-length", file_or_data.bytesize)
           @connection.set_header("content-type", type) if type
           data = StringIO.new(file_or_data)
         else

--- a/pakyow-routing/spec/features/routing_spec.rb
+++ b/pakyow-routing/spec/features/routing_spec.rb
@@ -73,14 +73,6 @@ RSpec.describe "routing requests" do
       call("/", method: :head)
       expect(Pakyow.apps.first.called).to be(true)
     end
-
-    it "responds with an empty body" do
-      expect(call("/", method: :head)[2].length).to eq(0)
-    end
-
-    it "responds with a valid content length header" do
-      expect(call("/", method: :head)[1]).to include("content-length" => "5")
-    end
   end
 
   context "when a default route is specified" do

--- a/pakyow-support/lib/pakyow/support/system.rb
+++ b/pakyow-support/lib/pakyow/support/system.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "pathname"
+require "socket"
 
 module Pakyow
   module Support
@@ -52,6 +53,13 @@ module Pakyow
 
       def ruby_gem_path_string
         @__ruby_gem_path_string ||= ruby_gem_path.to_s
+      end
+
+      def available_port
+        server = TCPServer.new("127.0.0.1", 0)
+        server.addr[1]
+      ensure
+        server.close
       end
     end
   end

--- a/spec/smoke/content_length_spec.rb
+++ b/spec/smoke/content_length_spec.rb
@@ -1,0 +1,31 @@
+require "smoke_helper"
+
+RSpec.describe "setting the content length header on the response", smoke: true do
+  before do
+    File.open(project_path.join("config/application.rb"), "w+") do |file|
+      file.write <<~SOURCE
+        Pakyow.app :smoke_test, only: %i[routing data] do
+          controller "/" do
+            default do
+              send "foo"
+            end
+          end
+        end
+      SOURCE
+    end
+
+    boot
+  end
+
+  it "is set" do
+    response = HTTP.get("http://localhost:#{port}/")
+    expect(response.headers["Content-Length"].to_i).to eq(3)
+  end
+
+  context "request is head" do
+    it "is set" do
+      response = HTTP.head("http://localhost:#{port}/")
+      expect(response.headers["Content-Length"].to_i).to eq(3)
+    end
+  end
+end

--- a/spec/smoke/database/bootstrap_spec.rb
+++ b/spec/smoke/database/bootstrap_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe "bootstrapping a database", smoke: true do
     project_path.join("config/application.rb").open("w+") do |file|
       file.write <<~SOURCE
         Pakyow.app :smoke_test do
+          configure do
+            config.assets.externals.fetch = false
+          end
+
           source :posts do
             attribute :title
           end

--- a/spec/smoke/database/create_spec.rb
+++ b/spec/smoke/database/create_spec.rb
@@ -15,6 +15,16 @@ RSpec.describe "creating a database", smoke: true do
       SOURCE
     end
 
+    project_path.join("config/application.rb").open("w+") do |file|
+      file.write <<~SOURCE
+        Pakyow.app :smoke_test do
+          configure do
+            config.assets.externals.fetch = false
+          end
+        end
+      SOURCE
+    end
+
     ensure_bundled "pg"
   end
 

--- a/spec/smoke/database/drop_spec.rb
+++ b/spec/smoke/database/drop_spec.rb
@@ -15,6 +15,16 @@ RSpec.describe "dropping a database", smoke: true do
       SOURCE
     end
 
+    project_path.join("config/application.rb").open("w+") do |file|
+      file.write <<~SOURCE
+        Pakyow.app :smoke_test do
+          configure do
+            config.assets.externals.fetch = false
+          end
+        end
+      SOURCE
+    end
+
     ensure_bundled "pg"
   end
 

--- a/spec/smoke/database/finalize_spec.rb
+++ b/spec/smoke/database/finalize_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe "finalizing a database", smoke: true do
     project_path.join("config/application.rb").open("w+") do |file|
       file.write <<~SOURCE
         Pakyow.app :smoke_test do
+          configure do
+            config.assets.externals.fetch = false
+          end
+
           source :posts do
             attribute :title
           end

--- a/spec/smoke/database/migrate_spec.rb
+++ b/spec/smoke/database/migrate_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe "migrating a database", smoke: true do
     project_path.join("config/application.rb").open("w+") do |file|
       file.write <<~SOURCE
         Pakyow.app :smoke_test do
+          configure do
+            config.assets.externals.fetch = false
+          end
+
           source :posts do
             attribute :title
           end

--- a/spec/smoke/database/reset_spec.rb
+++ b/spec/smoke/database/reset_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe "resetting a database", smoke: true do
     project_path.join("config/application.rb").open("w+") do |file|
       file.write <<~SOURCE
         Pakyow.app :smoke_test do
+          configure do
+            config.assets.externals.fetch = false
+          end
+
           source :posts do
             attribute :title
           end

--- a/spec/smoke/head_spec.rb
+++ b/spec/smoke/head_spec.rb
@@ -1,0 +1,29 @@
+require "smoke_helper"
+
+RSpec.describe "head requests", smoke: true do
+  before do
+    File.open(project_path.join("config/application.rb"), "w+") do |file|
+      file.write <<~SOURCE
+        Pakyow.app :smoke_test, only: %i[routing data] do
+          controller "/" do
+            default do
+              send "foo"
+            end
+          end
+        end
+      SOURCE
+    end
+
+    boot
+  end
+
+  it "sets an empty body" do
+    response = HTTP.head("http://localhost:#{port}/")
+    expect(response.body.to_s).to be_empty
+  end
+
+  it "sets the content-length header" do
+    response = HTTP.head("http://localhost:#{port}/")
+    expect(response.headers["Content-Length"].to_i).to eq(3)
+  end
+end

--- a/spec/smoke_helper.rb
+++ b/spec/smoke_helper.rb
@@ -2,7 +2,7 @@ require "bundler"
 require "http"
 require "fileutils"
 
-require "pakyow/processes/proxy"
+require "pakyow/support/system"
 
 module SmokeContext
   extend RSpec::SharedContext
@@ -16,7 +16,7 @@ module SmokeContext
   }
 
   let(:port) {
-    Pakyow::Processes::Proxy.find_local_port
+    Pakyow::Support::System.available_port
   }
 
   let(:environment) {


### PR DESCRIPTION
This pattern is completely irrelevant because of some changes to how processes are managed. Removing greatly simplifies things and lets us fix a handful of bugs that had been obfuscated.