### PR TITLE
Support a global --config CLI option

### DIFF
--- a/pakyow-assets/spec/expectations/commands/precompile/help
+++ b/pakyow-assets/spec/expectations/commands/precompile/help
@@ -4,6 +4,7 @@
   $ pakyow assets:precompile
 
 [1mOPTIONS[0m
-  -a, --app=app      [33mThe app to run the command on[0m
-  -e, --env=env      [33mThe environment to run this command under[0m
-      --debug        [33mShow low-level debugging information[0m
+  -a, --app=app        [33mThe app to run the command on[0m
+  -e, --env=env        [33mThe environment to run this command under[0m
+  -c, --config=config  [33mPath to the environment config file (default: config/environment)[0m
+      --debug          [33mShow low-level debugging information[0m

--- a/pakyow-assets/spec/expectations/commands/update/help
+++ b/pakyow-assets/spec/expectations/commands/update/help
@@ -7,6 +7,7 @@
   ASSET  [33mThe asset to update[0m
 
 [1mOPTIONS[0m
-  -a, --app=app      [33mThe app to run the command on[0m
-  -e, --env=env      [33mThe environment to run this command under[0m
-      --debug        [33mShow low-level debugging information[0m
+  -a, --app=app        [33mThe app to run the command on[0m
+  -e, --env=env        [33mThe environment to run this command under[0m
+  -c, --config=config  [33mPath to the environment config file (default: config/environment)[0m
+      --debug          [33mShow low-level debugging information[0m

--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `add` **Support a global `--config` CLI option.**
+
+    *Related links:*
+    - [Pull Request #472][pr-472]
+
   * `add` **Support a global `--debug` CLI flag.**
 
     *Related links:*
@@ -478,6 +483,7 @@
     *Related links:*
     - [Pull Request #338][pr-338]
 
+[pr-472]: https://github.com/pakyow/pakyow/pull/472
 [pr-471]: https://github.com/pakyow/pakyow/pull/471
 [pr-470]: https://github.com/pakyow/pakyow/pull/470
 [pr-469]: https://github.com/pakyow/pakyow/pull/469

--- a/pakyow-core/lib/pakyow/cli.rb
+++ b/pakyow-core/lib/pakyow/cli.rb
@@ -41,6 +41,10 @@ module Pakyow
         command = parser.command
         options = parser.options
 
+        if options[:config]
+          Pakyow.config.environment_path = options[:config]
+        end
+
         cli.handling(debug: options[:debug]) do
           case command
           when "prototype"

--- a/pakyow-core/lib/pakyow/cli/parsers/global.rb
+++ b/pakyow-core/lib/pakyow/cli/parsers/global.rb
@@ -34,12 +34,16 @@ module Pakyow
 
           parse_with_unknown_args!(argv) do
             OptionParser.new do |opts|
-              opts.on("-eENV", "--env=ENV") do |e|
-                options[:env] = e
+              opts.on("-eENV", "--env=ENV") do |value|
+                options[:env] = value
               end
 
-              opts.on("-aAPP", "--app=APP") do |a|
-                options[:app] = a
+              opts.on("-aAPP", "--app=APP") do |value|
+                options[:app] = value
+              end
+
+              opts.on("-cCONFIG", "--config=CONFIG") do |value|
+                options[:config] = value
               end
 
               opts.on("-h", "--help") do

--- a/pakyow-core/lib/pakyow/command.rb
+++ b/pakyow-core/lib/pakyow/command.rb
@@ -84,9 +84,11 @@ module Pakyow
       verify do
         optional :env
         optional :debug
+        optional :config
       end
 
       flag :debug, "Show low-level debugging information"
+      option :config, "Path to the environment config file", default: Pathname.new(Pakyow.config.environment_path).relative_path_from(Pathname.new(Dir.pwd))
 
       rake_args = [:values]
       rake_args = if dependent

--- a/pakyow-core/spec/expectations/cli/command-help/test:pass_arg_opt_flg-["--baz=baz_value", "foo_value", "bar_value", "--unknown=foo"]
+++ b/pakyow-core/spec/expectations/cli/command-help/test:pass_arg_opt_flg-["--baz=baz_value", "foo_value", "bar_value", "--unknown=foo"]
@@ -8,8 +8,9 @@
   BAR  [33mBar arg[0m
 
 [1mOPTIONS[0m
-  -e, --env=env      [33mThe environment to run this command under[0m
-  -b, --baz=baz      [33mBaz arg[0m[31m (required)[0m
-  -q, --qux=qux      [33mQux arg (default: qux)[0m
-      --meh          [33mMeh flag[0m
-      --debug        [33mShow low-level debugging information[0m
+  -e, --env=env        [33mThe environment to run this command under[0m
+  -b, --baz=baz        [33mBaz arg[0m[31m (required)[0m
+  -q, --qux=qux        [33mQux arg (default: qux)[0m
+  -c, --config=config  [33mPath to the environment config file (default: ../../../config/environment)[0m
+      --meh            [33mMeh flag[0m
+      --debug          [33mShow low-level debugging information[0m

--- a/pakyow-core/spec/expectations/cli/command-help/test:pass_arg_opt_flg-["--baz=baz_value", "foo_value", "baz_value", "unknown"]
+++ b/pakyow-core/spec/expectations/cli/command-help/test:pass_arg_opt_flg-["--baz=baz_value", "foo_value", "baz_value", "unknown"]
@@ -8,8 +8,9 @@
   BAR  [33mBar arg[0m
 
 [1mOPTIONS[0m
-  -e, --env=env      [33mThe environment to run this command under[0m
-  -b, --baz=baz      [33mBaz arg[0m[31m (required)[0m
-  -q, --qux=qux      [33mQux arg (default: qux)[0m
-      --meh          [33mMeh flag[0m
-      --debug        [33mShow low-level debugging information[0m
+  -e, --env=env        [33mThe environment to run this command under[0m
+  -b, --baz=baz        [33mBaz arg[0m[31m (required)[0m
+  -q, --qux=qux        [33mQux arg (default: qux)[0m
+  -c, --config=config  [33mPath to the environment config file (default: ../../../config/environment)[0m
+      --meh            [33mMeh flag[0m
+      --debug          [33mShow low-level debugging information[0m

--- a/pakyow-core/spec/expectations/cli/command-help/test:pass_arg_opt_flg-["--baz=baz_value"]
+++ b/pakyow-core/spec/expectations/cli/command-help/test:pass_arg_opt_flg-["--baz=baz_value"]
@@ -8,8 +8,9 @@
   BAR  [33mBar arg[0m
 
 [1mOPTIONS[0m
-  -e, --env=env      [33mThe environment to run this command under[0m
-  -b, --baz=baz      [33mBaz arg[0m[31m (required)[0m
-  -q, --qux=qux      [33mQux arg (default: qux)[0m
-      --meh          [33mMeh flag[0m
-      --debug        [33mShow low-level debugging information[0m
+  -e, --env=env        [33mThe environment to run this command under[0m
+  -b, --baz=baz        [33mBaz arg[0m[31m (required)[0m
+  -q, --qux=qux        [33mQux arg (default: qux)[0m
+  -c, --config=config  [33mPath to the environment config file (default: ../../../config/environment)[0m
+      --meh            [33mMeh flag[0m
+      --debug          [33mShow low-level debugging information[0m

--- a/pakyow-core/spec/expectations/cli/command-help/test:pass_arg_opt_flg-["--help"]
+++ b/pakyow-core/spec/expectations/cli/command-help/test:pass_arg_opt_flg-["--help"]
@@ -8,8 +8,9 @@
   BAR  [33mBar arg[0m
 
 [1mOPTIONS[0m
-  -e, --env=env      [33mThe environment to run this command under[0m
-  -b, --baz=baz      [33mBaz arg[0m[31m (required)[0m
-  -q, --qux=qux      [33mQux arg (default: qux)[0m
-      --meh          [33mMeh flag[0m
-      --debug        [33mShow low-level debugging information[0m
+  -e, --env=env        [33mThe environment to run this command under[0m
+  -b, --baz=baz        [33mBaz arg[0m[31m (required)[0m
+  -q, --qux=qux        [33mQux arg (default: qux)[0m
+  -c, --config=config  [33mPath to the environment config file (default: ../../../config/environment)[0m
+      --meh            [33mMeh flag[0m
+      --debug          [33mShow low-level debugging information[0m

--- a/pakyow-core/spec/expectations/cli/command-help/test:pass_arg_opt_flg-["-h"]
+++ b/pakyow-core/spec/expectations/cli/command-help/test:pass_arg_opt_flg-["-h"]
@@ -8,8 +8,9 @@
   BAR  [33mBar arg[0m
 
 [1mOPTIONS[0m
-  -e, --env=env      [33mThe environment to run this command under[0m
-  -b, --baz=baz      [33mBaz arg[0m[31m (required)[0m
-  -q, --qux=qux      [33mQux arg (default: qux)[0m
-      --meh          [33mMeh flag[0m
-      --debug        [33mShow low-level debugging information[0m
+  -e, --env=env        [33mThe environment to run this command under[0m
+  -b, --baz=baz        [33mBaz arg[0m[31m (required)[0m
+  -q, --qux=qux        [33mQux arg (default: qux)[0m
+  -c, --config=config  [33mPath to the environment config file (default: ../../../config/environment)[0m
+      --meh            [33mMeh flag[0m
+      --debug          [33mShow low-level debugging information[0m

--- a/pakyow-core/spec/expectations/cli/command-help/test:pass_arg_opt_flg-["foo_value"]
+++ b/pakyow-core/spec/expectations/cli/command-help/test:pass_arg_opt_flg-["foo_value"]
@@ -8,8 +8,9 @@
   BAR  [33mBar arg[0m
 
 [1mOPTIONS[0m
-  -e, --env=env      [33mThe environment to run this command under[0m
-  -b, --baz=baz      [33mBaz arg[0m[31m (required)[0m
-  -q, --qux=qux      [33mQux arg (default: qux)[0m
-      --meh          [33mMeh flag[0m
-      --debug        [33mShow low-level debugging information[0m
+  -e, --env=env        [33mThe environment to run this command under[0m
+  -b, --baz=baz        [33mBaz arg[0m[31m (required)[0m
+  -q, --qux=qux        [33mQux arg (default: qux)[0m
+  -c, --config=config  [33mPath to the environment config file (default: ../../../config/environment)[0m
+      --meh            [33mMeh flag[0m
+      --debug          [33mShow low-level debugging information[0m

--- a/pakyow-core/spec/expectations/cli/debug
+++ b/pakyow-core/spec/expectations/cli/debug
@@ -15,22 +15,22 @@
     spec/features/cli/debug_spec.rb:5:in `block (4 levels) in <top (required)>'
     lib/pakyow/operation.rb:50:in `block in perform'
     lib/pakyow/operation.rb:49:in `perform'
-    lib/pakyow/command.rb:99:in `block (2 levels) in <class:Command>'
-    lib/pakyow/command.rb:218:in `call'
-    lib/pakyow/cli.rb:222:in `call_command'
-    lib/pakyow/cli.rb:148:in `block in call'
-    lib/pakyow/cli.rb:104:in `block in with'
-    lib/pakyow/cli.rb:109:in `handling'
-    lib/pakyow/cli.rb:103:in `with'
-    lib/pakyow/cli.rb:131:in `call'
-    lib/pakyow/cli.rb:85:in `block in run_cli_command'
-    lib/pakyow/cli.rb:104:in `block in with'
-    lib/pakyow/cli.rb:109:in `handling'
-    lib/pakyow/cli.rb:103:in `with'
-    lib/pakyow/cli.rb:75:in `run_cli_command'
-    lib/pakyow/cli.rb:60:in `block in run'
-    lib/pakyow/cli.rb:109:in `handling'
-    lib/pakyow/cli.rb:44:in `run'
+    lib/pakyow/command.rb:101:in `block (2 levels) in <class:Command>'
+    lib/pakyow/command.rb:220:in `call'
+    lib/pakyow/cli.rb:226:in `call_command'
+    lib/pakyow/cli.rb:152:in `block in call'
+    lib/pakyow/cli.rb:108:in `block in with'
+    lib/pakyow/cli.rb:113:in `handling'
+    lib/pakyow/cli.rb:107:in `with'
+    lib/pakyow/cli.rb:135:in `call'
+    lib/pakyow/cli.rb:89:in `block in run_cli_command'
+    lib/pakyow/cli.rb:108:in `block in with'
+    lib/pakyow/cli.rb:113:in `handling'
+    lib/pakyow/cli.rb:107:in `with'
+    lib/pakyow/cli.rb:79:in `run_cli_command'
+    lib/pakyow/cli.rb:64:in `block in run'
+    lib/pakyow/cli.rb:113:in `handling'
+    lib/pakyow/cli.rb:48:in `run'
     spec/features/cli/debug_spec.rb:23:in `block (2 levels) in <top (required)>'
     spec/features/cli/debug_spec.rb:29:in `block (3 levels) in <top (required)>'
     spec/features/cli/debug_spec.rb:28:in `block (2 levels) in <top (required)>'
@@ -39,5 +39,6 @@
   $ pakyow failed
 
 [1mOPTIONS[0m
-  -e, --env=env      [33mThe environment to run this command under[0m
-      --debug        [33mShow low-level debugging information[0m
+  -e, --env=env        [33mThe environment to run this command under[0m
+  -c, --config=config  [33mPath to the environment config file (default: config/environment)[0m
+      --debug          [33mShow low-level debugging information[0m

--- a/pakyow-core/spec/expectations/commands/boot/help
+++ b/pakyow-core/spec/expectations/commands/boot/help
@@ -8,4 +8,5 @@
       --host=host              [33mThe host the server runs on (default: localhost)[0m
   -p, --port=port              [33mThe port the server runs on (default: 3000)[0m
   -f, --formation=formation    [33mThe formation to boot (default: all)[0m
+  -c, --config=config          [33mPath to the environment config file (default: config/environment)[0m
       --debug                  [33mShow low-level debugging information[0m

--- a/pakyow-core/spec/expectations/commands/create/help
+++ b/pakyow-core/spec/expectations/commands/create/help
@@ -9,4 +9,5 @@
 [1mOPTIONS[0m
   -e, --env=env            [33mThe environment to run this command under[0m
   -t, --template=template  [33mThe template to create the project from (default: default)[0m
+  -c, --config=config      [33mPath to the environment config file (default: config/environment)[0m
       --debug              [33mShow low-level debugging information[0m

--- a/pakyow-core/spec/expectations/commands/help/for/help
+++ b/pakyow-core/spec/expectations/commands/help/for/help
@@ -7,5 +7,6 @@
   COMMAND  [33mThe command to get help for[0m
 
 [1mOPTIONS[0m
-  -e, --env=env      [33mThe environment to run this command under[0m
-      --debug        [33mShow low-level debugging information[0m
+  -e, --env=env        [33mThe environment to run this command under[0m
+  -c, --config=config  [33mPath to the environment config file (default: config/environment)[0m
+      --debug          [33mShow low-level debugging information[0m

--- a/pakyow-core/spec/expectations/commands/help/help
+++ b/pakyow-core/spec/expectations/commands/help/help
@@ -7,5 +7,6 @@
   COMMAND  [33mThe command to get help for[0m
 
 [1mOPTIONS[0m
-  -e, --env=env      [33mThe environment to run this command under[0m
-      --debug        [33mShow low-level debugging information[0m
+  -e, --env=env        [33mThe environment to run this command under[0m
+  -c, --config=config  [33mPath to the environment config file (default: config/environment)[0m
+      --debug          [33mShow low-level debugging information[0m

--- a/pakyow-core/spec/expectations/commands/info/endpoints/help
+++ b/pakyow-core/spec/expectations/commands/info/endpoints/help
@@ -4,6 +4,7 @@
   $ pakyow info:endpoints
 
 [1mOPTIONS[0m
-  -a, --app=app      [33mThe app to run the command on[0m
-  -e, --env=env      [33mThe environment to run this command under[0m
-      --debug        [33mShow low-level debugging information[0m
+  -a, --app=app        [33mThe app to run the command on[0m
+  -e, --env=env        [33mThe environment to run this command under[0m
+  -c, --config=config  [33mPath to the environment config file (default: config/environment)[0m
+      --debug          [33mShow low-level debugging information[0m

--- a/pakyow-core/spec/expectations/commands/info/help
+++ b/pakyow-core/spec/expectations/commands/info/help
@@ -4,5 +4,6 @@
   $ pakyow info
 
 [1mOPTIONS[0m
-  -e, --env=env      [33mThe environment to run this command under[0m
-      --debug        [33mShow low-level debugging information[0m
+  -e, --env=env        [33mThe environment to run this command under[0m
+  -c, --config=config  [33mPath to the environment config file (default: ../../pakyow-core/config/environment)[0m
+      --debug          [33mShow low-level debugging information[0m

--- a/pakyow-core/spec/expectations/commands/irb/help
+++ b/pakyow-core/spec/expectations/commands/irb/help
@@ -4,5 +4,6 @@
   $ pakyow irb
 
 [1mOPTIONS[0m
-  -e, --env=env      [33mThe environment to run this command under[0m
-      --debug        [33mShow low-level debugging information[0m
+  -e, --env=env        [33mThe environment to run this command under[0m
+  -c, --config=config  [33mPath to the environment config file (default: config/environment)[0m
+      --debug          [33mShow low-level debugging information[0m

--- a/pakyow-core/spec/expectations/commands/prelaunch/build/help
+++ b/pakyow-core/spec/expectations/commands/prelaunch/build/help
@@ -4,5 +4,6 @@
   $ pakyow prelaunch:build
 
 [1mOPTIONS[0m
-  -e, --env=env      [33mThe environment to run this command under[0m
-      --debug        [33mShow low-level debugging information[0m
+  -e, --env=env        [33mThe environment to run this command under[0m
+  -c, --config=config  [33mPath to the environment config file (default: config/environment)[0m
+      --debug          [33mShow low-level debugging information[0m

--- a/pakyow-core/spec/expectations/commands/prelaunch/help
+++ b/pakyow-core/spec/expectations/commands/prelaunch/help
@@ -4,5 +4,6 @@
   $ pakyow prelaunch
 
 [1mOPTIONS[0m
-  -e, --env=env      [33mThe environment to run this command under[0m
-      --debug        [33mShow low-level debugging information[0m
+  -e, --env=env        [33mThe environment to run this command under[0m
+  -c, --config=config  [33mPath to the environment config file (default: config/environment)[0m
+      --debug          [33mShow low-level debugging information[0m

--- a/pakyow-core/spec/expectations/commands/prelaunch/release/help
+++ b/pakyow-core/spec/expectations/commands/prelaunch/release/help
@@ -4,5 +4,6 @@
   $ pakyow prelaunch:release
 
 [1mOPTIONS[0m
-  -e, --env=env      [33mThe environment to run this command under[0m
-      --debug        [33mShow low-level debugging information[0m
+  -e, --env=env        [33mThe environment to run this command under[0m
+  -c, --config=config  [33mPath to the environment config file (default: config/environment)[0m
+      --debug          [33mShow low-level debugging information[0m

--- a/pakyow-core/spec/expectations/commands/prototype/help
+++ b/pakyow-core/spec/expectations/commands/prototype/help
@@ -4,7 +4,8 @@
   $ pakyow prototype
 
 [1mOPTIONS[0m
-  -e, --env=env      [33mThe environment to run this command under[0m
-      --host=host    [33mThe host the server runs on (default: localhost)[0m
-  -p, --port=port    [33mThe port the server runs on (default: 3000)[0m
-      --debug        [33mShow low-level debugging information[0m
+  -e, --env=env        [33mThe environment to run this command under[0m
+      --host=host      [33mThe host the server runs on (default: localhost)[0m
+  -p, --port=port      [33mThe port the server runs on (default: 3000)[0m
+  -c, --config=config  [33mPath to the environment config file (default: config/environment)[0m
+      --debug          [33mShow low-level debugging information[0m

--- a/pakyow-core/spec/features/cli/config_spec.rb
+++ b/pakyow-core/spec/features/cli/config_spec.rb
@@ -1,0 +1,61 @@
+require "fileutils"
+require "securerandom"
+
+RSpec.describe "setting the environment config in the cli" do
+  before do
+    FileUtils.mkdir_p(path)
+    config_file.open("w+") do |file|
+      file.write <<~CODE
+        ENV[#{key.inspect}] = "true"
+      CODE
+    end
+
+    Pakyow.command :config do; end
+    allow(output).to receive(:tty?).and_return(true)
+    allow(Pakyow::CLI).to receive(:project_context?).and_return(true)
+  end
+
+  after do
+    FileUtils.rm_r(path)
+  end
+
+  let(:command) {
+    "config"
+  }
+
+  let(:argv) {
+    ["--config=#{config_path}"]
+  }
+
+  let(:output) {
+    StringIO.new
+  }
+
+  let(:result) {
+    output.rewind; output.read
+  }
+
+  let(:config_path) {
+    path.join("e")
+  }
+
+  let(:config_file) {
+    Pathname.new(config_path.to_s + ".rb")
+  }
+
+  let(:path) {
+    Pathname.new(File.expand_path("../tmp", __FILE__))
+  }
+
+  let(:key) {
+    SecureRandom.hex(8).upcase
+  }
+
+  it "loads the correct environment config" do
+    expect {
+      Pakyow::CLI.run([command].concat(argv).compact, output: output)
+    }.to change {
+      ENV[key]
+    }.from(nil).to("true")
+  end
+end

--- a/pakyow-data/spec/expectations/commands/bootstrap/help
+++ b/pakyow-data/spec/expectations/commands/bootstrap/help
@@ -7,4 +7,5 @@
   -e, --env=env                [33mThe environment to run this command under[0m
       --adapter=adapter        [33mThe database adapter (default: sql)[0m
   -c, --connection=connection  [33mThe database connection (default: default)[0m
+  -c, --config=config          [33mPath to the environment config file (default: config/environment)[0m
       --debug                  [33mShow low-level debugging information[0m

--- a/pakyow-data/spec/expectations/commands/create/help
+++ b/pakyow-data/spec/expectations/commands/create/help
@@ -7,4 +7,5 @@
   -e, --env=env                [33mThe environment to run this command under[0m
       --adapter=adapter        [33mThe database adapter (default: sql)[0m
   -c, --connection=connection  [33mThe database connection (default: default)[0m
+  -c, --config=config          [33mPath to the environment config file (default: config/environment)[0m
       --debug                  [33mShow low-level debugging information[0m

--- a/pakyow-data/spec/expectations/commands/drop/help
+++ b/pakyow-data/spec/expectations/commands/drop/help
@@ -7,4 +7,5 @@
   -e, --env=env                [33mThe environment to run this command under[0m
       --adapter=adapter        [33mThe database adapter (default: sql)[0m
   -c, --connection=connection  [33mThe database connection (default: default)[0m
+  -c, --config=config          [33mPath to the environment config file (default: config/environment)[0m
       --debug                  [33mShow low-level debugging information[0m

--- a/pakyow-data/spec/expectations/commands/finalize/help
+++ b/pakyow-data/spec/expectations/commands/finalize/help
@@ -7,4 +7,5 @@
   -e, --env=env                [33mThe environment to run this command under[0m
       --adapter=adapter        [33mThe database adapter (default: sql)[0m
   -c, --connection=connection  [33mThe database connection (default: default)[0m
+  -c, --config=config          [33mPath to the environment config file (default: config/environment)[0m
       --debug                  [33mShow low-level debugging information[0m

--- a/pakyow-data/spec/expectations/commands/info/sources/help
+++ b/pakyow-data/spec/expectations/commands/info/sources/help
@@ -4,6 +4,7 @@
   $ pakyow info:sources
 
 [1mOPTIONS[0m
-  -a, --app=app      [33mThe app to run the command on[0m
-  -e, --env=env      [33mThe environment to run this command under[0m
-      --debug        [33mShow low-level debugging information[0m
+  -a, --app=app        [33mThe app to run the command on[0m
+  -e, --env=env        [33mThe environment to run this command under[0m
+  -c, --config=config  [33mPath to the environment config file (default: config/environment)[0m
+      --debug          [33mShow low-level debugging information[0m

--- a/pakyow-data/spec/expectations/commands/migrate/help
+++ b/pakyow-data/spec/expectations/commands/migrate/help
@@ -7,4 +7,5 @@
   -e, --env=env                [33mThe environment to run this command under[0m
       --adapter=adapter        [33mThe database adapter (default: sql)[0m
   -c, --connection=connection  [33mThe database connection (default: default)[0m
+  -c, --config=config          [33mPath to the environment config file (default: config/environment)[0m
       --debug                  [33mShow low-level debugging information[0m

--- a/pakyow-data/spec/expectations/commands/reset/help
+++ b/pakyow-data/spec/expectations/commands/reset/help
@@ -7,4 +7,5 @@
   -e, --env=env                [33mThe environment to run this command under[0m
       --adapter=adapter        [33mThe database adapter (default: sql)[0m
   -c, --connection=connection  [33mThe database connection (default: default)[0m
+  -c, --config=config          [33mPath to the environment config file (default: config/environment)[0m
       --debug                  [33mShow low-level debugging information[0m


### PR DESCRIPTION
Since the environment config path is itself a configuration option, passing the `--config` option allows the path to be changed prior to loading the environment.