### PR TITLE
Ensure that defined state maintains the original definition order

### DIFF
--- a/pakyow-support/CHANGELOG.md
+++ b/pakyow-support/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `fix` **Ensure that defined state maintains the original definition order.**
+
+    *Related links:*
+    - [Pull Request #414][pr-414]
+
   * `fix` **Prevent multiple forwards to the same deprecator.**
 
     *Related links:*
@@ -213,6 +218,7 @@
     *Related links:*
     - [Pull Request #364][pr-364]
 
+[pr-414]: https://github.com/pakyow/pakyow/pull/414
 [pr-408]: https://github.com/pakyow/pakyow/pull/408
 [pr-403]: https://github.com/pakyow/pakyow/pull/403
 [pr-396]: https://github.com/pakyow/pakyow/pull/396

--- a/pakyow-support/lib/pakyow/support/definable/registry.rb
+++ b/pakyow-support/lib/pakyow/support/definable/registry.rb
@@ -23,7 +23,7 @@ module Pakyow
         attr_reader :builder, :parent, :definitions
 
         # @api private
-        PRIORITIES = { default: 0, high: 1, low: -1 }.freeze
+        PRIORITIES = { high: 1, default: 0, low: -1 }.freeze
 
         def initialize(name, object, parent:, namespace: [], builder: nil, lookup: nil, abstract: true)
           @name = name
@@ -162,8 +162,10 @@ module Pakyow
         end
 
         private def reprioritize!
-          @definitions.sort! { |a, b|
-            (@priorities[b] || 0) <=> (@priorities[a] || 0)
+          @definitions = @definitions.group_by { |definition|
+            @priorities[definition]
+          }.sort.reverse.flat_map { |_priority, definitions|
+            definitions
           }
         end
 

--- a/pakyow-support/spec/features/definable_spec.rb
+++ b/pakyow-support/spec/features/definable_spec.rb
@@ -95,6 +95,21 @@ RSpec.describe "defining state via definable" do
         "Test::Application::Controllers::Foo"
       ])
     end
+
+    context "with a numerical priority" do
+      before do
+        application.controller :qux, priority: -100 do; end
+      end
+
+      it "respects the priority" do
+        expect(application.controllers.each.map(&:name)).to eq([
+          "Test::Application::Controllers::Bar",
+          "Test::Application::Controllers::Baz",
+          "Test::Application::Controllers::Foo",
+          "Test::Application::Controllers::Qux"
+        ])
+      end
+    end
   end
 
   describe "defined state introspection" do
@@ -466,6 +481,22 @@ RSpec.describe "defining state via definable" do
       application.controllers(:foo) {}
 
       expect(application.controllers(:foo)).to be(Test::Application::Controllers::Foo)
+    end
+  end
+
+  describe "defined state order" do
+    before do
+      application.controller :foo do; end
+      application.controller :bar do; end
+      application.controller :baz do; end
+    end
+
+    it "maintains the definition order" do
+      expect(application.controllers.definitions).to eq([
+        Test::Application::Controllers::Foo,
+        Test::Application::Controllers::Bar,
+        Test::Application::Controllers::Baz
+      ])
     end
   end
 end


### PR DESCRIPTION
Note that the test case added here does not actually fail with the old approach. I wasn't able to see this fail outside of a complex real-world case that was difficult to reproduce. Adding an explicit test case for ordering felt like the next best option.