### PR TITLE
Assume all mounted applications are instances of Pakyow::Application

### DIFF
--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `chg` **Assume all mounted applications are instances of `Pakyow::Application`.**
+
+    *Related links:*
+    - [Pull Request #411][pr-411]
+
   * `chg` **Accept the environment name in `Pakyow::boot` and `Pakyow::run`.**
 
     *Related links:*
@@ -267,6 +272,7 @@
     *Related links:*
     - [Pull Request #338][pr-338]
 
+[pr-411]: https://github.com/pakyow/pakyow/pull/411
 [pr-410]: https://github.com/pakyow/pakyow/pull/410
 [pr-409]: https://github.com/pakyow/pakyow/pull/409
 [pr-406]: https://github.com/pakyow/pakyow/pull/406

--- a/pakyow-core/lib/pakyow/environment.rb
+++ b/pakyow-core/lib/pakyow/environment.rb
@@ -466,7 +466,7 @@ module Pakyow
           # Mount each app.
           #
           @apps = mounts.map { |mount|
-            initialize_app_for_mount(mount)
+            mount[:app].new(mount_path: mount[:path])
           }
 
           # Create the callable pipeline.
@@ -480,7 +480,7 @@ module Pakyow
 
           # Now tell each app that it has been booted.
           #
-          @apps.select { |app| app.respond_to?(:booted) }.each(&:booted)
+          @apps.each(&:booted)
         end
       end
 
@@ -549,15 +549,6 @@ module Pakyow
       load_apps_common
     end
     deprecate :load_apps
-
-    # @api private
-    def initialize_app_for_mount(mount)
-      if mount[:app].ancestors.include?(Pakyow::Application)
-        mount[:app].new(mount_path: mount[:path])
-      else
-        mount[:app].new
-      end
-    end
 
     private
 

--- a/pakyow-core/spec/unit/environment_spec.rb
+++ b/pakyow-core/spec/unit/environment_spec.rb
@@ -475,7 +475,7 @@ RSpec.describe Pakyow do
     end
 
     let :app_instance do
-      instance_double(Pakyow::Application)
+      instance_double(Pakyow::Application, booted: true)
     end
 
     it "calls after boot hooks" do
@@ -485,13 +485,6 @@ RSpec.describe Pakyow do
 
     it "calls booted on each app that responds to booted" do
       expect(app_instance).to receive(:booted)
-      perform
-    end
-
-    it "does not call booted on an app that does not respond to booted" do
-      allow(app_instance).to receive(:respond_to?)
-      allow(app_instance).to receive(:respond_to?).with(:booted).and_return(false)
-      expect(app_instance).to_not receive(:booted)
       perform
     end
 


### PR DESCRIPTION
The defensiveness around this continues to make adding new features more difficult. Since we don't actually have a use-case for running applications that aren't Pakyow Applications, removing this seems to be the right decision.