### PR TITLE
Add the rescue pattern to the environment

### DIFF
--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -277,6 +277,8 @@
 
 ## Deprecations
 
+  * `Pakyow.config.exit_on_boot_failure` is deprecated with no replacement.
+
   * `Pakyow::Actions::Dispatch` is deprecated with no replacement.
 
     *Related links:*

--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # v1.1.0 (unreleased)
 
+  * `add` **Add the rescue pattern to the environment.**
+
   * `fix` **Make `Rack::Compatibility` compatible with protocol-http@0.16.**
 
     *Related links:*

--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -2,6 +2,9 @@
 
   * `add` **Add the rescue pattern to the environment.**
 
+    *Related links:*
+    - [Pull Request #444][pr-444]
+
   * `fix` **Make `Rack::Compatibility` compatible with protocol-http@0.16.**
 
     *Related links:*
@@ -278,6 +281,9 @@
 ## Deprecations
 
   * `Pakyow.config.exit_on_boot_failure` is deprecated with no replacement.
+
+    *Related links:*
+    - [Pull Request #444][pr-444]
 
   * `Pakyow::Actions::Dispatch` is deprecated with no replacement.
 

--- a/pakyow-core/lib/pakyow/behavior/rescuing.rb
+++ b/pakyow-core/lib/pakyow/behavior/rescuing.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "pakyow/support/extension"
+
+module Pakyow
+  module Behavior
+    # Lets the environment to be rescued from errors encountered when running. Once rescued,
+    # the environment triggers a 500 response with the error that caused it to fail.
+    #
+    module Rescuing
+      extend Support::Extension
+
+      apply_extension do
+        events :rescue
+      end
+
+      class_methods do
+        # Error the environment was rescued from.
+        #
+        attr_reader :error
+        alias rescued error
+
+        # Returns true if the environment has been rescued.
+        #
+        def rescued?
+          instance_variable_defined?(:@error) && !!@error
+        end
+
+        # Enters rescue mode after reporting the error.
+        #
+        def rescue!(error)
+          @error = error
+
+          performing :rescue, error: error do
+            Pakyow.houston(error)
+
+            include Rescued
+          end
+        end
+      end
+
+      # Installs the `rescued` action on the including object.
+      #
+      module Rescued
+        extend Support::Extension
+
+        apply_extension do
+          action :rescued, before: :all do |connection|
+            connection.error = rescued
+            connection.trigger 500
+          end
+        end
+      end
+    end
+  end
+end

--- a/pakyow-core/lib/pakyow/behavior/running.rb
+++ b/pakyow-core/lib/pakyow/behavior/running.rb
@@ -177,8 +177,10 @@ module Pakyow
         private def handle_environment_error(error)
           Pakyow.rescue!(error)
 
-          if config.exit_on_boot_failure
-            exit(false)
+          Pakyow.deprecator.ignore do
+            if config.exit_on_boot_failure
+              exit(false)
+            end
           end
         end
       end

--- a/pakyow-core/lib/pakyow/environment.rb
+++ b/pakyow-core/lib/pakyow/environment.rb
@@ -104,7 +104,7 @@ module Pakyow
 
   setting :default_env, :development
   setting :freeze_on_boot, true
-  setting :exit_on_boot_failure, true
+  setting :exit_on_boot_failure, false
   setting :timezone, :utc
   setting :secrets, ["pakyow"]
 
@@ -136,6 +136,7 @@ module Pakyow
   end
 
   config.deprecate :freeze_on_boot
+  config.deprecate :exit_on_boot_failure
 
   configurable :server do
     setting :host, "localhost"

--- a/pakyow-core/lib/pakyow/environment.rb
+++ b/pakyow-core/lib/pakyow/environment.rb
@@ -19,6 +19,7 @@ require "pakyow/behavior/erroring"
 require "pakyow/behavior/initializers"
 require "pakyow/behavior/input_parsing"
 require "pakyow/behavior/plugins"
+require "pakyow/behavior/rescuing"
 require "pakyow/behavior/silencing"
 require "pakyow/behavior/tasks"
 require "pakyow/behavior/timezone"
@@ -274,6 +275,7 @@ module Pakyow
   include Behavior::Initializers
   include Behavior::InputParsing
   include Behavior::Plugins
+  include Behavior::Rescuing
   include Behavior::Silencing
   include Behavior::Tasks
   include Behavior::Timezone
@@ -318,10 +320,6 @@ module Pakyow
     # Name of the environment
     #
     attr_reader :env
-
-    # Any error encountered during the boot process
-    #
-    attr_reader :error
 
     # Global log output.
     #
@@ -400,6 +398,10 @@ module Pakyow
 
         @__loaded = true
       end
+    rescue ApplicationError => error
+      raise error
+    rescue ScriptError, StandardError => error
+      raise EnvironmentError.build(error)
     end
 
     # Returns true if the environment has loaded.
@@ -464,6 +466,10 @@ module Pakyow
       end
 
       self
+    rescue ApplicationError => error
+      raise error
+    rescue ScriptError, StandardError => error
+      raise EnvironmentError.build(error)
     end
 
     # Returns true if the environment has been setup.
@@ -493,6 +499,10 @@ module Pakyow
       end
 
       self
+    rescue ApplicationError => error
+      raise error
+    rescue ScriptError, StandardError => error
+      raise EnvironmentError.build(error)
     end
 
     # Returns true if the environment has booted.

--- a/pakyow-core/lib/pakyow/errors.rb
+++ b/pakyow-core/lib/pakyow/errors.rb
@@ -5,6 +5,9 @@ require "json"
 require "pakyow/error"
 
 module Pakyow
+  class EnvironmentError < Error
+  end
+
   class ApplicationError < Error
   end
 

--- a/pakyow-core/spec/features/rescuing_spec.rb
+++ b/pakyow-core/spec/features/rescuing_spec.rb
@@ -1,0 +1,74 @@
+RSpec.describe "environment rescuing" do
+  include_context "app"
+
+  let(:autorun) {
+    false
+  }
+
+  let(:allow_environment_errors) {
+    true
+  }
+
+  let(:allow_request_failures) {
+    true
+  }
+
+  context "environment is rescued" do
+    def rescue!
+      allow(Pakyow.logger).to receive(:houston)
+      Pakyow.rescue!(error)
+      setup_and_run
+    end
+
+    before do
+      rescue!
+    end
+
+    let(:error) {
+      begin
+        fail "this is a test"
+      rescue => error
+        error
+      end
+    }
+
+    it "reports the error" do
+      expect(Pakyow.logger).to have_received(:houston).with(error)
+    end
+
+    it "appears to be rescued" do
+      expect(Pakyow.rescued?).to be(true)
+    end
+
+    it "exposes the error" do
+      expect(Pakyow.rescued).to be(error)
+    end
+
+    it "responds 500 to any request" do
+      expect(call("/")[0]).to eq(500)
+      expect(call("/foo/tfwayn")[0]).to eq(500)
+    end
+
+    describe "calling handlers" do
+      def rescue!
+        allow(Pakyow.logger).to receive(:houston)
+        setup(env: mode)
+        Pakyow.rescue!(error)
+        run
+      end
+
+      let(:env_def) {
+        Proc.new {
+          handle 500 do |connection:|
+            connection.body = "handled #{connection.error}"
+            connection.halt
+          end
+        }
+      }
+
+      it "calls 500 handlers on the environment" do
+        expect(call("/")[2]).to eq("handled this is a test")
+      end
+    end
+  end
+end

--- a/pakyow-core/spec/unit/environment/config_spec.rb
+++ b/pakyow-core/spec/unit/environment/config_spec.rb
@@ -14,17 +14,15 @@ RSpec.describe Pakyow do
 
     describe "exit_on_boot_failure" do
       it "has a default value" do
-        expect(Pakyow.config.exit_on_boot_failure).to eq(true)
+        expect(Pakyow.config.exit_on_boot_failure).to eq(false)
       end
 
-      context "in test" do
-        before do
-          Pakyow.configure!(:test)
-        end
+      it "is deprecated" do
+        expect(Pakyow::Support::Deprecator.global).to receive(:deprecated).with(
+          "Pakyow.config.exit_on_boot_failure", { solution: "do not use" }
+        )
 
-        it "defaults to false" do
-          expect(Pakyow.config.exit_on_boot_failure).to eq(false)
-        end
+        Pakyow.config.exit_on_boot_failure
       end
     end
 

--- a/pakyow-data/spec/features/migrations/auto_migrate_spec.rb
+++ b/pakyow-data/spec/features/migrations/auto_migrate_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "auto migrating on boot" do
           let :app_def do
             Proc.new do
               before "initialize" do
-                @error = true
+                rescue!(RuntimeError.new)
               end
 
               source :posts do

--- a/pakyow-data/spec/features/migrations/auto_migrate_spec.rb
+++ b/pakyow-data/spec/features/migrations/auto_migrate_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "auto migrating on boot" do
           let :app_def do
             Proc.new do
               before "initialize" do
-                @rescued = true
+                @error = true
               end
 
               source :posts do

--- a/spec/smoke/rescues/environment_spec.rb
+++ b/spec/smoke/rescues/environment_spec.rb
@@ -1,0 +1,43 @@
+require "smoke_helper"
+
+RSpec.describe "rescuing the environment", smoke: true do
+  context "error occurs before load" do
+    before do
+      File.open(project_path.join("config/environment.rb"), "w+") do |file|
+        file.write <<~SOURCE
+          Pakyow.on :load do
+            fail "something went wrong"
+          end
+        SOURCE
+      end
+
+      boot(wait: false)
+    end
+
+    it "fails to boot" do
+      expect {
+        HTTP.get("http://localhost:#{port}/")
+      }.to raise_error(HTTP::ConnectionError)
+    end
+  end
+
+  context "error occurs before setup" do
+    before do
+      File.open(project_path.join("config/environment.rb"), "w+") do |file|
+        file.write <<~SOURCE
+          Pakyow.on :setup do
+            fail "something went wrong"
+          end
+        SOURCE
+      end
+
+      boot
+    end
+
+    it "responds 500" do
+      response = HTTP.get("http://localhost:#{port}/")
+
+      expect(response.status).to eq(500)
+    end
+  end
+end

--- a/spec/smoke_helper.rb
+++ b/spec/smoke_helper.rb
@@ -79,13 +79,15 @@ RSpec.configure do |config|
     Dir.chdir(@project_path)
   end
 
-  def boot(environment: self.environment, envars: self.envars, port: self.port, host: self.host)
+  def boot(environment: self.environment, envars: self.envars, port: self.port, host: self.host, wait: true)
     Bundler.with_original_env do
       @server = Process.spawn(envars, "pakyow boot -e #{environment} -p #{port} --host #{host}")
     end
 
-    wait_for_boot do
-      yield if block_given?
+    if wait
+      wait_for_boot do
+        yield if block_given?
+      end
     end
   end
 

--- a/spec/spec_config.rb
+++ b/spec/spec_config.rb
@@ -136,7 +136,7 @@ RSpec.configure do |config|
     reset_config(Pakyow::Application) if defined?(Pakyow::Application)
     reset_config(Pakyow)
 
-    [:@port, :@host, :@logger, :@app, :@output, :@deprecator, :@config].each do |ivar|
+    [:@port, :@host, :@logger, :@app, :@output, :@deprecator, :@config, :@error].each do |ivar|
       if Pakyow.instance_variable_defined?(ivar)
         Pakyow.remove_instance_variable(ivar)
       end


### PR DESCRIPTION
If an exception occurs when running the environment, it reports the error and boots into rescue mode. When in rescue mode a single `rescued` action is called that triggers a 500 error.