### PR TITLE
Add event/error handling to applications, connections, and the environment

### DIFF
--- a/pakyow-assets/spec/features/processing_spec.rb
+++ b/pakyow-assets/spec/features/processing_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe "processing an asset" do
         expect(call("/assets/nonexistent.css")[1]["content-type"]).to eq(nil)
       end
 
-      it "responds with an empty body" do
-        expect(call("/assets/nonexistent.css")[2]).to be_empty
+      it "responds with the default body" do
+        expect(call("/assets/nonexistent.css")[2]).to eq("404 Not Found")
       end
     end
   end
@@ -53,8 +53,8 @@ RSpec.describe "processing an asset" do
         expect(call("/assets/default.css")[1]["content-type"]).to eq(nil)
       end
 
-      it "responds with an empty body" do
-        expect(call("/assets/default.css")[2]).to be_empty
+      it "responds with the default body" do
+        expect(call("/assets/default.css")[2]).to eq("404 Not Found")
       end
     end
 
@@ -67,8 +67,8 @@ RSpec.describe "processing an asset" do
         expect(call("/assets/nonexistent.css")[1]["content-type"]).to eq(nil)
       end
 
-      it "responds with an empty body" do
-        expect(call("/assets/nonexistent.css")[2]).to be_empty
+      it "responds with the default body" do
+        expect(call("/assets/nonexistent.css")[2]).to eq("404 Not Found")
       end
     end
   end

--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # v1.1.0 (unreleased)
 
+  * `add` **Handle events and errors in the environment and application objects.**
+
   * `fix` **Log the epilogue even if another action halts.**
 
     *Related links:*

--- a/pakyow-core/lib/pakyow/actions/dispatch.rb
+++ b/pakyow-core/lib/pakyow/actions/dispatch.rb
@@ -15,26 +15,6 @@ module Pakyow
             app.call(connection)
           end
         end
-
-        unless connection.halted?
-          error_404(connection)
-        end
-      rescue StandardError => error
-        Pakyow.houston(error)
-        connection.error = error
-        error_500(connection)
-      end
-
-      private
-
-      def error_404(connection, message = "404 Not Found")
-        connection.status = 404
-        connection.body = StringIO.new(message)
-      end
-
-      def error_500(connection, message = "500 Server Error")
-        connection.status = 500
-        connection.body = StringIO.new(message)
       end
     end
   end

--- a/pakyow-core/lib/pakyow/actions/missing.rb
+++ b/pakyow-core/lib/pakyow/actions/missing.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Pakyow
+  module Actions
+    class Missing
+      def call(connection)
+        yield
+
+        unless connection.halted? || connection.streaming?
+          connection.trigger 404, connection: connection
+        end
+      end
+    end
+  end
+end

--- a/pakyow-core/lib/pakyow/application/actions/missing.rb
+++ b/pakyow-core/lib/pakyow/application/actions/missing.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Pakyow
+  class Application
+    module Actions
+      class Missing
+        def call(connection)
+          yield
+
+          unless connection.halted? || connection.streaming?
+            connection.trigger 404
+          end
+        end
+      end
+    end
+  end
+end

--- a/pakyow-core/lib/pakyow/connection/behavior/handling.rb
+++ b/pakyow-core/lib/pakyow/connection/behavior/handling.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "pakyow/support/extension"
+
+module Pakyow
+  class Connection
+    module Behavior
+      module Handling
+        extend Support::Extension
+
+        require "pakyow/handleable/behavior/statuses"
+        include_dependency Handleable::Behavior::Statuses
+
+        prepend_methods do
+          # Adds the connection to the triggered keyword arguments.
+          #
+          def trigger(event, *args, **kwargs)
+            super(event, *args, connection: self, **kwargs)
+          end
+        end
+      end
+    end
+  end
+end

--- a/pakyow-core/lib/pakyow/connection/statuses.rb
+++ b/pakyow-core/lib/pakyow/connection/statuses.rb
@@ -105,7 +105,6 @@ module Pakyow
           when Symbol
             SYMBOL_TO_CODE[code_or_symbol]
           else
-            code_or_symbol = code_or_symbol.to_i
             if CODE_TO_DESCRIPTION.key?(code_or_symbol)
               code_or_symbol
             else

--- a/pakyow-core/lib/pakyow/handleable/actions/handle.rb
+++ b/pakyow-core/lib/pakyow/handleable/actions/handle.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Pakyow
+  module Handleable
+    module Actions
+      class Handle
+        def call(connection)
+          connection.handling(connection: connection) do
+            yield
+          rescue => error
+            connection.error = error
+            Pakyow.houston(error)
+            raise error
+          end
+        rescue
+          connection.trigger 500
+        end
+      end
+    end
+  end
+end

--- a/pakyow-core/lib/pakyow/handleable/behavior/defaults/not_found.rb
+++ b/pakyow-core/lib/pakyow/handleable/behavior/defaults/not_found.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "pakyow/support/extension"
+
+module Pakyow
+  module Handleable
+    module Behavior
+      module Defaults
+        module NotFound
+          extend Support::Extension
+
+          apply_extension do
+            # The default 404 handler. Override this for custom 404 handling.
+            #
+            handle 404 do |event, connection:|
+              connection.headers.clear
+              connection.body = StringIO.new("404 Not Found")
+              connection.halt
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/pakyow-core/lib/pakyow/handleable/behavior/defaults/server_error.rb
+++ b/pakyow-core/lib/pakyow/handleable/behavior/defaults/server_error.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "pakyow/support/extension"
+
+module Pakyow
+  module Handleable
+    module Behavior
+      module Defaults
+        module ServerError
+          extend Support::Extension
+
+          apply_extension do
+            # The default 500 handler. Prefer overriding this instead of the top-level error handler.
+            #
+            handle 500 do |event, connection:|
+              connection.headers.clear
+              connection.body = StringIO.new("500 Server Error")
+              connection.halt
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/pakyow-core/lib/pakyow/handleable/behavior/statuses.rb
+++ b/pakyow-core/lib/pakyow/handleable/behavior/statuses.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "pakyow/support/extension"
+
+module Pakyow
+  module Handleable
+    module Behavior
+      module Statuses
+        extend Support::Extension
+
+        common_prepend_methods do
+          # Registers a handler that optionally sets the connection status to the value for `as` if
+          # a connection is passed as a keyword argument.
+          #
+          # @example
+          #   handle Sequel::NoMatchingRow, as: 404 do
+          #     ...
+          #   end
+          #
+          def handle(event = nil, as: nil, &block)
+            event = if code = Connection::Statuses.code(event)
+              code
+            else
+              event
+            end
+
+            if code = Connection::Statuses.code(as)
+              super(event) do |event, *args, **kwargs|
+                connection = kwargs[:connection]
+                connection&.status = code
+
+                if block
+                  instance_exec(event, *args, **kwargs, &block)
+                end
+
+                trigger code, *args, **kwargs
+              end
+            else
+              super(event, &block)
+            end
+          end
+
+          # Triggers `event`, passing any arguments to triggered handlers.
+          #
+          # Sets the connection status if `event` is an http status code or name and a connection is
+          # passed as a keyword argument.
+          #
+          def trigger(event, *args, **kwargs)
+            connection = kwargs[:connection]
+
+            if code = Connection::Statuses.code(event)
+              connection&.status = code
+              event = code
+            end
+
+            super(event, *args, **kwargs)
+
+            connection&.halt
+          end
+        end
+      end
+    end
+  end
+end

--- a/pakyow-core/lib/pakyow/plugin.rb
+++ b/pakyow-core/lib/pakyow/plugin.rb
@@ -3,6 +3,7 @@
 require "pakyow/support/class_state"
 require "pakyow/support/configurable"
 require "pakyow/support/definable"
+require "pakyow/support/handleable"
 require "pakyow/support/hookable"
 require "pakyow/support/makeable"
 require "pakyow/support/pipeline"
@@ -14,6 +15,8 @@ require "pakyow/application/behavior/helpers"
 require "pakyow/application/behavior/operations"
 require "pakyow/application/behavior/rescuing"
 require "pakyow/application/behavior/restarting"
+
+require "pakyow/handleable/behavior/statuses"
 
 require "pakyow/application"
 require "pakyow/endpoints"
@@ -67,6 +70,7 @@ module Pakyow
     end
 
     include Support::Definable
+    include Support::Handleable
     include Support::Hookable
     include Support::Makeable
     include Support::Pipeline
@@ -84,6 +88,8 @@ module Pakyow
     include Application::Behavior::Operations
     include Application::Behavior::Rescuing
     include Application::Behavior::Restarting
+
+    include Handleable::Behavior::Statuses
 
     attr_reader :parent
 

--- a/pakyow-core/spec/features/dispatch_hooks_spec.rb
+++ b/pakyow-core/spec/features/dispatch_hooks_spec.rb
@@ -11,8 +11,6 @@ RSpec.describe "environment dispatch hooks" do
 
       after :dispatch do |*args, **kwargs|
         local.calls[:after] << [args, kwargs]
-
-        kwargs[:connection].halt
       end
     }
   }
@@ -43,9 +41,5 @@ RSpec.describe "environment dispatch hooks" do
 
   it "passes the connection to after dispatch hooks" do
     expect(@calls[:after][0][1][:connection]).to be_instance_of(Pakyow::Connection)
-  end
-
-  it "calls after dispatch before handling as missing" do
-    expect(call("/")[0]).to eq(200)
   end
 end

--- a/pakyow-core/spec/features/erroring_spec.rb
+++ b/pakyow-core/spec/features/erroring_spec.rb
@@ -1,16 +1,74 @@
-RSpec.describe "handling errors when calling the environment" do
+RSpec.describe "handling errors during a request lifecycle" do
   before do
     allow(Pakyow).to receive(:houston)
   end
 
-  context "low-level error occurs" do
-    before do
-      Pakyow.action do |connection|
-        fail "something went wrong"
-      end
+  include_context "app"
+
+  let(:allow_request_failures) {
+    true
+  }
+
+  shared_examples :errors do
+    it "responds with the expected status" do
+      expect(call("/")[0]).to eq(500)
     end
 
-    include_context "app"
+    it "responds with the expected body" do
+      expect(call("/")[2]).to eq("500 Server Error")
+    end
+
+    it "sets the error on the connection" do
+      call("/")
+
+      expect(connection.error.message).to eq("something went wrong")
+    end
+
+    it "reports the error" do
+      expect(Pakyow).to receive(:houston) do |error|
+        expect(error.message).to eq("something went wrong")
+      end
+
+      call("/")
+    end
+  end
+
+  context "error occurs in the environment" do
+    let(:app_def) {
+      Proc.new {
+        Pakyow.action do
+          fail "something went wrong"
+        end
+      }
+    }
+
+    it_behaves_like :errors
+  end
+
+  context "error occurs in an application" do
+    let(:app_def) {
+      Proc.new {
+        action do
+          fail "something went wrong"
+        end
+      }
+    }
+
+    it_behaves_like :errors
+  end
+
+  context "error occurs within a handler" do
+    let(:app_def) {
+      Proc.new {
+        Pakyow.action do
+          fail "something went wrong"
+        end
+
+        Pakyow.handle do |*|
+          fail "something went wrong"
+        end
+      }
+    }
 
     it "responds with the expected status" do
       expect(call("/")[0]).to eq(500)
@@ -21,91 +79,7 @@ RSpec.describe "handling errors when calling the environment" do
     end
 
     it "responds with the expected body" do
-      expect(call("/")[2]).to eq("500 Low-Level Server Error")
-    end
-  end
-
-  context "error occurs during dispatch" do
-    include_context "app"
-
-    let :app_def do
-      Proc.new do
-        action do |connection|
-          fail "something went wrong"
-        end
-      end
-    end
-
-    let :allow_request_failures do
-      true
-    end
-
-    it "sets the error on the connection" do
-      expect_any_instance_of(Pakyow::Connection).to receive(:error=) do |_, error|
-        expect(error.message).to eq("something went wrong")
-      end
-
-      call("/")
-    end
-
-    it "reports the error" do
-      expect(Pakyow).to receive(:houston)
-
-      call("/")
-    end
-
-    it "responds with the expected status" do
-      expect(call("/")[0]).to eq(500)
-    end
-
-    it "responds with the expected body" do
       expect(call("/")[2]).to eq("500 Server Error")
-    end
-
-    context "app implements `controller_for_connection`" do
-      let :app_def do
-        local = self
-        Proc.new do
-          action do |connection|
-            fail "something went wrong"
-          end
-
-          define_method :controller_for_connection do |connection|
-            local.controller.new(connection)
-          end
-        end
-      end
-
-      let :controller do
-        Class.new do
-          def initialize(connection)
-            @connection = connection
-          end
-
-          def handle_error(error)
-            @connection.body = StringIO.new("handled: #{error}")
-            @connection.halt
-          end
-        end
-      end
-
-      it "lets the controller handle the error" do
-        expect(call("/")[2]).to eq("handled: something went wrong")
-      end
-
-      context "connection does not get created" do
-        before do
-          expect(Test::Application::Connection).to receive(:new) do
-            fail
-          end
-
-          expect(Pakyow.app(:test)).not_to receive(:controller_for_connection)
-        end
-
-        it "lets the app handle the error" do
-          expect(call("/")[2]).to eq("500 Server Error")
-        end
-      end
     end
   end
 end

--- a/pakyow-core/spec/features/handling/connection_spec.rb
+++ b/pakyow-core/spec/features/handling/connection_spec.rb
@@ -1,0 +1,289 @@
+RSpec.describe "handling events during a request lifecycle with connection handlers" do
+  include_context "app"
+
+  let(:global_handlers_def) {
+    Proc.new {
+      Pakyow.handle :foo do |connection:|
+        connection.body.write "foo_environment"
+      end
+
+      handle :foo do |connection:|
+        connection.body.write "foo_application"
+      end
+    }
+  }
+
+  context "connection defines a matching handler" do
+    let(:handlers_def) {
+      local = self
+
+      Proc.new {
+        instance_eval(&local.global_handlers_def)
+
+        action do |connection|
+          connection.handle :foo do
+            connection.body.write "foo_connection"
+          end
+        end
+      }
+    }
+
+    context "event is triggered on the environment" do
+      let(:app_def) {
+        local = self
+
+        Proc.new {
+          instance_eval(&local.handlers_def)
+
+          action do |connection|
+            Pakyow.trigger :foo, connection: connection
+          end
+        }
+      }
+
+      it "handles the event in the environment" do
+        expect(call("/")[2]).to eq("foo_environment")
+      end
+    end
+
+    context "event is triggered on the application" do
+      let(:app_def) {
+        local = self
+
+        Proc.new {
+          instance_eval(&local.handlers_def)
+
+          action do |connection|
+            trigger :foo, connection: connection
+          end
+        }
+      }
+
+      it "handles the event in the application" do
+        expect(call("/")[2]).to eq("foo_application")
+      end
+    end
+
+    context "event is triggered on the connection" do
+      let(:app_def) {
+        local = self
+
+        Proc.new {
+          instance_eval(&local.handlers_def)
+
+          action do |connection|
+            connection.trigger :foo
+          end
+        }
+      }
+
+      it "handles the event in the connection" do
+        expect(call("/")[2]).to eq("foo_connection")
+      end
+    end
+  end
+
+  context "connection does not define a matching handler" do
+    let(:handlers_def) {
+      local = self
+
+      Proc.new {
+        instance_eval(&local.global_handlers_def)
+      }
+    }
+
+    context "event is triggered in the environment connection" do
+      let(:app_def) {
+        local = self
+
+        Proc.new {
+          instance_eval(&local.handlers_def)
+
+          Pakyow.action do |connection|
+            connection.trigger :foo
+          end
+        }
+      }
+
+      it "handles the event in the environment" do
+        expect(call("/")[2]).to eq("foo_environment")
+      end
+    end
+
+    context "event is triggered in the application connection" do
+      let(:app_def) {
+        local = self
+
+        Proc.new {
+          instance_eval(&local.handlers_def)
+
+          action do |connection|
+            connection.trigger :foo
+          end
+        }
+      }
+
+      it "handles the event in the application" do
+        expect(call("/")[2]).to eq("foo_application")
+      end
+    end
+  end
+
+  context "event is an error" do
+    let(:allow_request_failures) {
+      true
+    }
+
+    let(:global_handlers_def) {
+      Proc.new {
+        Pakyow.handle RuntimeError do |connection:|
+          connection.body.write "foo_environment"
+        end
+
+        handle RuntimeError do |connection:|
+          connection.body.write "foo_application"
+        end
+      }
+    }
+
+    context "error occurs in the environment" do
+      let(:app_def) {
+        local = self
+
+        Proc.new {
+          instance_eval(&local.global_handlers_def)
+
+          Pakyow.action do |connection|
+            fail
+          end
+        }
+      }
+
+      it "handles the event in the environment" do
+        expect(call("/")[2]).to eq("foo_environment")
+      end
+    end
+
+    context "error occurs in the application" do
+      let(:app_def) {
+        local = self
+
+        Proc.new {
+          instance_eval(&local.global_handlers_def)
+
+          action do |connection|
+            fail
+          end
+        }
+      }
+
+      it "handles the event in the application" do
+        expect(call("/")[2]).to eq("foo_application")
+      end
+    end
+
+    context "environment connection defines a matching handler" do
+      let(:handlers_def) {
+        local = self
+
+        Proc.new {
+          instance_eval(&local.global_handlers_def)
+
+          Pakyow.action do |connection|
+            connection.handle RuntimeError do
+              connection.body.write "foo_environment_connection"
+            end
+          end
+        }
+      }
+
+      context "error occurs in the environment" do
+        let(:app_def) {
+          local = self
+
+          Proc.new {
+            instance_eval(&local.handlers_def)
+
+            Pakyow.action do |connection|
+              fail
+            end
+          }
+        }
+
+        it "handles the event in the environment connection" do
+          expect(call("/")[2]).to eq("foo_environment_connection")
+        end
+      end
+
+      context "error occurs in the application" do
+        let(:app_def) {
+          local = self
+
+          Proc.new {
+            instance_eval(&local.handlers_def)
+
+            action do |connection|
+              fail
+            end
+          }
+        }
+
+        it "handles the event in the application" do
+          expect(call("/")[2]).to eq("foo_application")
+        end
+      end
+    end
+
+    context "application connection defines a matching handler" do
+      let(:handlers_def) {
+        local = self
+
+        Proc.new {
+          instance_eval(&local.global_handlers_def)
+
+          action do |connection|
+            connection.handle RuntimeError do
+              connection.body.write "foo_application_connection"
+            end
+          end
+        }
+      }
+
+      context "error occurs in the environment" do
+        let(:app_def) {
+          local = self
+
+          Proc.new {
+            instance_eval(&local.handlers_def)
+
+            Pakyow.action do |connection|
+              fail
+            end
+          }
+        }
+
+        it "handles the event in the environment" do
+          expect(call("/")[2]).to eq("foo_environment")
+        end
+      end
+
+      context "error occurs in the application" do
+        let(:app_def) {
+          local = self
+
+          Proc.new {
+            instance_eval(&local.handlers_def)
+
+            action do |connection|
+              fail
+            end
+          }
+        }
+
+        it "handles the event in the application connection" do
+          expect(call("/")[2]).to eq("foo_application_connection")
+        end
+      end
+    end
+  end
+end

--- a/pakyow-core/spec/features/handling/errors_spec.rb
+++ b/pakyow-core/spec/features/handling/errors_spec.rb
@@ -1,0 +1,209 @@
+RSpec.describe "handling errors during a request lifecycle" do
+  include_context "app"
+
+  let(:response) {
+    call("/")
+  }
+
+  let(:allow_request_failures) {
+    true
+  }
+
+  describe "from the environment" do
+    let(:env_def) {
+      Proc.new {
+        action do
+          fail "something went wrong"
+        end
+      }
+    }
+
+    it "responds with the expected body" do
+      expect(response[0]).to eq(500)
+      expect(response[2]).to eq("500 Server Error")
+    end
+
+    context "connection headers were modified but the connection was not halted" do
+      let(:env_def) {
+        Proc.new {
+          action do |connection|
+            connection.headers["foo"] = "bar"
+            fail "something went wrong"
+          end
+        }
+      }
+
+      it "clears the headers" do
+        expect(response[1]).to be_empty
+      end
+    end
+
+    context "connection body was modified but the connection was not halted" do
+      let(:env_def) {
+        Proc.new {
+          action do |connection|
+            connection.body.write "foo"
+            fail "something went wrong"
+          end
+        }
+      }
+
+      it "returns the correct status" do
+        expect(response[0]).to eq(500)
+      end
+
+      it "returns the default body" do
+        expect(response[2]).to eq("500 Server Error")
+      end
+    end
+
+    context "500 handler is defined on the environment" do
+      let(:env_def) {
+        Proc.new {
+          handle 500 do |connection:|
+            connection.body.write "environment_handled"
+            connection.halt
+          end
+
+          action do
+            fail "something went wrong"
+          end
+        }
+      }
+
+      it "handles the error" do
+        expect(response[0]).to eq(500)
+        expect(response[2]).to eq("environment_handled")
+      end
+
+      context "500 handler does not halt" do
+        let(:env_def) {
+          Proc.new {
+            handle 500 do |connection:|
+              connection.body.write "environment_handled"
+            end
+
+            action do
+              fail "something went wrong"
+            end
+          }
+        }
+
+        it "calls the default 500 handler" do
+          expect(response[0]).to eq(500)
+          expect(response[2]).to eq("500 Server Error")
+        end
+      end
+    end
+
+    context "error handler is defined on the environment" do
+      let(:env_def) {
+        Proc.new {
+          handle ArgumentError do |connection:|
+            connection.body.write "environment_handled_argument_error"
+          end
+
+          action do |connection|
+            raise Kernel.const_get(connection.params[:error])
+          end
+        }
+      }
+
+      it "handles matching errors" do
+        response = call("/", params: { error: "ArgumentError" })
+
+        expect(response[0]).to eq(200)
+        expect(response[2]).to eq("environment_handled_argument_error")
+      end
+
+      it "does not handle unmatching errors" do
+        response = call("/", params: { error: "RuntimeError" })
+
+        expect(response[0]).to eq(500)
+        expect(response[2]).to eq("500 Server Error")
+      end
+    end
+  end
+
+  describe "from the application" do
+    let(:app_def) {
+      Proc.new {
+        action do
+          fail "something went wrong"
+        end
+      }
+    }
+
+    it "responds with the expected body" do
+      expect(response[0]).to eq(500)
+      expect(response[2]).to eq("500 Server Error")
+    end
+
+    context "500 handler is defined on the application" do
+      let(:app_def) {
+        Proc.new {
+          handle 500 do |connection:|
+            connection.body.write "application_handled"
+            connection.halt
+          end
+
+          action do
+            fail "something went wrong"
+          end
+        }
+      }
+
+      it "handles the error" do
+        expect(response[0]).to eq(500)
+        expect(response[2]).to eq("application_handled")
+      end
+
+      context "500 handler does not halt" do
+        let(:app_def) {
+          Proc.new {
+            handle 500 do |connection:|
+              connection.body.write "application_handled"
+            end
+
+            action do
+              fail "something went wrong"
+            end
+          }
+        }
+
+        it "calls the default 500 handler" do
+          expect(response[0]).to eq(500)
+          expect(response[2]).to eq("500 Server Error")
+        end
+      end
+    end
+
+    context "error handler is defined on the application" do
+      let(:app_def) {
+        Proc.new {
+          handle ArgumentError do |connection:|
+            connection.body.write "application_handled_argument_error"
+          end
+
+          action do |connection|
+            raise Kernel.const_get(connection.params[:error])
+          end
+        }
+      }
+
+      it "handles matching errors" do
+        response = call("/", params: { error: "ArgumentError" })
+
+        expect(response[0]).to eq(200)
+        expect(response[2]).to eq("application_handled_argument_error")
+      end
+
+      it "does not handle unmatching errors" do
+        response = call("/", params: { error: "RuntimeError" })
+
+        expect(response[0]).to eq(500)
+        expect(response[2]).to eq("500 Server Error")
+      end
+    end
+  end
+end

--- a/pakyow-core/spec/features/handling/events_spec.rb
+++ b/pakyow-core/spec/features/handling/events_spec.rb
@@ -1,0 +1,198 @@
+RSpec.describe "handling events during a request lifecycle" do
+  include_context "app"
+
+  let(:app_def) {
+    local = self
+
+    Proc.new {
+      Pakyow.handle :foo do |event, connection:|
+        local.handled = { event: event, connection: connection }
+      end
+
+      Pakyow.action do |connection|
+        trigger :foo, connection: connection
+      end
+    }
+  }
+
+  attr_accessor :handled
+
+  after do
+    @handled = nil
+  end
+
+  it "handles environment events with the environment handler" do
+    call("/")
+
+    expect(@handled).to_not be(nil)
+  end
+
+  it "passes keyword arguments to the handler" do
+    call("/")
+
+    expect(@handled[:connection]).to be_instance_of(Pakyow::Connection)
+  end
+
+  describe "the handling context" do
+    let(:app_def) {
+      local = self
+
+      Proc.new {
+        Pakyow.handle do
+          local.handled = self
+        end
+
+        Pakyow.action do
+          trigger :foo
+        end
+      }
+    }
+
+    it "handles in context of the environment" do
+      call("/")
+
+      expect(@handled).to be(Pakyow)
+    end
+  end
+
+  context "event is triggered on an application" do
+    let(:app_def) {
+      local = self
+      Proc.new {
+        Pakyow.handle :foo do
+          local.handled = true
+        end
+
+        action do
+          trigger :foo
+        end
+      }
+    }
+
+    it "handles application events with the environment handler" do
+      call("/")
+
+      expect(@handled).to be(true)
+    end
+
+    context "application handler is defined" do
+      before do
+        @handled = []
+      end
+
+      let(:app_def) {
+        local = self
+
+        Proc.new {
+          Pakyow.handle :foo do
+            local.handled << :environment_foo
+          end
+
+          Pakyow.handle :bar do
+            local.handled << :environment_bar
+          end
+
+          handle :foo do
+            local.handled << :application_foo
+          end
+
+          action do |connection|
+            trigger connection.params[:event].to_sym
+          end
+        }
+      }
+
+      it "handles matching application events with the first handler" do
+        call("/", params: { event: :foo })
+
+        expect(@handled).to eq([:application_foo])
+      end
+
+      it "handles other application events with the environment handler" do
+        call("/", params: { event: :bar })
+
+        expect(@handled).to eq([:environment_bar])
+      end
+
+      context "application handler halts" do
+        let(:app_def) {
+          local = self
+
+          Proc.new {
+            Pakyow.handle :foo do
+              local.handled << :environment_foo
+            end
+
+            handle :foo do
+              local.handled << :application_foo
+              throw :halt
+            end
+
+            action do |connection|
+              trigger connection.params[:event].to_sym
+            end
+          }
+        }
+
+        it "calls only the application handler" do
+          call("/", params: { event: :foo })
+
+          expect(@handled).to eq([:application_foo])
+        end
+      end
+
+      describe "the handling context" do
+        let(:app_def) {
+          local = self
+
+          Proc.new {
+            handle do
+              local.handled = self
+            end
+
+            action do
+              trigger :foo
+            end
+          }
+        }
+
+        it "handles in context of the application" do
+          call("/")
+
+          expect(@handled).to be(Pakyow.app(:test))
+        end
+      end
+
+      describe "halting event handling" do
+        before do
+          @handled = []
+        end
+
+        let(:app_def) {
+          local = self
+
+          Proc.new {
+            Pakyow.handle :foo do
+              local.handled << :environment_foo
+            end
+
+            handle :foo do
+              local.handled << :application_foo
+              throw :halt
+            end
+
+            action do |connection|
+              trigger connection.params[:event].to_sym
+            end
+          }
+        }
+
+        it "does not call environment handlers when halted in the application" do
+          call("/", params: { event: :foo })
+
+          expect(@handled).to eq([:application_foo])
+        end
+      end
+    end
+  end
+end

--- a/pakyow-core/spec/features/handling/missing_spec.rb
+++ b/pakyow-core/spec/features/handling/missing_spec.rb
@@ -1,0 +1,135 @@
+RSpec.describe "handling missing" do
+  include_context "app"
+
+  let(:response) {
+    call("/")
+  }
+
+  describe "in the environment" do
+    let(:mount_app) {
+      false
+    }
+
+    it "returns the default missing response" do
+      expect(response[0]).to eq(404)
+      expect(response[2]).to eq("404 Not Found")
+    end
+
+    context "connection headers were modified but the connection was not halted" do
+      let(:env_def) {
+        Proc.new {
+          action do |connection|
+            connection.headers["foo"] = "bar"
+          end
+        }
+      }
+
+      it "clears the headers" do
+        expect(response[1]).to be_empty
+      end
+    end
+
+    context "connection body was modified but the connection was not halted" do
+      let(:env_def) {
+        Proc.new {
+          action do |connection|
+            connection.body.write "foo"
+          end
+        }
+      }
+
+      it "returns the correct status" do
+        expect(response[0]).to eq(404)
+      end
+
+      it "returns the default body" do
+        expect(response[2]).to eq("404 Not Found")
+      end
+    end
+
+    context "404 handler is defined on the environment" do
+      let(:env_def) {
+        Proc.new {
+          handle 404 do |event, connection:|
+            connection.body.write "foo"
+            connection.halt
+          end
+        }
+      }
+
+      it "handles with the environment handler" do
+        expect(response[2]).to eq("foo")
+      end
+
+      context "404 handler does not halt" do
+        let(:env_def) {
+          Proc.new {
+            handle 404 do |event, connection:|
+              connection.body.write "foo"
+            end
+          }
+        }
+
+        it "calls the default 404 handler" do
+          expect(response[0]).to eq(404)
+          expect(response[2]).to eq("404 Not Found")
+        end
+      end
+    end
+  end
+
+  describe "in the application" do
+    it "returns the default missing response" do
+      expect(response[0]).to eq(404)
+      expect(response[2]).to eq("404 Not Found")
+    end
+
+    context "connection body was modified but the connection was not halted" do
+      let(:app_def) {
+        Proc.new {
+          action do |connection|
+            connection.body.write "foo"
+          end
+        }
+      }
+
+      it "returns the correct status" do
+        expect(response[0]).to eq(404)
+      end
+
+      it "returns the default body" do
+        expect(response[2]).to eq("404 Not Found")
+      end
+    end
+
+    context "404 handler is defined on the application" do
+      let(:app_def) {
+        Proc.new {
+          handle 404 do |event, connection:|
+            connection.body.write "foo"
+            connection.halt
+          end
+        }
+      }
+
+      it "handles with the application handler" do
+        expect(response[2]).to eq("foo")
+      end
+
+      context "404 handler does not halt" do
+        let(:app_def) {
+          Proc.new {
+            handle 404 do |event, connection:|
+              connection.body.write "foo"
+            end
+          }
+        }
+
+        it "calls the default 404 handler" do
+          expect(response[0]).to eq(404)
+          expect(response[2]).to eq("404 Not Found")
+        end
+      end
+    end
+  end
+end

--- a/pakyow-core/spec/features/handling/status_codes_spec.rb
+++ b/pakyow-core/spec/features/handling/status_codes_spec.rb
@@ -1,0 +1,929 @@
+RSpec.describe "handling status code events during a request lifecycle" do
+  include_context "app"
+
+  describe "triggering a status code event by name" do
+    context "triggering on the environment" do
+      let(:app_def) {
+        Proc.new {
+          Pakyow.action do |connection|
+            trigger :unauthorized, connection: connection
+          end
+        }
+      }
+
+      it "sets the response status" do
+        expect(call("/")[0]).to eq(401)
+      end
+
+      context "handler is defined on the environment" do
+        context "handler is defined by name" do
+          let(:app_def) {
+            Proc.new {
+              Pakyow.handle :unauthorized do |connection:|
+                connection.body = "unauthorized"
+              end
+
+              Pakyow.action do |connection|
+                trigger :unauthorized, connection: connection
+              end
+            }
+          }
+
+          it "sets the response status" do
+            expect(call("/")[0]).to eq(401)
+          end
+
+          it "handles the event" do
+            expect(call("/")[2]).to eq("unauthorized")
+          end
+        end
+
+        context "handler is defined by code" do
+          let(:app_def) {
+            Proc.new {
+              Pakyow.handle 401 do |connection:|
+                connection.body = "unauthorized"
+              end
+
+              Pakyow.action do |connection|
+                trigger :unauthorized, connection: connection
+              end
+            }
+          }
+
+          it "sets the response status" do
+            expect(call("/")[0]).to eq(401)
+          end
+
+          it "handles the event" do
+            expect(call("/")[2]).to eq("unauthorized")
+          end
+        end
+      end
+    end
+
+    context "triggering on the application" do
+      let(:app_def) {
+        Proc.new {
+          action do |connection|
+            trigger :unauthorized, connection: connection
+          end
+        }
+      }
+
+      it "sets the response status" do
+        expect(call("/")[0]).to eq(401)
+      end
+
+      context "handler is defined on the application" do
+        context "handler is defined by name" do
+          let(:app_def) {
+            Proc.new {
+              handle :unauthorized do |connection:|
+                connection.body = "unauthorized"
+              end
+
+              action do |connection|
+                trigger :unauthorized, connection: connection
+              end
+            }
+          }
+
+          it "sets the response status" do
+            expect(call("/")[0]).to eq(401)
+          end
+
+          it "handles the event" do
+            expect(call("/")[2]).to eq("unauthorized")
+          end
+        end
+
+        context "handler is defined by code" do
+          let(:app_def) {
+            Proc.new {
+              handle 401 do |connection:|
+                connection.body = "unauthorized"
+              end
+
+              action do |connection|
+                trigger :unauthorized, connection: connection
+              end
+            }
+          }
+
+          it "sets the response status" do
+            expect(call("/")[0]).to eq(401)
+          end
+
+          it "handles the event" do
+            expect(call("/")[2]).to eq("unauthorized")
+          end
+        end
+      end
+    end
+
+    context "triggering on the environment connection" do
+      let(:app_def) {
+        Proc.new {
+          Pakyow.action do |connection|
+            connection.trigger :unauthorized
+          end
+        }
+      }
+
+      it "sets the response status" do
+        expect(call("/")[0]).to eq(401)
+      end
+
+      context "handler is defined on the environment connection" do
+        context "handler is defined by name" do
+          let(:app_def) {
+            Proc.new {
+              Pakyow.handle :unauthorized do |connection:|
+                connection.body = "unauthorized"
+              end
+
+              Pakyow.action do |connection|
+                connection.trigger :unauthorized
+              end
+            }
+          }
+
+          it "sets the response status" do
+            expect(call("/")[0]).to eq(401)
+          end
+
+          it "handles the event" do
+            expect(call("/")[2]).to eq("unauthorized")
+          end
+        end
+
+        context "handler is defined by code" do
+          let(:app_def) {
+            Proc.new {
+              Pakyow.handle 401 do |connection:|
+                connection.body = "unauthorized"
+              end
+
+              Pakyow.action do |connection|
+                connection.trigger :unauthorized
+              end
+            }
+          }
+
+          it "sets the response status" do
+            expect(call("/")[0]).to eq(401)
+          end
+
+          it "handles the event" do
+            expect(call("/")[2]).to eq("unauthorized")
+          end
+        end
+      end
+    end
+
+    context "triggering on the application connection" do
+      let(:app_def) {
+        Proc.new {
+          action do |connection|
+            connection.trigger :unauthorized
+          end
+        }
+      }
+
+      it "sets the response status" do
+        expect(call("/")[0]).to eq(401)
+      end
+
+      context "handler is defined on the environment connection" do
+        context "handler is defined by name" do
+          let(:app_def) {
+            Proc.new {
+              handle :unauthorized do |connection:|
+                connection.body = "unauthorized"
+              end
+
+              action do |connection|
+                connection.trigger :unauthorized
+              end
+            }
+          }
+
+          it "sets the response status" do
+            expect(call("/")[0]).to eq(401)
+          end
+
+          it "handles the event" do
+            expect(call("/")[2]).to eq("unauthorized")
+          end
+        end
+
+        context "handler is defined by code" do
+          let(:app_def) {
+            Proc.new {
+              handle 401 do |connection:|
+                connection.body = "unauthorized"
+              end
+
+              action do |connection|
+                connection.trigger :unauthorized
+              end
+            }
+          }
+
+          it "sets the response status" do
+            expect(call("/")[0]).to eq(401)
+          end
+
+          it "handles the event" do
+            expect(call("/")[2]).to eq("unauthorized")
+          end
+        end
+      end
+    end
+  end
+
+  describe "triggering a status code event by code" do
+    context "triggering on the environment" do
+      context "handler is defined on the environment" do
+        context "handler is defined by name" do
+          let(:app_def) {
+            Proc.new {
+              Pakyow.handle :unauthorized do |connection:|
+                connection.body = "unauthorized"
+              end
+
+              Pakyow.action do |connection|
+                trigger 401, connection: connection
+              end
+            }
+          }
+
+          it "handles the event" do
+            expect(call("/")[2]).to eq("unauthorized")
+          end
+        end
+
+        context "handler is defined by code" do
+          let(:app_def) {
+            Proc.new {
+              Pakyow.handle 401 do |connection:|
+                connection.body = "unauthorized"
+              end
+
+              Pakyow.action do |connection|
+                trigger 401, connection: connection
+              end
+            }
+          }
+
+          it "handles the event" do
+            expect(call("/")[2]).to eq("unauthorized")
+          end
+        end
+      end
+    end
+
+    context "triggering on the application" do
+      let(:app_def) {
+        Proc.new {
+          action do |connection|
+            trigger 401
+          end
+        }
+      }
+
+      context "handler is defined on the application" do
+        context "handler is defined by name" do
+          let(:app_def) {
+            Proc.new {
+              handle :unauthorized do |connection:|
+                connection.body = "unauthorized"
+              end
+
+              action do |connection|
+                trigger 401, connection: connection
+              end
+            }
+          }
+
+          it "handles the event" do
+            expect(call("/")[2]).to eq("unauthorized")
+          end
+        end
+
+        context "handler is defined by code" do
+          let(:app_def) {
+            Proc.new {
+              handle 401 do |connection:|
+                connection.body = "unauthorized"
+              end
+
+              action do |connection|
+                trigger 401, connection: connection
+              end
+            }
+          }
+
+          it "handles the event" do
+            expect(call("/")[2]).to eq("unauthorized")
+          end
+        end
+      end
+    end
+
+    context "triggering on the environment connection" do
+      let(:app_def) {
+        Proc.new {
+          Pakyow.action do |connection|
+            connection.trigger 401
+          end
+        }
+      }
+
+      it "sets the response status" do
+        expect(call("/")[0]).to eq(401)
+      end
+
+      context "handler is defined on the environment connection" do
+        context "handler is defined by name" do
+          let(:app_def) {
+            Proc.new {
+              Pakyow.handle :unauthorized do |connection:|
+                connection.body = "unauthorized"
+              end
+
+              Pakyow.action do |connection|
+                connection.trigger 401
+              end
+            }
+          }
+
+          it "sets the response status" do
+            expect(call("/")[0]).to eq(401)
+          end
+
+          it "handles the event" do
+            expect(call("/")[2]).to eq("unauthorized")
+          end
+        end
+
+        context "handler is defined by code" do
+          let(:app_def) {
+            Proc.new {
+              Pakyow.handle 401 do |connection:|
+                connection.body = "unauthorized"
+              end
+
+              Pakyow.action do |connection|
+                connection.trigger 401
+              end
+            }
+          }
+
+          it "sets the response status" do
+            expect(call("/")[0]).to eq(401)
+          end
+
+          it "handles the event" do
+            expect(call("/")[2]).to eq("unauthorized")
+          end
+        end
+      end
+    end
+
+    context "triggering on the application connection" do
+      let(:app_def) {
+        Proc.new {
+          action do |connection|
+            connection.trigger 401
+          end
+        }
+      }
+
+      it "sets the response status" do
+        expect(call("/")[0]).to eq(401)
+      end
+
+      context "handler is defined on the environment connection" do
+        context "handler is defined by name" do
+          let(:app_def) {
+            Proc.new {
+              handle :unauthorized do |connection:|
+                connection.body = "unauthorized"
+              end
+
+              action do |connection|
+                connection.trigger 401
+              end
+            }
+          }
+
+          it "sets the response status" do
+            expect(call("/")[0]).to eq(401)
+          end
+
+          it "handles the event" do
+            expect(call("/")[2]).to eq("unauthorized")
+          end
+        end
+
+        context "handler is defined by code" do
+          let(:app_def) {
+            Proc.new {
+              handle 401 do |connection:|
+                connection.body = "unauthorized"
+              end
+
+              action do |connection|
+                connection.trigger 401
+              end
+            }
+          }
+
+          it "sets the response status" do
+            expect(call("/")[0]).to eq(401)
+          end
+
+          it "handles the event" do
+            expect(call("/")[2]).to eq("unauthorized")
+          end
+        end
+      end
+    end
+  end
+
+  describe "handling an event as a status by name" do
+    context "handler is defined on the environment" do
+      let(:app_def) {
+        Proc.new {
+          Pakyow.handle :foo, as: :unauthorized do |connection:|
+            connection.body = "unauthorized"
+          end
+
+          Pakyow.action do |connection|
+            trigger :foo, connection: connection
+          end
+        }
+      }
+
+      it "sets the response status" do
+        expect(call("/")[0]).to eq(401)
+      end
+
+      it "handles the event" do
+        expect(call("/")[2]).to eq("unauthorized")
+      end
+
+      context "handler is defined without a block" do
+        let(:app_def) {
+          Proc.new {
+            Pakyow.handle :foo, as: :unauthorized
+
+            Pakyow.action do |connection|
+              trigger :foo, connection: connection
+            end
+          }
+        }
+
+        it "sets the response status" do
+          expect(call("/")[0]).to eq(401)
+        end
+      end
+    end
+
+    context "handler is defined on the application" do
+      let(:app_def) {
+        Proc.new {
+          handle :foo, as: :unauthorized do |connection:|
+            connection.body = "unauthorized"
+          end
+
+          action do |connection|
+            trigger :foo, connection: connection
+          end
+        }
+      }
+
+      it "sets the response status" do
+        expect(call("/")[0]).to eq(401)
+      end
+
+      it "handles the event" do
+        expect(call("/")[2]).to eq("unauthorized")
+      end
+
+      context "handler is defined without a block" do
+        let(:app_def) {
+          Proc.new {
+            handle :foo, as: :unauthorized
+
+            action do |connection|
+              trigger :foo, connection: connection
+            end
+          }
+        }
+
+        it "sets the response status" do
+          expect(call("/")[0]).to eq(401)
+        end
+      end
+    end
+
+    context "handler is defined on the environment connection" do
+      let(:app_def) {
+        Proc.new {
+          Pakyow.action do |connection|
+            connection.handle :foo, as: :unauthorized do
+              connection.body = "unauthorized"
+            end
+
+            connection.trigger :foo
+          end
+        }
+      }
+
+      it "sets the response status" do
+        expect(call("/")[0]).to eq(401)
+      end
+
+      it "handles the event" do
+        expect(call("/")[2]).to eq("unauthorized")
+      end
+
+      context "handler is defined without a block" do
+        let(:app_def) {
+          Proc.new {
+            Pakyow.action do |connection|
+              connection.handle :foo, as: :unauthorized
+              connection.trigger :foo
+            end
+          }
+        }
+
+        it "sets the response status" do
+          expect(call("/")[0]).to eq(401)
+        end
+      end
+    end
+
+    context "handler is defined on the application connection" do
+      let(:app_def) {
+        Proc.new {
+          action do |connection|
+            connection.handle :foo, as: :unauthorized do
+              connection.body = "unauthorized"
+            end
+
+            connection.trigger :foo
+          end
+        }
+      }
+
+      it "sets the response status" do
+        expect(call("/")[0]).to eq(401)
+      end
+
+      it "handles the event" do
+        expect(call("/")[2]).to eq("unauthorized")
+      end
+
+      context "handler is defined without a block" do
+        let(:app_def) {
+          Proc.new {
+            action do |connection|
+              connection.handle :foo, as: :unauthorized
+              connection.trigger :foo
+            end
+          }
+        }
+
+        it "sets the response status" do
+          expect(call("/")[0]).to eq(401)
+        end
+      end
+    end
+  end
+
+  describe "handling an event as a status by code" do
+    context "handler is defined on the environment" do
+      let(:app_def) {
+        Proc.new {
+          Pakyow.handle :foo, as: 401 do |connection:|
+            connection.body = "unauthorized"
+          end
+
+          Pakyow.action do |connection|
+            trigger :foo, connection: connection
+          end
+        }
+      }
+
+      it "sets the response status" do
+        expect(call("/")[0]).to eq(401)
+      end
+
+      it "handles the event" do
+        expect(call("/")[2]).to eq("unauthorized")
+      end
+
+      context "handler is defined without a block" do
+        let(:app_def) {
+          Proc.new {
+            Pakyow.handle :foo, as: 401
+
+            Pakyow.action do |connection|
+              trigger :foo, connection: connection
+            end
+          }
+        }
+
+        it "sets the response status" do
+          expect(call("/")[0]).to eq(401)
+        end
+      end
+    end
+
+    context "handler is defined on the application" do
+      let(:app_def) {
+        Proc.new {
+          handle :foo, as: 401 do |connection:|
+            connection.body = "unauthorized"
+          end
+
+          action do |connection|
+            trigger :foo, connection: connection
+          end
+        }
+      }
+
+      it "sets the response status" do
+        expect(call("/")[0]).to eq(401)
+      end
+
+      it "handles the event" do
+        expect(call("/")[2]).to eq("unauthorized")
+      end
+
+      context "handler is defined without a block" do
+        let(:app_def) {
+          Proc.new {
+            handle :foo, as: 401
+
+            action do |connection|
+              trigger :foo, connection: connection
+            end
+          }
+        }
+
+        it "sets the response status" do
+          expect(call("/")[0]).to eq(401)
+        end
+      end
+    end
+
+    context "handler is defined on the environment connection" do
+      let(:app_def) {
+        Proc.new {
+          Pakyow.action do |connection|
+            connection.handle :foo, as: 401 do
+              connection.body = "unauthorized"
+            end
+
+            connection.trigger :foo
+          end
+        }
+      }
+
+      it "sets the response status" do
+        expect(call("/")[0]).to eq(401)
+      end
+
+      it "handles the event" do
+        expect(call("/")[2]).to eq("unauthorized")
+      end
+
+      context "handler is defined without a block" do
+        let(:app_def) {
+          Proc.new {
+            Pakyow.action do |connection|
+              connection.handle :foo, as: 401
+              connection.trigger :foo
+            end
+          }
+        }
+
+        it "sets the response status" do
+          expect(call("/")[0]).to eq(401)
+        end
+      end
+    end
+
+    context "handler is defined on the application connection" do
+      let(:app_def) {
+        Proc.new {
+          action do |connection|
+            connection.handle :foo, as: 401 do
+              connection.body = "unauthorized"
+            end
+
+            connection.trigger :foo
+          end
+        }
+      }
+
+      it "sets the response status" do
+        expect(call("/")[0]).to eq(401)
+      end
+
+      it "handles the event" do
+        expect(call("/")[2]).to eq("unauthorized")
+      end
+
+      context "handler is defined without a block" do
+        let(:app_def) {
+          Proc.new {
+            action do |connection|
+              connection.handle :foo, as: 401
+              connection.trigger :foo
+            end
+          }
+        }
+
+        it "sets the response status" do
+          expect(call("/")[0]).to eq(401)
+        end
+      end
+    end
+  end
+
+  describe "handling an event as a status in both the original handler and the status handler" do
+    context "handler is defined on the environment" do
+      let(:app_def) {
+        Proc.new {
+          Pakyow.handle :foo, as: 401 do |connection:|
+            connection.body.write "unauthorized"
+          end
+
+          Pakyow.handle 401 do |connection:|
+            connection.body.write "401"
+          end
+
+          Pakyow.action do |connection|
+            trigger :foo, connection: connection
+          end
+        }
+      }
+
+      it "handles the event" do
+        expect(call("/")[2]).to eq("unauthorized401")
+      end
+
+      context "handler is defined without a block" do
+        let(:app_def) {
+          Proc.new {
+            Pakyow.handle :foo, as: 401
+
+            Pakyow.handle 401 do |connection:|
+              connection.body.write "401"
+            end
+
+            Pakyow.action do |connection|
+              trigger :foo, connection: connection
+            end
+          }
+        }
+
+        it "handles the event" do
+          expect(call("/")[2]).to eq("401")
+        end
+      end
+    end
+
+    context "handler is defined on the application" do
+      let(:app_def) {
+        Proc.new {
+          handle :foo, as: 401 do |connection:|
+            connection.body.write "unauthorized"
+          end
+
+          handle 401 do |connection:|
+            connection.body.write "401"
+          end
+
+          action do |connection|
+            trigger :foo, connection: connection
+          end
+        }
+      }
+
+      it "handles the event" do
+        expect(call("/")[2]).to eq("unauthorized401")
+      end
+
+      context "handler is defined without a block" do
+        let(:app_def) {
+          Proc.new {
+            handle :foo, as: 401
+
+            handle 401 do |connection:|
+              connection.body.write "401"
+            end
+
+            action do |connection|
+              trigger :foo, connection: connection
+            end
+          }
+        }
+
+        it "handles the event" do
+          expect(call("/")[2]).to eq("401")
+        end
+      end
+    end
+
+    context "handler is defined on the environment connection" do
+      let(:app_def) {
+        Proc.new {
+          Pakyow.action do |connection|
+            connection.handle :foo, as: 401 do
+              connection.body.write "unauthorized"
+            end
+
+            connection.handle 401 do |connection:|
+              connection.body.write "401"
+            end
+
+            connection.trigger :foo
+          end
+        }
+      }
+
+      it "handles the event" do
+        expect(call("/")[2]).to eq("unauthorized401")
+      end
+
+      context "handler is defined without a block" do
+        let(:app_def) {
+          Proc.new {
+            Pakyow.action do |connection|
+              connection.handle :foo, as: 401
+
+              connection.handle 401 do |connection:|
+                connection.body.write "401"
+              end
+
+              connection.trigger :foo
+            end
+          }
+        }
+
+        it "handles the event" do
+          expect(call("/")[2]).to eq("401")
+        end
+      end
+    end
+
+    context "handler is defined on the application connection" do
+      let(:app_def) {
+        Proc.new {
+          action do |connection|
+            connection.handle :foo, as: 401 do
+              connection.body.write "unauthorized"
+            end
+
+            connection.handle 401 do |connection:|
+              connection.body.write "401"
+            end
+
+            connection.trigger :foo
+          end
+        }
+      }
+
+      it "handles the event" do
+        expect(call("/")[2]).to eq("unauthorized401")
+      end
+
+      context "handler is defined without a block" do
+        let(:app_def) {
+          Proc.new {
+            action do |connection|
+              connection.handle :foo, as: 401
+
+              connection.handle 401 do |connection:|
+                connection.body.write "401"
+              end
+
+              connection.trigger :foo
+            end
+          }
+        }
+
+        it "handles the event" do
+          expect(call("/")[2]).to eq("401")
+        end
+      end
+    end
+  end
+end

--- a/pakyow-core/spec/features/input_parsing_spec.rb
+++ b/pakyow-core/spec/features/input_parsing_spec.rb
@@ -19,6 +19,10 @@ RSpec.describe "parsing requests" do
 
   include_context "app"
 
+  let(:allow_request_failures) {
+    true
+  }
+
   it "is possible to define a connection parser" do
     expect(call("/", method: :post, headers: { "content-type" => "application/foo" }, input: StringIO.new("foo"))[2]).to eq("oof")
   end

--- a/pakyow-core/spec/unit/app/instance_handle_spec.rb
+++ b/pakyow-core/spec/unit/app/instance_handle_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe Pakyow::Application, "#handle" do
+  let(:instance) {
+    described_class.new
+  }
+
+  it "is not defined" do
+    expect {
+      instance.handle
+    }.to raise_error(NoMethodError)
+  end
+end

--- a/pakyow-core/spec/unit/environment_spec.rb
+++ b/pakyow-core/spec/unit/environment_spec.rb
@@ -661,7 +661,7 @@ RSpec.describe Pakyow do
       end
 
       it "restarts before dispatch" do
-        expect(pipeline.actions.map(&:name)).to eq([:log, :normalize, :parse, :restart, :dispatch])
+        expect(pipeline.actions.map(&:name)).to eq([:handle, :missing, :log, :normalize, :parse, :restart, :dispatch])
       end
     end
 
@@ -675,7 +675,7 @@ RSpec.describe Pakyow do
       end
 
       it "restarts before dispatch" do
-        expect(pipeline.actions.map(&:name)).to eq([:log, :normalize, :parse, :restart, :dispatch])
+        expect(pipeline.actions.map(&:name)).to eq([:handle, :missing, :log, :normalize, :parse, :restart, :dispatch])
       end
     end
 

--- a/pakyow-form/spec/features/errors/array_spec.rb
+++ b/pakyow-form/spec/features/errors/array_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "triggering errors with a result containing an array of messages"
       expect(result[0]).to be(400)
       body = result[2]
       expect(body).to include_sans_whitespace("something went wrong")
-      expect(body).to include_sans_whitespace("something elsewent wrong")
+      expect(body).to include_sans_whitespace("something else went wrong")
     end
   end
 end

--- a/pakyow-presenter/lib/pakyow/application/helpers/presenter/rendering.rb
+++ b/pakyow-presenter/lib/pakyow/application/helpers/presenter/rendering.rb
@@ -6,12 +6,7 @@ module Pakyow
       module Presenter
         module Rendering
           def render(view_path = nil, as: nil, modes: [:default])
-            @connection.app.isolated(:Renderer).render(
-              @connection,
-              view_path: view_path,
-              presenter_path: as,
-              modes: modes
-            )
+            @connection.render(view_path, as: as, modes: modes)
           end
         end
       end

--- a/pakyow-presenter/lib/pakyow/plugin/helpers/presenter/rendering.rb
+++ b/pakyow-presenter/lib/pakyow/plugin/helpers/presenter/rendering.rb
@@ -19,12 +19,7 @@ module Pakyow
                 @connection, :@app => @connection.app.parent
               )
 
-              connection.app.isolated(:Renderer).render(
-                connection,
-                view_path: view_path,
-                presenter_path: as,
-                modes: modes
-              )
+              connection.render(view_path, as: as, modes: modes)
             end
           end
         end

--- a/pakyow-presenter/lib/pakyow/presenter/renderable.rb
+++ b/pakyow-presenter/lib/pakyow/presenter/renderable.rb
@@ -23,6 +23,15 @@ module Pakyow
       def rendered?
         @rendered == true
       end
+
+      def render(view_path = nil, as: nil, modes: [:default])
+        app.isolated(:Renderer).render(
+          self,
+          view_path: view_path,
+          presenter_path: as,
+          modes: modes
+        )
+      end
     end
   end
 end

--- a/pakyow-presenter/lib/pakyow/presenter/renderer.rb
+++ b/pakyow-presenter/lib/pakyow/presenter/renderer.rb
@@ -162,12 +162,6 @@ module Pakyow
               end
             end
           end
-        rescue StandardError => error
-          Pakyow.houston(error)
-
-          if connection.app.class.includes_framework?(:routing)
-            connection.app.controller_for_connection(connection).handle_error(error)
-          end
         end
 
         # @api private

--- a/pakyow-presenter/spec/features/errors/production/500_error_view_spec.rb
+++ b/pakyow-presenter/spec/features/errors/production/500_error_view_spec.rb
@@ -48,9 +48,9 @@ RSpec.describe "500 error views in production" do
   context "app defines its own 500 handler" do
     let :app_def do
       Proc.new do
-        handle 500 do
-          $handled = true
+        handle 500 do |connection:|
           connection.body = StringIO.new("foo")
+          connection.halt
         end
 
         controller do
@@ -61,20 +61,15 @@ RSpec.describe "500 error views in production" do
       end
     end
 
-    after do
-      $handled = false
-    end
-
     it "handles instead of presenter" do
       expect(call("/fail")[2]).to eq("foo")
-      expect($handled).to eq(true)
     end
 
     context "handler renders the default 500 view" do
       let :app_def do
         Proc.new do
-          handle 500 do
-            render "/500"
+          handle 500 do |connection:|
+            connection.render "/500"
           end
 
           controller do
@@ -98,8 +93,8 @@ RSpec.describe "500 error views in production" do
             config.presenter.path = File.expand_path("../../views", __FILE__)
           end
 
-          handle 500 do
-            render "/non_standard_500"
+          handle 500 do |connection:|
+            connection.render "/non_standard_500"
           end
 
           controller do

--- a/pakyow-routing/lib/pakyow/application/actions/routing/respond_missing.rb
+++ b/pakyow-routing/lib/pakyow/application/actions/routing/respond_missing.rb
@@ -1,12 +1,17 @@
 # frozen_string_literal: true
 
+require "pakyow/support/deprecatable"
+
 module Pakyow
   class Application
     module Actions
       module Routing
         class RespondMissing
+          extend Support::Deprecatable
+          deprecate
+
           def call(connection)
-            connection.app.controller_for_connection(connection).trigger(404)
+            connection.trigger(404)
           end
         end
       end

--- a/pakyow-routing/lib/pakyow/application/behavior/routing/definition.rb
+++ b/pakyow-routing/lib/pakyow/application/behavior/routing/definition.rb
@@ -24,13 +24,6 @@ module Pakyow
                 expand_within(:resource, param: param, &block)
               end
             end
-
-            # Registers an error handler automatically available in all Controller instances.
-            #
-            # @see Routing::Behavior::ErrorHandling#handle
-            def handle(name_exception_or_code, as: nil, &block)
-              isolated(:Controller).handle(name_exception_or_code, as: as, &block)
-            end
           end
         end
       end

--- a/pakyow-routing/lib/pakyow/routing/controller/behavior/error_handling.rb
+++ b/pakyow-routing/lib/pakyow/routing/controller/behavior/error_handling.rb
@@ -12,132 +12,20 @@ module Pakyow
       module ErrorHandling
         extend Support::Extension
 
-        apply_extension do
-          class_state :handlers, default: {}, inheritable: true
-          class_state :exceptions, default: {}, inheritable: true
-
-          include API
-          extend API
-        end
-
         prepend_methods do
-          using Support::DeepDup
-
-          def initialize(*)
-            @handlers = self.class.handlers.deep_dup
-            @exceptions = self.class.exceptions.deep_dup
-
-            super
-          end
-        end
-
-        # Calls the handler for a particular http status code.
-        #
-        def trigger(name_or_code)
-          code = Connection::Statuses.code(name_or_code)
-          connection.status = code
-          trigger_for_code(code)
-        end
-
-        def handle_error(error)
-          connection.error = error
-          connection.status = 500
-
-          call_handlers_with_args(
-            exceptions_for_class(error.class) || handlers_for_code(500),
-            error
-          )
-
-          halt
-        end
-
-        private
-
-        def call_handlers_with_args(handlers, *args)
-          handlers.to_a.reverse.each do |status_code, handler|
-            catch :reject do
-              connection.status = status_code
-
-              if handler
-                instance_exec(*args, &handler)
+          # Triggers handlers for `event` in the following order:
+          #
+          #   * connection handlers
+          #   * controller handlers
+          #   * application handlers
+          #   * environment handlers
+          #
+          def trigger(event, *args, **kwargs)
+            kwargs[:connection] = connection
+            connection.trigger(event, *args, **kwargs) do
+              super(event, *args, **kwargs) do
+                app.trigger(event, *args, **kwargs)
               end
-
-              halt
-            end
-          end
-        end
-
-        def trigger_for_code(code)
-          call_handlers_with_args(handlers_for_code(code)); halt
-        end
-
-        def handlers_for_code(code)
-          @handlers[code]
-        end
-
-        def exceptions_for_class(klass)
-          @exceptions[klass]
-        end
-
-        module API
-          # Registers an error handler used within a controller or request lifecycle.
-          #
-          # @example Defining for a controller:
-          #   Pakyow::Application.controller do
-          #     handle 500 do
-          #       # build and send a response for `request.error`
-          #     end
-          #
-          #     default do
-          #       # do something that might cause an error
-          #     end
-          #   end
-          #
-          # @example Defining for a request lifecycle:
-          #   Pakyow::Application.controller do
-          #     default do
-          #       handle 500 do
-          #         # build and send a response for `request.error`
-          #       end
-          #
-          #       # do something that might cause an error
-          #     end
-          #   end
-          #
-          # @example Handling by status code:
-          #   handle 500 do
-          #     # build and send a response
-          #   end
-          #
-          #   default do
-          #     trigger 500
-          #   end
-          #
-          # @example Handling by status name:
-          #   handle :forbidden do
-          #     # build and send a response
-          #   end
-          #
-          #   default do
-          #     trigger 403 # or, `trigger :forbidden`
-          #   end
-          #
-          # @example Handling an exception:
-          #   handle Sequel::NoMatchingRow, as: 404 do
-          #     # build and send a response
-          #   end
-          #
-          #   default do
-          #     raise Sequel::NoMatchingRow
-          #   end
-          #
-          def handle(name_exception_or_code, as: nil, &block)
-            if name_exception_or_code.is_a?(Class) && name_exception_or_code.ancestors.include?(Exception)
-              raise ArgumentError, "status code is required" if as.nil?
-              (@exceptions[name_exception_or_code] ||= []) << [Connection::Statuses.code(as), block]
-            else
-              status_code = Connection::Statuses.code(name_exception_or_code)
-              (@handlers[status_code] ||= []) << [as || status_code, block]
             end
           end
         end

--- a/pakyow-routing/lib/pakyow/routing/framework.rb
+++ b/pakyow-routing/lib/pakyow/routing/framework.rb
@@ -14,7 +14,6 @@ module Pakyow
         require "pakyow/routing/extensions"
         require "pakyow/routing/helpers/exposures"
 
-        require "pakyow/application/actions/routing/respond_missing"
         require "pakyow/application/behavior/routing/definition"
 
         require "pakyow/security/behavior/disabling"
@@ -86,12 +85,6 @@ module Pakyow
             end
           end
 
-          # Create the global controller instance.
-          #
-          after "initialize" do
-            @global_controller = isolated(:Controller).new(self)
-          end
-
           # Register routes as endpoints.
           #
           after "initialize" do
@@ -99,22 +92,6 @@ module Pakyow
               controllers.each do |controller|
                 controller.build_endpoints(endpoints)
               end
-            end
-          end
-
-          # Register the respond missing action as the last registered action.
-          #
-          after "initialize", priority: -10 do
-            unless Pakyow.env?(:prototype) || is_a?(Plugin)
-              action(Application::Actions::Routing::RespondMissing)
-            end
-          end
-
-          # Expose the global controller for handling errors from other frameworks.
-          #
-          def controller_for_connection(connection)
-            @global_controller.dup.tap do |controller|
-              controller.instance_variable_set(:@connection, connection)
             end
           end
 

--- a/pakyow-routing/lib/pakyow/security/behavior/insecure.rb
+++ b/pakyow-routing/lib/pakyow/security/behavior/insecure.rb
@@ -11,8 +11,8 @@ module Pakyow
         extend Support::Extension
 
         apply_extension do
-          handle InsecureRequest, as: 403 do
-            trigger(403)
+          isolated :Controller do
+            handle InsecureRequest, as: 403
           end
         end
       end

--- a/pakyow-routing/spec/features/security/csrf_spec.rb
+++ b/pakyow-routing/spec/features/security/csrf_spec.rb
@@ -51,8 +51,9 @@ RSpec.describe "processing requests with csrf protection" do
     context "403 handler is defined globally" do
       let :app_def do
         Proc.new do
-          handle 403 do
-            send "403"
+          handle 403 do |connection:|
+            connection.body = "403"
+            connection.halt
           end
 
           controller do
@@ -86,11 +87,11 @@ RSpec.describe "processing requests with csrf protection" do
       end
     end
 
-    context "error handler is defined globally" do
+    xcontext "error handler is defined globally" do
       let :app_def do
         Proc.new do
-          handle Pakyow::Security::InsecureRequest, as: 404 do
-            send "404"
+          handle Pakyow::Security::InsecureRequest, as: 404 do |connection:|
+            connection.body = "404"
           end
 
           controller do

--- a/pakyow-routing/spec/features/validations/length_spec.rb
+++ b/pakyow-routing/spec/features/validations/length_spec.rb
@@ -15,6 +15,10 @@ RSpec.describe "email validation" do
     end
   end
 
+  let :allow_request_failures do
+    true
+  end
+
   context "value is not accepted" do
     it "responds 400" do
       expect(call("/test", params: { value: "b" })[0]).to eq(400)

--- a/spec/context/app_context.rb
+++ b/spec/context/app_context.rb
@@ -50,6 +50,10 @@ RSpec.shared_context "app" do
     @connection
   end
 
+  let :mount_app do
+    true
+  end
+
   before do
     ENV["SECRET"] = "test"
     Pakyow.config.logger.enabled = false
@@ -59,7 +63,7 @@ RSpec.shared_context "app" do
 
   def setup(env: :test)
     super if defined?(super)
-    Pakyow.mount(app, at: mount_path)
+    Pakyow.mount(app, at: mount_path) if mount_app
     Pakyow.class_eval(&env_def)
     Pakyow.setup(env: env)
   end


### PR DESCRIPTION
`Pakyow::Application`, `Pakyow::Connection` and the main environment can now handle events and errors (behavior previously only available to controllers). Events triggered in specific contexts propagate all the way up to the environment until they are handled.