### PR TITLE
Render normal error views when rescued

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require ./spec/spec_config

--- a/pakyow-core/lib/pakyow/application.rb
+++ b/pakyow-core/lib/pakyow/application.rb
@@ -122,7 +122,7 @@ module Pakyow
     inspectable :@environment
 
     include Support::Hookable
-    events :setup, :initialize, :configure, :load, :finalize, :boot, :rescue, :shutdown
+    events :setup, :initialize, :configure, :load, :finalize, :boot, :shutdown
 
     extend Support::ClassState
     class_state :__setup, default: false, reader: false

--- a/pakyow-core/lib/pakyow/application/behavior/rescuing.rb
+++ b/pakyow-core/lib/pakyow/application/behavior/rescuing.rb
@@ -5,33 +5,38 @@ require "pakyow/support/extension"
 module Pakyow
   class Application
     module Behavior
-      # Lets an app to be rescued from errors encountered during boot. Once rescued,
-      # an app returns a 500 response with the error that caused it to fail.
+      # Lets an application to be rescued from errors encountered when running. Once rescued,
+      # the application triggers a 500 response with the error that caused it to fail.
       #
       module Rescuing
         extend Support::Extension
 
-        common_methods do
-          # Error the app was rescued from.
-          #
-          def rescued
-            defined?(@rescued) ? @rescued : self.class.rescued
-          end
+        apply_extension do
+          events :rescue
+        end
 
-          # Returns true if the app has been rescued.
+        common_methods do
+          # Error the application was rescued from.
+          #
+          def error
+            defined?(@error) ? @error : self.class.error
+          end
+          alias rescued error
+
+          # Returns true if the application has been rescued.
           #
           def rescued?
             if is_a?(Application)
-              self.class.rescued? || (instance_variable_defined?(:@rescued) && !!@rescued)
+              self.class.rescued? || (instance_variable_defined?(:@error) && !!@error)
             else
-              instance_variable_defined?(:@rescued) && !!@rescued
+              instance_variable_defined?(:@error) && !!@error
             end
           end
 
           # Enters rescue mode after reporting the error.
           #
           def rescue!(error)
-            @rescued = error
+            @error = error
 
             performing :rescue, error: error do
               Pakyow.houston(error)
@@ -47,10 +52,9 @@ module Pakyow
 
         module Rescued
           def call(connection)
-            isolated(:Connection).new(self, connection).tap do |application_connection|
-              application_connection.error = rescued
-              application_connection.trigger 500
-            end
+            application_connection = isolated(:Connection).new(self, connection)
+            application_connection.error = rescued
+            application_connection.trigger 500
           end
         end
       end

--- a/pakyow-core/lib/pakyow/application/connection.rb
+++ b/pakyow-core/lib/pakyow/application/connection.rb
@@ -31,9 +31,17 @@ module Pakyow
       using Support::Refinements::String::Normalization
 
       def initialize(app, connection)
-        performing :initialize do
-          @app = app; __setobj__(connection)
+        if app.rescued?
+          __initialize(app, connection)
+        else
+          performing :initialize do
+            __initialize(app, connection)
+          end
         end
+      end
+
+      private def __initialize(app, connection)
+        @app = app; __setobj__(connection)
       end
 
       def initialize_dup(_)

--- a/pakyow-core/spec/unit/app/connection_spec.rb
+++ b/pakyow-core/spec/unit/app/connection_spec.rb
@@ -1,6 +1,7 @@
 require_relative "./connection/shared_examples/values"
 require_relative "./connection/shared_examples/verifier"
 
+require "pakyow/application/connection"
 require "pakyow/application/connection/session/cookie"
 
 require "pakyow/support/deep_dup"
@@ -17,7 +18,8 @@ RSpec.describe Pakyow::Application::Connection do
       Pakyow::Application,
       config: Pakyow::Application.config.deep_dup,
       session_object: Pakyow::Application::Connection::Session::Cookie,
-      session_options: Pakyow::Application.config.session.cookie.deep_dup
+      session_options: Pakyow::Application.config.session.cookie.deep_dup,
+      rescued?: false
     )
   end
 
@@ -57,6 +59,29 @@ RSpec.describe Pakyow::Application::Connection do
 
       expect(before).to be(true)
       expect(after).to be(true)
+    end
+
+    context "application is rescued" do
+      before do
+        allow(app).to receive(:rescued?).and_return(true)
+      end
+
+      it "does not call the initialize hooks" do
+        before, after = nil
+
+        described_class.before "initialize" do
+          before = true
+        end
+
+        described_class.after "initialize" do
+          after = true
+        end
+
+        connection
+
+        expect(before).to be(nil)
+        expect(after).to be(nil)
+      end
     end
   end
 

--- a/pakyow-presenter/CHANGELOG.md
+++ b/pakyow-presenter/CHANGELOG.md
@@ -1,5 +1,7 @@
 # v1.1.0 (unreleased)
 
+  * `chg` **Render error views when the application is rescued before setup.**
+
   * `chg` **Endpoints now pull param values from related objects.**
 
     *Related links:*

--- a/pakyow-presenter/CHANGELOG.md
+++ b/pakyow-presenter/CHANGELOG.md
@@ -2,6 +2,9 @@
 
   * `chg` **Render error views when the application is rescued before setup.**
 
+    *Related links:*
+    - [Pull Request #446][pr-446]
+
   * `chg` **Endpoints now pull param values from related objects.**
 
     *Related links:*
@@ -13,6 +16,7 @@
     - [Pull Request #297][pr-297]
     - [Commit 802295c][802295c]
 
+[pr-446]: https://github.com/pakyow/pakyow/pull/446
 [pr-297]: https://github.com/pakyow/pakyow/pull/297/commits
 [ce9a018]: https://github.com/pakyow/pakyow/commit/ce9a0186b70f99aadb173fc37e1d9541ce9834da
 [802295c]: https://github.com/pakyow/pakyow/commit/802295c0396383b96fadafd121192d41bb63457e

--- a/pakyow-presenter/lib/pakyow/application/behavior/presenter/initializing.rb
+++ b/pakyow-presenter/lib/pakyow/application/behavior/presenter/initializing.rb
@@ -27,8 +27,6 @@ module Pakyow
                     }
                   )
                 )
-
-                templates << Pakyow::Presenter::Templates.new(:errors, File.join(File.expand_path("../../../../", __FILE__), "views", "errors"))
               end
             end
 

--- a/pakyow-presenter/lib/pakyow/presenter/framework.rb
+++ b/pakyow-presenter/lib/pakyow/presenter/framework.rb
@@ -197,9 +197,9 @@ module Pakyow
             end
           end
 
+          include Application::Behavior::Presenter::Initializing
           include Application::Behavior::Presenter::ErrorRendering
           include Application::Behavior::Presenter::Exposures
-          include Application::Behavior::Presenter::Initializing
           include Application::Behavior::Presenter::Modes
           include Application::Behavior::Presenter::Versions
           include Application::Behavior::Presenter::Watching

--- a/spec/smoke/rescues/application_spec.rb
+++ b/spec/smoke/rescues/application_spec.rb
@@ -1,0 +1,72 @@
+require "smoke_helper"
+
+RSpec.describe "rescuing the application", smoke: true do
+  context "error occurs before setup" do
+    before do
+      File.open(project_path.join("config/application.rb"), "w+") do |file|
+        file.write <<~SOURCE
+          Pakyow.app :smoke_test do
+            on :setup do
+              fail "something went wrong"
+            end
+          end
+        SOURCE
+      end
+
+      boot
+    end
+
+    let(:response) {
+      HTTP.get("http://localhost:#{port}/")
+    }
+
+    context "running in development" do
+      let(:environment) {
+        :development
+      }
+
+      it "responds 500" do
+        expect(response.status).to eq(500)
+      end
+
+      it "responds with a nice error" do
+        expect(response.body.to_s).to include_sans_whitespace(
+          <<~HTML
+            <article data-b="pw_error">
+              <header>
+                <h1 data-b="name">Application error</h1>
+
+                <section data-b="message"><p>something went wrong</p>
+          HTML
+        )
+      end
+    end
+
+    context "running in production" do
+      let(:environment) {
+        :production
+      }
+
+      let(:envars) {
+        {
+          "SECRET" => "sekret",
+          "DATABASE_URL" => "sqlite://database/production.db"
+        }
+      }
+
+      it "responds 500" do
+        expect(response.status).to eq(500)
+      end
+
+      it "responds with a default error" do
+        expect(response.body.to_s).to include_sans_whitespace(
+          <<~HTML
+            <main>
+              <p>
+                <strong>500 (Server Error)</strong>
+          HTML
+        )
+      end
+    end
+  end
+end

--- a/spec/spec_config.rb
+++ b/spec/spec_config.rb
@@ -26,12 +26,6 @@ RSpec.configure do |config|
     config.filter_run_excluding benchmark: true
   end
 
-  if ENV.key?("CI_SMOKE")
-    config.filter_run smoke: true
-  else
-    config.filter_run_excluding smoke: true
-  end
-
   def rss
    `ps -eo pid,rss | grep #{Process.pid} | awk '{print $2}'`.to_i
   end


### PR DESCRIPTION
This guarantees that error views will be rendered in rescue mode, even if presenter isn't setup.