### PR TITLE
Let applications define connection acceptance with an `#accept?` method

### DIFF
--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `add` **Let applications define connection acceptance with an `#accept?` method.**
+
+    *Related links:*
+    - [Pull Request #433][pr-433]
+
   * `add` **Introduce a `dispatch` event to the environment.**
 
     *Related links:*
@@ -313,6 +318,7 @@
     *Related links:*
     - [Pull Request #338][pr-338]
 
+[pr-433]: https://github.com/pakyow/pakyow/pull/433
 [pr-432]: https://github.com/pakyow/pakyow/pull/432
 [pr-431]: https://github.com/pakyow/pakyow/pull/431
 [pr-418]: https://github.com/pakyow/pakyow/pull/418

--- a/pakyow-core/lib/pakyow/application.rb
+++ b/pakyow-core/lib/pakyow/application.rb
@@ -223,6 +223,12 @@ module Pakyow
       raise ApplicationError.build(error, context: self)
     end
 
+    # Returns true if the application accepts the connection.
+    #
+    def accept?(connection)
+      connection.path.start_with?(mount_path)
+    end
+
     # Calls the app pipeline with a connection created from the rack env.
     #
     def call(connection)

--- a/pakyow-core/lib/pakyow/behavior/dispatching.rb
+++ b/pakyow-core/lib/pakyow/behavior/dispatching.rb
@@ -20,9 +20,7 @@ module Pakyow
       def dispatch(connection)
         performing :dispatch, connection: connection do
           apps.each do |app|
-            if connection.path.start_with?(app.mount_path)
-              app.call(connection)
-            end
+            app.call(connection) if app.accept?(connection)
           end
         end
 

--- a/pakyow-core/spec/features/app/accept_spec.rb
+++ b/pakyow-core/spec/features/app/accept_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe "defining an application accept method" do
+  include_context "app"
+
+  let(:app_def) {
+    Proc.new {
+      def accept?(connection)
+        connection.params.include?(:acceptable)
+      end
+
+      action do |connection|
+        connection.body = "accepted"
+        connection.halt
+      end
+    }
+  }
+
+  it "is called when the connection is acceptable" do
+    expect(call("/", params: { acceptable: true })[2]).to eq("accepted")
+  end
+
+  it "is called when the connection is not acceptable" do
+    expect(call("/")[2]).to eq("404 Not Found")
+  end
+end


### PR DESCRIPTION
By default, applications accept a connection if the connection path starts with the application path. This can be overridden as necessary through a new `Pakyow::Application#accept`? method.