### PR TITLE
Improve environment startup

### DIFF
--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -2,7 +2,13 @@
 
   * `chg` **Accept the environment name in `Pakyow::boot` and `Pakyow::run`.**
 
+    *Related links:*
+    - [Pull Request #410][pr-410]
+
   * `chg` **Setup the environment as part of the boot phase, and setup applications in `setup` instead of `boot`.**
+
+    *Related links:*
+    - [Pull Request #410][pr-410]
 
   * `fix` **Setup the default environment deprecator to be forwarded to from global.**
 
@@ -200,6 +206,9 @@
 
   * `Pakyow::load_apps` is deprecated with no replacement.
 
+    *Related links:*
+    - [Pull Request #410][pr-410]
+
   * `Pakyow::Processes::Proxy::find_local_port` is deprecated, replaced with `Pakyow::Support::System::available_port`.
 
     *Related links:*
@@ -258,6 +267,7 @@
     *Related links:*
     - [Pull Request #338][pr-338]
 
+[pr-410]: https://github.com/pakyow/pakyow/pull/410
 [pr-409]: https://github.com/pakyow/pakyow/pull/409
 [pr-406]: https://github.com/pakyow/pakyow/pull/406
 [pr-405]: https://github.com/pakyow/pakyow/pull/405

--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # v1.1.0 (unreleased)
 
+  * `chg` **Setup the environment as part of the boot phase, and setup applications in `setup` instead of `boot`.**
+
   * `fix` **Setup the default environment deprecator to be forwarded to from global.**
 
     *Related links:*
@@ -193,6 +195,8 @@
     - [Commit 26f586d][26f586d]
 
 ## Deprecations
+
+  * `Pakyow::load_apps` is deprecated with no replacement.
 
   * `Pakyow::Processes::Proxy::find_local_port` is deprecated, replaced with `Pakyow::Support::System::available_port`.
 

--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # v1.1.0 (unreleased)
 
+  * `chg` **Accept the environment name in `Pakyow::boot` and `Pakyow::run`.**
+
   * `chg` **Setup the environment as part of the boot phase, and setup applications in `setup` instead of `boot`.**
 
   * `fix` **Setup the default environment deprecator to be forwarded to from global.**

--- a/pakyow-core/lib/pakyow/behavior/running.rb
+++ b/pakyow-core/lib/pakyow/behavior/running.rb
@@ -55,6 +55,10 @@ module Pakyow
           )
         end
 
+        # Runs the environment by booting and starting all registered processes.
+        #
+        # @param env [Symbol] the environment to prepare for
+        #
         def run(env: nil)
           unless running?
             boot(env: env)

--- a/pakyow-core/lib/pakyow/behavior/running.rb
+++ b/pakyow-core/lib/pakyow/behavior/running.rb
@@ -55,9 +55,9 @@ module Pakyow
           )
         end
 
-        def run
+        def run(env: nil)
           unless running?
-            boot
+            boot(env: env)
 
             Async::Reactor.run do |reactor|
               @__reactor = reactor

--- a/pakyow-core/lib/pakyow/environment.rb
+++ b/pakyow-core/lib/pakyow/environment.rb
@@ -454,12 +454,12 @@ module Pakyow
 
     # Boots the environment without running it.
     #
-    def boot
+    def boot(env: nil)
       ensure_setup_succeeded
 
       unless booted?
         performing :boot do
-          setup
+          setup(env: env)
 
           # Mount each app.
           #

--- a/pakyow-core/lib/pakyow/environment.rb
+++ b/pakyow-core/lib/pakyow/environment.rb
@@ -393,7 +393,7 @@ module Pakyow
       @__loaded == true
     end
 
-    # Prepares the environment for booting.
+    # Prepares the environment for booting by setting up internal state, including applications.
     #
     # @param env [Symbol] the environment to prepare for
     #
@@ -452,7 +452,9 @@ module Pakyow
       @__setup == true
     end
 
-    # Boots the environment without running it.
+    # Boots the environment so that it can be used, without running it.
+    #
+    # @param env [Symbol] the environment to prepare for
     #
     def boot(env: nil)
       ensure_setup_succeeded

--- a/pakyow-core/spec/features/app/creating_spec.rb
+++ b/pakyow-core/spec/features/app/creating_spec.rb
@@ -101,8 +101,8 @@ RSpec.describe "creating an app" do
       end
     end
 
-    it "evals the given block during boot" do
-      Pakyow.boot
+    it "evals the given block during setup" do
+      Pakyow.setup
       expect(Test::Application.config.name).to eq(:foo)
     end
   end

--- a/pakyow-core/spec/features/requests_spec.rb
+++ b/pakyow-core/spec/features/requests_spec.rb
@@ -114,21 +114,19 @@ RSpec.describe "calling the environment with a request" do
       end
     end
 
-    before do
-      @calls = []
-    end
-
-    # Override `run` so we can mount a second app.
-    #
-    def run
+    let :env_def do
       local = self
-      Pakyow.app :test2 do
-        action do |connection|
-          local.instance_variable_get(:@calls) << :foo
+      Proc.new do
+        Pakyow.app :test2 do
+          action do |connection|
+            local.instance_variable_get(:@calls) << :foo
+          end
         end
       end
+    end
 
-      super
+    before do
+      @calls = []
     end
 
     it "calls both apps for requests to paths at the mounted path" do

--- a/pakyow-core/spec/integration/request_logging_spec.rb
+++ b/pakyow-core/spec/integration/request_logging_spec.rb
@@ -1,3 +1,5 @@
+require "pakyow/logger/destination"
+
 RSpec.describe "request logging" do
   let :logger do
     Pakyow::Logger.new(:http, output: Pakyow.output, level: Pakyow.config.logger.level)

--- a/pakyow-core/spec/unit/environment_spec.rb
+++ b/pakyow-core/spec/unit/environment_spec.rb
@@ -292,11 +292,6 @@ RSpec.describe Pakyow do
           Pakyow.load
         end
       end
-
-      it "calls load_apps" do
-        expect(Pakyow).to receive(:load_apps)
-        Pakyow.load
-      end
     end
 
     context "environment loader exists" do
@@ -360,15 +355,8 @@ RSpec.describe Pakyow do
       Pakyow.load_apps
     end
 
-    context "application config exists" do
-      before do
-        allow(File).to receive(:exist?).and_call_original
-        allow(File).to receive(:exist?).with(File.join(Pakyow.config.root, "config/application.rb")).and_return(true)
-      end
-
-      it "requires the application" do
-        expect(Pakyow).to receive(:require).with(File.join(Pakyow.config.root, "config/application")) do; end
-      end
+    it "is deprecated" do
+      expect(Pakyow::Support::Deprecator.global).to receive(:deprecated).with(Pakyow, :load_apps, { solution: "do not use" })
     end
   end
 
@@ -394,6 +382,19 @@ RSpec.describe Pakyow do
 
       it "uses the default name" do
         expect(Pakyow.env).to be(Pakyow.config.default_env)
+      end
+    end
+
+    context "application config exists" do
+      before do
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:exist?).with(File.join(Pakyow.config.root, "config/application.rb")).and_return(true)
+      end
+
+      it "requires the application" do
+        expect(Pakyow).to receive(:require).with(File.join(Pakyow.config.root, "config/application")) do; end
+
+        Pakyow.setup
       end
     end
 
@@ -510,7 +511,7 @@ RSpec.describe Pakyow do
       end
 
       let :logger do
-        double(:logger, houston: nil)
+        double(:logger, houston: nil, replace: nil)
       end
 
       it "exposes the error" do

--- a/pakyow-core/spec/unit/environment_spec.rb
+++ b/pakyow-core/spec/unit/environment_spec.rb
@@ -495,6 +495,14 @@ RSpec.describe Pakyow do
       perform
     end
 
+    context "passed an env" do
+      it "passes the env to setup" do
+        expect(Pakyow).to receive(:setup).with(env: :test)
+
+        Pakyow.boot(env: :test)
+      end
+    end
+
     context "something goes wrong" do
       before do
         allow(app_instance).to receive(:booted).and_raise(error)
@@ -712,17 +720,25 @@ RSpec.describe Pakyow do
   end
 
   describe "::run" do
-    describe "idempotence" do
-      before do
-        allow(Async::Reactor).to receive(:run) do |&block|
-          block.call
-        end
-
-        allow(Pakyow).to receive(:boot)
-        allow(Pakyow).to receive(:call_hooks)
-        allow(Pakyow).to receive(:start_processes).and_return(instance_double(Thread, join: nil))
+    before do
+      allow(Async::Reactor).to receive(:run) do |&block|
+        block.call
       end
 
+      allow(Pakyow).to receive(:boot)
+      allow(Pakyow).to receive(:call_hooks)
+      allow(Pakyow).to receive(:start_processes).and_return(instance_double(Thread, join: nil))
+    end
+
+    context "passed an env" do
+      it "passes the env to boot" do
+        expect(Pakyow).to receive(:boot).with(env: :test)
+
+        Pakyow.run(env: :test)
+      end
+    end
+
+    describe "idempotence" do
       it "is idempotent" do
         Pakyow.run
         Pakyow.run

--- a/pakyow-realtime/spec/features/persisting_state_spec.rb
+++ b/pakyow-realtime/spec/features/persisting_state_spec.rb
@@ -1,3 +1,5 @@
+require "pakyow/support/serializer"
+
 RSpec.describe "persisting state on shutdown" do
   include_context "app"
 

--- a/spec/context/app_context.rb
+++ b/spec/context/app_context.rb
@@ -26,6 +26,10 @@ RSpec.shared_context "app" do
     end
   end
 
+  let :env_def do
+    Proc.new {}
+  end
+
   let :app_def do
     Proc.new {}
   end
@@ -56,6 +60,7 @@ RSpec.shared_context "app" do
   def setup(env: :test)
     super if defined?(super)
     Pakyow.mount(app, at: mount_path)
+    Pakyow.class_eval(&env_def)
     Pakyow.setup(env: env)
   end
 


### PR DESCRIPTION
Makes it easier to interact with the environment in any of its key startup phases:

* `load`: Loads and configures the environment.
* `setup`: Sets up internal state, including applications. Introspection can be performed on the environment at this point, but it isn't completely ready to use (e.g. database connections are not established during the `setup` phase).
* `boot`: Fully boots the environment so that it's ready to use.
* `run`: Boots the environment and starts all registered processes.

Calling a phase will automatically trigger all the phases underneath it.