### PR TITLE
Output logfmt events in a single write

### DIFF
--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `chg` **Output logfmt events in a single write.**
+
+    *Related links:*
+    - [Pull Request #486][pr-486]
+
   * `chg` **Pass arguments through operations.**
 
     *Related links:*
@@ -543,6 +548,7 @@
     *Related links:*
     - [Pull Request #338][pr-338]
 
+[pr-486]: https://github.com/pakyow/pakyow/pull/486
 [pr-483]: https://github.com/pakyow/pakyow/pull/483
 [pr-481]: https://github.com/pakyow/pakyow/pull/481
 [pr-480]: https://github.com/pakyow/pakyow/pull/480

--- a/pakyow-core/lib/pakyow/logger/formatters/logfmt.rb
+++ b/pakyow-core/lib/pakyow/logger/formatters/logfmt.rb
@@ -19,7 +19,8 @@ module Pakyow
         UNESCAPED_STRING = /\A[\w\.\-\+\%\,\:\;\/]*\z/i
 
         def serialize(message)
-          first = true
+          string = String.new
+
           message.each_pair do |key, value|
             value = case value
             when Array
@@ -32,17 +33,10 @@ module Pakyow
               value = value.dump
             end
 
-            unless first
-              @output.call(" ")
-            end
-
-            @output.call(key)
-            @output.call("=")
-            @output.call(value)
-            first = false
+            string << key.to_s << "=" << value << " "
           end
 
-          @output.call("\n")
+          @output.call(string.rstrip << "\n")
         end
       end
     end


### PR DESCRIPTION
This was causing events to be jumbled in high-traffic production deployments.