### PR TITLE
Stop container notifiers more cleanly

### DIFF
--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `fix` **Stop container notifiers more cleanly.**
+
+    *Related links:*
+    - [Pull Request #492][pr-492]
+
   * `add` **Generate new applications, converting existing projects to multiapp environments.**
 
     *Related links:*
@@ -568,6 +573,7 @@
     *Related links:*
     - [Pull Request #338][pr-338]
 
+[pr-492]: https://github.com/pakyow/pakyow/pull/492
 [pr-490]: https://github.com/pakyow/pakyow/pull/490
 [pr-484]: https://github.com/pakyow/pakyow/pull/484
 [pr-488]: https://github.com/pakyow/pakyow/pull/488

--- a/pakyow-core/spec/integration/runnable/container/signaling_spec.rb
+++ b/pakyow-core/spec/integration/runnable/container/signaling_spec.rb
@@ -89,7 +89,9 @@ RSpec.describe "signaling runnable containers" do
 
       it "restarts the container" do
         run_then_kill do
-          expect(result).to eq("bar: performbar: stopbar: perform")
+          wait_for length: 33, timeout: 1 do |result|
+            expect(result).to eq("bar: performbar: stopbar: perform")
+          end
         end
       end
     end

--- a/pakyow-core/spec/integration/runnable/shared.rb
+++ b/pakyow-core/spec/integration/runnable/shared.rb
@@ -82,7 +82,9 @@ RSpec.shared_context "runnable container" do
         result << child_socket.recv(4096)
       end
 
-      yield result[0...length], Time.now - start
+      if block_given?
+        yield result[0...length], Time.now - start
+      end
     end
   end
 


### PR DESCRIPTION
The way we stopped internal container notifiers was too harsh and caused issues, particularly in Ruby 2.5.8. This PR is an attempt to resolve these issues by stopping more cleanly. It also resolves several intermittent test failures.