### PR TITLE
Refactor Babel to be a Pakyow::Assets::Script

### DIFF
--- a/pakyow-assets/CHANGELOG.md
+++ b/pakyow-assets/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `chg` **Refactor Babel to be a `Pakyow::Assets::Script`.**
+
+    *Related links:*
+    - [Pull Request #439][pr-439]
+
   * `chg` **Replace uglifier with terser.**
 
     *Related links:*

--- a/pakyow-assets/lib/pakyow/application/behavior/assets/types/js.rb
+++ b/pakyow-assets/lib/pakyow/application/behavior/assets/types/js.rb
@@ -2,7 +2,7 @@
 
 require "pakyow/support/extension"
 
-require "pakyow/assets/babel"
+require "pakyow/assets/scripts/babel"
 require "pakyow/assets/scripts/terser"
 
 module Pakyow
@@ -31,7 +31,7 @@ module Pakyow
 
                 def process(content)
                   result = if transformable?
-                    transformed = Pakyow::Assets::Babel.transform(content, **@options)
+                    transformed = Pakyow::Assets::Scripts::Babel.transform(content, **@options)
                     { content: transformed["code"], map: transformed["map"] }
                   else
                     { content: content, map: "" }

--- a/pakyow-assets/lib/pakyow/assets/babel.rb
+++ b/pakyow-assets/lib/pakyow/assets/babel.rb
@@ -1,33 +1,20 @@
 # frozen_string_literal: true
 
-require "mini_racer"
-require "execjs"
+require "pakyow/support/deprecatable"
 
-require "pakyow/support/inflector"
+require "pakyow/assets/scripts/babel"
 
 module Pakyow
   module Assets
     class Babel
-      def self.transform(content, **options)
-        context.call("Babel.transform", content, camelize_keys(options))
-      end
+      class << self
+        extend Support::Deprecatable
 
-      private
+        def transform(content, **options)
+          Scripts::Babel.transform(content, **options)
+        end
 
-      def self.context
-        @context ||= ExecJS.compile(
-          File.read(
-            File.expand_path("../../../../src/@babel/standalone@7.9.4/babel.js", __FILE__)
-          )
-        )
-      end
-
-      def self.camelize_keys(options)
-        Hash[options.map { |key, value|
-          key = Support.inflector.camelize(key)
-          key = key[0, 1].downcase + key[1..-1]
-          [key, value]
-        }]
+        deprecate :transform, solution: "use `Pakyow::Assets::Scripts::Babel::transform'"
       end
     end
   end

--- a/pakyow-assets/lib/pakyow/assets/script.rb
+++ b/pakyow-assets/lib/pakyow/assets/script.rb
@@ -69,6 +69,15 @@ module Pakyow
             context.eval(function)
           end
         end
+
+        private def camelize_keys(hash)
+          Hash[hash.map { |key, value|
+            key = Support.inflector.camelize(key)
+            key = key[0, 1].downcase + key[1..-1]
+            value = camelize_keys(value) if value.is_a?(Hash)
+            [key, value]
+          }]
+        end
       end
     end
   end

--- a/pakyow-assets/lib/pakyow/assets/scripts/babel.rb
+++ b/pakyow-assets/lib/pakyow/assets/scripts/babel.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "pakyow/assets/script"
+
+module Pakyow
+  module Assets
+    module Scripts
+      # Transforms Javascript using Babel.
+      #
+      # @example
+      #   code = <<~CODE
+      #     class Rectangle {
+      #       constructor(foo) {
+      #         console.log(foo);
+      #       }
+      #     }
+      #   CODE
+      #
+      #   Pakyow::Assets::Scripts::Babel.transform(code, presets: ["es2015"])
+      #   => { code "...", ... }
+      #
+      class Babel < Script
+        dependency File.expand_path("../../../../../src/@babel/standalone@7.9.4/babel.js", __FILE__)
+
+        function :transform, <<~CODE
+          function transform(code, options) {
+            return Babel.transform(code, options);
+          }
+        CODE
+
+        class << self
+          def transform(code, **options)
+            super(code, camelize_keys(options))
+          end
+        end
+      end
+    end
+  end
+end

--- a/pakyow-assets/lib/pakyow/assets/types/js.rb
+++ b/pakyow-assets/lib/pakyow/assets/types/js.rb
@@ -2,7 +2,7 @@
 
 require "pakyow/support/deprecatable"
 
-require "pakyow/assets/asset"
+require "pakyow/assets/scripts/asset"
 require "pakyow/assets/scripts/terser"
 
 module Pakyow
@@ -28,7 +28,7 @@ module Pakyow
 
         def process(content)
           result = if transformable?
-            transformed = Babel.transform(content, **@options)
+            transformed = Scripts::Babel.transform(content, **@options)
             { content: transformed["code"], map: transformed["map"] }
           else
             { content: content, map: "" }

--- a/pakyow-assets/pakyow-assets.gemspec
+++ b/pakyow-assets/pakyow-assets.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "pakyow-support", Pakyow::VERSION
 
   spec.add_dependency "async-http", "~> 0.50.0"
-  spec.add_dependency "execjs", "~> 2.7"
   spec.add_dependency "mini_mime", "~> 1.0"
   spec.add_dependency "mini_racer", "~> 0.2.9"
   spec.add_dependency "sassc", "~> 2.2"

--- a/pakyow-assets/spec/unit/babel_spec.rb
+++ b/pakyow-assets/spec/unit/babel_spec.rb
@@ -1,45 +1,25 @@
 require "pakyow/assets/babel"
 
 RSpec.describe Pakyow::Assets::Babel do
-  describe "#transform" do
-    let :content do
-      ""
-    end
+  before do
+    allow(Pakyow::Assets::Scripts::Babel).to receive(:transform)
+  end
 
-    let :options do
-      {}
-    end
-
-    before do
-      described_class.send(:context)
-    end
-
-    it "calls Babel.transform with content and options" do
-      expect(described_class.context).to receive(:call).with(
-        "Babel.transform", content, options
+  describe "::transform" do
+    it "is deprecated" do
+      expect(Pakyow::Support::Deprecator.global).to receive(:deprecated).with(
+        Pakyow::Assets::Babel, :transform, solution: "use `Pakyow::Assets::Scripts::Babel::transform'"
       )
 
-      described_class.transform(content, **options)
+      described_class.transform("")
     end
 
-    it "returns the transformed content" do
-      allow(described_class.context).to receive(:call).and_return("transpiled")
-      expect(described_class.transform(content, **options)).to eq("transpiled")
-    end
-
-    it "only loads the execjs context once" do
-      described_class.instance_variable_set(:@context, nil)
-      expect(ExecJS).to receive(:compile).once.and_call_original
-      described_class.transform(content, **options)
-      described_class.transform(content, **options)
-    end
-
-    it "camelizes option keys" do
-      expect(described_class.context).to receive(:call).with(
-        "Babel.transform", content, { "fooBar" => "baz" }
+    it "calls Pakyow::Assets::Scripts::Babel::transform" do
+      expect(Pakyow::Assets::Scripts::Babel).to receive(:transform).with(
+        "code", foo: "bar"
       )
 
-      described_class.transform(content, foo_bar: "baz")
+      described_class.transform("code", foo: "bar")
     end
   end
 end

--- a/pakyow-assets/spec/unit/scripts/babel_spec.rb
+++ b/pakyow-assets/spec/unit/scripts/babel_spec.rb
@@ -1,0 +1,59 @@
+require "pakyow/assets/scripts/babel"
+
+RSpec.describe Pakyow::Assets::Scripts::Babel do
+  let(:code) {
+    <<~CODE
+      class Rectangle {
+        constructor(foo) {
+          console.log(foo);
+        }
+      }
+    CODE
+  }
+
+  after do
+    described_class.destroy
+  end
+
+  it "transforms" do
+    expect(described_class.transform(code, presets: ["es2015"])["code"]).to eq_sans_whitespace(
+      <<~CODE
+        "use strict";
+
+        function _instanceof(left, right) { if (right != null && typeof Symbol !== "undefined" && right[Symbol.hasInstance]) { return !!right[Symbol.hasInstance](left); } else { return left instanceof right; } }
+
+        function _classCallCheck(instance, Constructor) { if (!_instanceof(instance, Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+        var Rectangle = function Rectangle(foo) {
+          _classCallCheck(this, Rectangle);
+
+          console.log(foo);
+        };
+      CODE
+    )
+  end
+
+  describe "option remapping" do
+    before do
+      described_class.instance_variable_set(:@__context, context)
+    end
+
+    let(:context) {
+      double(call: nil)
+    }
+
+    let(:options) {
+      {
+        source_map: {}
+      }
+    }
+
+    it "camelizes options" do
+      expect(context).to receive(:call) do |function, code, passed_options|
+        expect(passed_options).to include("sourceMap")
+      end
+
+      described_class.transform(code, **options)
+    end
+  end
+end

--- a/pakyow-assets/spec/unit/types/js_spec.rb
+++ b/pakyow-assets/spec/unit/types/js_spec.rb
@@ -1,4 +1,5 @@
 require "pakyow/application/behavior/assets/types/js"
+require "pakyow/assets/asset"
 
 RSpec.describe Pakyow::Application::Behavior::Assets::Types::Js do
   let :config do
@@ -50,7 +51,7 @@ RSpec.describe Pakyow::Application::Behavior::Assets::Types::Js do
     end
 
     it "transpiles" do
-      expect(Pakyow::Assets::Babel).to receive(:transform).with(
+      expect(Pakyow::Assets::Scripts::Babel).to receive(:transform).with(
         content, **config.babel.to_h
       ).and_call_original
 
@@ -58,7 +59,7 @@ RSpec.describe Pakyow::Application::Behavior::Assets::Types::Js do
     end
 
     it "returns the transpiled code" do
-      allow(Pakyow::Assets::Babel).to receive(:transform).and_return(
+      allow(Pakyow::Assets::Scripts::Babel).to receive(:transform).and_return(
         "code" => "transpiled"
       )
 

--- a/spec/spec_config.rb
+++ b/spec/spec_config.rb
@@ -158,6 +158,14 @@ RSpec.configure do |config|
       end
     end
 
+    if defined?(Pakyow::Assets::Scripts::Babel)
+      Pakyow::Assets::Scripts::Babel.destroy
+    end
+
+    if defined?(Pakyow::Assets::Scripts::Terser)
+      Pakyow::Assets::Scripts::Terser.destroy
+    end
+
     remove_constants(
       (Object.constants - $original_constants).select { |constant_name|
         constant_name.to_s.start_with?("Test")


### PR DESCRIPTION
This makes `pakyow/assets` fully reliant on `mini_racer`. Goodbye `execjs`!