### PR TITLE
Prevent deep freeze error when running formations

### DIFF
--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `fix` **Prevent deep freeze error when running formations.**
+
+    *Related links:*
+    - [Pull Request #488][pr-488]
+
   * `chg` **Don't sync logger destinations in production.**
 
     *Related links:*
@@ -553,6 +558,7 @@
     *Related links:*
     - [Pull Request #338][pr-338]
 
+[pr-488]: https://github.com/pakyow/pakyow/pull/488
 [pr-487]: https://github.com/pakyow/pakyow/pull/487
 [pr-486]: https://github.com/pakyow/pakyow/pull/486
 [pr-483]: https://github.com/pakyow/pakyow/pull/483

--- a/pakyow-core/lib/pakyow/runnable/container/strategies/base.rb
+++ b/pakyow-core/lib/pakyow/runnable/container/strategies/base.rb
@@ -28,7 +28,7 @@ module Pakyow
             @notifier&.stop
             @notifier = Notifier.new(container: container, &method(:handle_notification).to_proc)
 
-            container.formation.each do |service_name, desired_service_count|
+            container.formation.each.map {|service_name, desired_service_count|
               service_instance = container.services(service_name).new(**container.options)
               desired_service_count ||= (service_instance.count || 1)
               service_limit = service_instance.limit
@@ -41,6 +41,8 @@ module Pakyow
                 service_limit
               end
 
+              [service_instance, service_count]
+            }.each do |service_instance, service_count|
               service_count.times do |index|
                 manage_service(service_instance.dup)
               end

--- a/spec/smoke/formations_spec.rb
+++ b/spec/smoke/formations_spec.rb
@@ -1,0 +1,24 @@
+require "smoke_helper"
+
+RSpec.describe "booting a formation", smoke: true do
+  before do
+    File.open(project_path.join("config/application.rb"), "w+") do |file|
+      file.write <<~SOURCE
+        Pakyow.app :smoke_test, only: %i[routing data] do
+          controller "/" do
+            default do
+              send "foo"
+            end
+          end
+        end
+      SOURCE
+    end
+
+    boot(formation: "environment.server=1")
+  end
+
+  it "boots" do
+    response = HTTP.get("http://localhost:#{port}/")
+    expect(response.body.to_s).to eq("foo")
+  end
+end

--- a/spec/smoke_helper.rb
+++ b/spec/smoke_helper.rb
@@ -79,9 +79,15 @@ RSpec.configure do |config|
     Dir.chdir(@project_path)
   end
 
-  def boot(environment: self.environment, envars: self.envars, port: self.port, host: self.host, wait: true)
+  def boot(environment: self.environment, envars: self.envars, port: self.port, host: self.host, wait: true, formation: nil)
     Bundler.with_original_env do
-      @server = Process.spawn(envars, "pakyow boot -e #{environment} -p #{port} --host #{host}")
+      command = if formation
+        "pakyow boot -e #{environment} -p #{port} --host #{host} -f #{formation}"
+      else
+        "pakyow boot -e #{environment} -p #{port} --host #{host}"
+      end
+
+      @server = Process.spawn(envars, command)
     end
 
     if wait


### PR DESCRIPTION
Services deep freeze the environment on boot, which was causing a hash replacement error in some situations. The error stemmed from freezing the `@services` hash in the `Formation` class. We iterate over this object to start each service, then deep freezing causes the services hash to be replaced while we're iterating. This change iterates over local state instead.