### PR TITLE
Only yield from ensure boot when the environment has booted successfully

### DIFF
--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `fix` **Only yield from ensure boot when the environment has booted successfully.**
+
+    *Related links:*
+    - [Pull Request #485][pr-485]
+
   * `chg` **Pass arguments through operations.**
 
     *Related links:*

--- a/pakyow-core/lib/pakyow/behavior/running/ensure_booted.rb
+++ b/pakyow-core/lib/pakyow/behavior/running/ensure_booted.rb
@@ -18,9 +18,13 @@ module Pakyow
         # Call from a service to ensure that the environment has booted. Yields when booted.
         #
         private def ensure_booted
-          unless Pakyow.booted? || Pakyow.rescued?
+          if Pakyow.booted?
+            yield unless Pakyow.rescued?
+          elsif !Pakyow.rescued?
             handling do
               Pakyow.boot(env: options[:env])
+
+              yield
 
               Pakyow.deprecator.ignore do
                 if Pakyow.config.freeze_on_boot
@@ -29,8 +33,6 @@ module Pakyow
               end
             end
           end
-        ensure
-          yield
         end
       end
     end

--- a/pakyow-core/spec/unit/behavior/running/ensure_booted_spec.rb
+++ b/pakyow-core/spec/unit/behavior/running/ensure_booted_spec.rb
@@ -1,0 +1,78 @@
+require "pakyow/support/handleable"
+require "pakyow/behavior/running/ensure_booted"
+
+RSpec.describe Pakyow::Behavior::Running::EnsureBooted do
+  subject { klass.new }
+
+  let(:klass) {
+    Class.new {
+      include Pakyow::Support::Handleable
+      include Pakyow::Behavior::Running::EnsureBooted
+
+      def options
+        {}
+      end
+
+      def handling
+        yield
+      rescue
+      end
+    }
+  }
+
+  describe "#ensure_booted" do
+    context "environment is not booted" do
+      it "yields" do
+        expect { |block|
+          subject.send(:ensure_booted, &block)
+        }.to yield_control
+      end
+
+      it "deep freezes after yielding" do
+        allow(Pakyow).to receive(:deep_freeze)
+
+        subject.send(:ensure_booted) do
+          expect(Pakyow).not_to have_received(:deep_freeze)
+        end
+
+        expect(Pakyow).to have_received(:deep_freeze)
+      end
+
+      context "environment fails to boot" do
+        before do
+          allow(Pakyow).to receive(:boot).and_raise(RuntimeError)
+        end
+
+        it "does not yield" do
+          expect { |block|
+          subject.send(:ensure_booted, &block)
+        }.not_to yield_control
+        end
+      end
+    end
+
+    context "environment is booted" do
+      before do
+        allow(Pakyow).to receive(:booted?).and_return(true)
+      end
+
+      it "yields" do
+        expect { |block|
+          subject.send(:ensure_booted, &block)
+        }.to yield_control
+      end
+
+      context "environment is rescued" do
+        before do
+          allow(Pakyow).to receive(:rescued?).and_return(true)
+        end
+
+        it "does not yield" do
+          expect { |block|
+          subject.send(:ensure_booted, &block)
+        }.not_to yield_control
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Prevents some hard-to-test side-effects when the environment fails to boot within a service.