### PR TITLE
Introduce a dispatch event to the environment

### DIFF
--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `add` **Introduce a `dispatch` event to the environment.**
+
+    *Related links:*
+    - [Pull Request #432][pr-432]
+
   * `chg` **Ensure that environment dispatch happens after user-defined actions.**
 
     *Related links:*
@@ -308,6 +313,7 @@
     *Related links:*
     - [Pull Request #338][pr-338]
 
+[pr-432]: https://github.com/pakyow/pakyow/pull/432
 [pr-431]: https://github.com/pakyow/pakyow/pull/431
 [pr-418]: https://github.com/pakyow/pakyow/pull/418
 [pr-416]: https://github.com/pakyow/pakyow/pull/416

--- a/pakyow-core/lib/pakyow/behavior/dispatching.rb
+++ b/pakyow-core/lib/pakyow/behavior/dispatching.rb
@@ -11,14 +11,18 @@ module Pakyow
         after :setup do
           action :dispatch
         end
+
+        events :dispatch
       end
 
       # Dispatches the connection to an application.
       #
       def dispatch(connection)
-        apps.each do |app|
-          if connection.path.start_with?(app.mount_path)
-            app.call(connection)
+        performing :dispatch, connection: connection do
+          apps.each do |app|
+            if connection.path.start_with?(app.mount_path)
+              app.call(connection)
+            end
           end
         end
 

--- a/pakyow-core/spec/features/dispatch_hooks_spec.rb
+++ b/pakyow-core/spec/features/dispatch_hooks_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe "environment dispatch hooks" do
+  include_context "app"
+
+  let(:env_def) {
+    local = self
+
+    Proc.new {
+      before :dispatch do |*args, **kwargs|
+        local.calls[:before] << [args, kwargs]
+      end
+
+      after :dispatch do |*args, **kwargs|
+        local.calls[:after] << [args, kwargs]
+
+        kwargs[:connection].halt
+      end
+    }
+  }
+
+  before do
+    @calls = { before: [], after: [] }
+
+    call("/")
+  end
+
+  after do
+    @calls.clear
+  end
+
+  attr_reader :calls
+
+  it "calls before dispatch hooks" do
+    expect(@calls[:before]).not_to be_empty
+  end
+
+  it "passes the connection to before dispatch hooks" do
+    expect(@calls[:before][0][1][:connection]).to be_instance_of(Pakyow::Connection)
+  end
+
+  it "calls after dispatch hooks" do
+    expect(@calls[:after]).not_to be_empty
+  end
+
+  it "passes the connection to after dispatch hooks" do
+    expect(@calls[:after][0][1][:connection]).to be_instance_of(Pakyow::Connection)
+  end
+
+  it "calls after dispatch before handling as missing" do
+    expect(call("/")[0]).to eq(200)
+  end
+end

--- a/pakyow-core/spec/unit/environment/events_spec.rb
+++ b/pakyow-core/spec/unit/environment/events_spec.rb
@@ -23,5 +23,9 @@ RSpec.describe Pakyow do
     it "includes `run`" do
       expect(Pakyow.events).to include(:run)
     end
+
+    it "includes `dispatch`" do
+      expect(Pakyow.events).to include(:dispatch)
+    end
   end
 end


### PR DESCRIPTION
Dispatch is a terminal action, meaning it should always be the last action called. But sometimes it's necessary to perform work after dispatch. This change introduces a conceptual model for these cases that's separate from that of actions: any work done in a dispatch hook is considered to be part of the dispatch action itself.