### PR TITLE
Pass arguments through operations

### DIFF
--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `chg` **Pass arguments through operations.**
+
+    *Related links:*
+    - [Pull Request #483][pr-483]
+
   * `chg` **Load commands after load instead of after configure.**
 
     *Related links:*
@@ -518,6 +523,7 @@
     *Related links:*
     - [Pull Request #338][pr-338]
 
+[pr-483]: https://github.com/pakyow/pakyow/pull/483
 [pr-480]: https://github.com/pakyow/pakyow/pull/480
 [pr-478]: https://github.com/pakyow/pakyow/pull/478
 [pr-477]: https://github.com/pakyow/pakyow/pull/477

--- a/pakyow-core/lib/pakyow/operation.rb
+++ b/pakyow-core/lib/pakyow/operation.rb
@@ -45,9 +45,9 @@ module Pakyow
       end
     end
 
-    def perform
+    def perform(*args, **kwargs)
       handling do
-        call(self)
+        call(*args, **kwargs); self
       end
     end
 

--- a/pakyow-core/spec/features/operation/arguments_spec.rb
+++ b/pakyow-core/spec/features/operation/arguments_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe "passing arguments through an operation" do
+  include_context "app"
+
+  let(:app_def) {
+    local = self
+
+    Proc.new {
+      operation :foo do
+        action do |arg_1, arg_2, foo:|
+          local.arguments = {
+            arg_1: arg_1,
+            arg_2: arg_2,
+            foo: foo
+          }
+        end
+      end
+    }
+  }
+
+  attr_accessor :arguments
+
+  let(:operation) {
+    app.operations(:foo).new
+  }
+
+  it "passes arguments through the operation" do
+    operation.perform(:foo, :bar, foo: :baz)
+
+    expect(arguments).to eq({
+      arg_1: :foo,
+      arg_2: :bar,
+      foo: :baz
+    })
+  end
+end


### PR DESCRIPTION
`Pakyow::Operation#perform` now passes arguments through its internal pipeline. This allows an instance of an operation to be created with some initial state and be called multiple times, each time with different call-time state.

```ruby
operation :hello do
  optional :greeting, default: "hello"

  action do |target|
    logger << "#{greeting} #{target}"
  end
end

operation = operations(:hello).new
operation.perform("web")
# => logs: hello web
```