### PR TITLE
Deep freeze the environment after yielding

### DIFF
--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `fix` **Deep freeze the environment after yielding.**
+
+    *Related links:*
+    - [Pull Request #489][pr-489]
+
   * `fix` **Prevent deep freeze error when running formations.**
 
     *Related links:*
@@ -558,6 +563,7 @@
     *Related links:*
     - [Pull Request #338][pr-338]
 
+[pr-489]: https://github.com/pakyow/pakyow/pull/489
 [pr-488]: https://github.com/pakyow/pakyow/pull/488
 [pr-487]: https://github.com/pakyow/pakyow/pull/487
 [pr-486]: https://github.com/pakyow/pakyow/pull/486

--- a/pakyow-core/lib/pakyow/behavior/running/ensure_booted.rb
+++ b/pakyow-core/lib/pakyow/behavior/running/ensure_booted.rb
@@ -21,7 +21,13 @@ module Pakyow
           unless Pakyow.booted? || Pakyow.rescued?
             handling do
               Pakyow.boot(env: options[:env])
-
+            end
+          end
+        ensure
+          begin
+            yield
+          ensure
+            unless Pakyow.frozen?
               Pakyow.deprecator.ignore do
                 if Pakyow.config.freeze_on_boot
                   Pakyow.deep_freeze
@@ -29,8 +35,6 @@ module Pakyow
               end
             end
           end
-        ensure
-          yield
         end
       end
     end

--- a/pakyow-core/spec/unit/behavior/running/ensure_booted_spec.rb
+++ b/pakyow-core/spec/unit/behavior/running/ensure_booted_spec.rb
@@ -1,0 +1,95 @@
+require "pakyow/support/handleable"
+require "pakyow/behavior/running/ensure_booted"
+
+RSpec.describe Pakyow::Behavior::Running::EnsureBooted do
+  subject { klass.new }
+
+  let(:klass) {
+    Class.new {
+      include Pakyow::Support::Handleable
+      include Pakyow::Behavior::Running::EnsureBooted
+
+      def options
+        {}
+      end
+
+      def handling
+        yield
+      rescue
+      end
+    }
+  }
+
+  describe "#ensure_booted" do
+    context "environment is not booted" do
+      it "yields" do
+        expect { |block|
+          subject.send(:ensure_booted, &block)
+        }.to yield_control
+      end
+
+      it "deep freezes after yielding" do
+        allow(Pakyow).to receive(:deep_freeze)
+
+        subject.send(:ensure_booted) do
+          expect(Pakyow).not_to have_received(:deep_freeze)
+        end
+
+        expect(Pakyow).to have_received(:deep_freeze)
+      end
+
+      context "environment fails to boot" do
+        before do
+          allow(Pakyow).to receive(:boot).and_raise(RuntimeError)
+        end
+
+        it "yields" do
+          expect { |block|
+          subject.send(:ensure_booted, &block)
+        }.to yield_control
+        end
+      end
+    end
+
+    context "environment is booted" do
+      before do
+        allow(Pakyow).to receive(:booted?).and_return(true)
+      end
+
+      it "yields" do
+        expect { |block|
+          subject.send(:ensure_booted, &block)
+        }.to yield_control
+      end
+
+      context "environment is rescued" do
+        before do
+          allow(Pakyow).to receive(:rescued?).and_return(true)
+        end
+
+        it "yields" do
+          expect { |block|
+          subject.send(:ensure_booted, &block)
+        }.to yield_control
+        end
+      end
+    end
+
+    context "yield fails" do
+      before do
+        allow(Pakyow).to receive(:deep_freeze)
+
+        begin
+          subject.send(:ensure_booted) do
+            fail "something went wrong"
+          end
+        rescue
+        end
+      end
+
+      it "freezes the environment" do
+        expect(Pakyow).to have_received(:deep_freeze)
+      end
+    end
+  end
+end

--- a/pakyow-core/spec/unit/containers/environment/services/server_spec.rb
+++ b/pakyow-core/spec/unit/containers/environment/services/server_spec.rb
@@ -155,12 +155,6 @@ RSpec.describe "environment.server service" do
         instance.perform
       end
 
-      it "does not deep freeze the environment" do
-        expect(Pakyow).not_to receive(:deep_freeze)
-
-        instance.perform
-      end
-
       it "runs the server" do
         expect(Pakyow::Server).to receive(:run).with(
           Pakyow,
@@ -168,6 +162,18 @@ RSpec.describe "environment.server service" do
           protocol: protocol,
           scheme: scheme
         )
+
+        instance.perform
+      end
+    end
+
+    context "environment is already frozen" do
+      before do
+        allow(Pakyow).to receive(:frozen?).and_return(true)
+      end
+
+      it "does not deep freeze the environment" do
+        expect(Pakyow).not_to receive(:deep_freeze)
 
         instance.perform
       end

--- a/spec/smoke/sessions/cookie_spec.rb
+++ b/spec/smoke/sessions/cookie_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe "sessions, with the cookie adapter", smoke: true do
 
   let(:get_response) {
     HTTP.get("http://localhost:#{port}/session/get", headers: {
-      "cookie" => "pakyow.session=#{extract_session(set_response)}"
+      "cookie" => "smoke_test.session=#{extract_session(set_response)}"
     })
   }
 
   def extract_session(response)
-    response.headers["Set-Cookie"].split("pakyow.session=", 2)[1].split(";", 2)[0]
+    response.headers["Set-Cookie"].split("smoke_test.session=", 2)[1].split(";", 2)[0]
   end
 
   describe "setting and getting a session" do
@@ -39,7 +39,7 @@ RSpec.describe "sessions, with the cookie adapter", smoke: true do
     end
 
     it "sets the session" do
-      expect(set_response.headers["Set-Cookie"]).to start_with("pakyow.session=")
+      expect(set_response.headers["Set-Cookie"]).to start_with("smoke_test.session=")
       expect(set_response.headers["Set-Cookie"]).to end_with("; path=/; HttpOnly")
     end
 
@@ -82,13 +82,13 @@ RSpec.describe "sessions, with the cookie adapter", smoke: true do
 
     let(:chg_response) {
       HTTP.put("http://localhost:#{port}/session/chg", headers: {
-        "cookie" => "pakyow.session=#{extract_session(set_response)}"
+        "cookie" => "smoke_test.session=#{extract_session(set_response)}"
       })
     }
 
     let(:get_response_2) {
       HTTP.get("http://localhost:#{port}/session/get", headers: {
-        "cookie" => "pakyow.session=#{extract_session(chg_response)}"
+        "cookie" => "smoke_test.session=#{extract_session(chg_response)}"
       })
     }
 
@@ -126,13 +126,13 @@ RSpec.describe "sessions, with the cookie adapter", smoke: true do
 
     let(:del_response) {
       HTTP.delete("http://localhost:#{port}/session/del", headers: {
-        "cookie" => "pakyow.session=#{extract_session(set_response)}"
+        "cookie" => "smoke_test.session=#{extract_session(set_response)}"
       })
     }
 
     let(:get_response_2) {
       HTTP.get("http://localhost:#{port}/session/get", headers: {
-        "cookie" => "pakyow.session=#{extract_session(del_response)}"
+        "cookie" => "smoke_test.session=#{extract_session(del_response)}"
       })
     }
 


### PR DESCRIPTION
Allows for two things:

1. Code that is yielded to can still change the environment in some way.
2. The environment is still frozen even if an error is raised in yielded code.