### PR TITLE
Expose results from operations

### DIFF
--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # v1.1.0 (unreleased)
 
+  * `add` **Expose results from operations.**
+
   * `fix` **Stop container notifiers more cleanly.**
 
     *Related links:*

--- a/pakyow-core/spec/expectations/cli/debug
+++ b/pakyow-core/spec/expectations/cli/debug
@@ -13,8 +13,8 @@
     [30;47;1m BACKTRACE                                                                      [0m
     
     spec/features/cli/debug_spec.rb:5:in `block (4 levels) in <top (required)>'
-    lib/pakyow/operation.rb:50:in `block in perform'
-    lib/pakyow/operation.rb:49:in `perform'
+    lib/pakyow/operation.rb:51:in `block in perform'
+    lib/pakyow/operation.rb:50:in `perform'
     lib/pakyow/command.rb:105:in `block (2 levels) in <class:Command>'
     lib/pakyow/command.rb:224:in `call'
     lib/pakyow/cli.rb:226:in `call_command'

--- a/pakyow-core/spec/features/operation/result_spec.rb
+++ b/pakyow-core/spec/features/operation/result_spec.rb
@@ -1,0 +1,62 @@
+RSpec.describe "exposing results from an operation" do
+  include_context "app"
+
+  let(:app_def) {
+    Proc.new {
+      operation :foo do
+        action do |value|
+          value
+        end
+      end
+    }
+  }
+
+  let(:operation) {
+    app.operations(:foo).new
+  }
+
+  it "exposes the result" do
+    expect(operation.perform(:foo).result).to eq(:foo)
+  end
+
+  context "operation has not performed" do
+    it "returns nil" do
+      expect(operation.result).to be(nil)
+    end
+  end
+
+  context "operation is performed multiple times" do
+    it "exposes the latest result" do
+      expect(operation.perform(:foo).result).to eq(:foo)
+      expect(operation.perform(:bar).result).to eq(:bar)
+    end
+  end
+
+  describe "multithread support" do
+    it "exposes the latest result to a child thread" do
+      result = nil
+      operation.perform(:foo)
+      Thread.new { result = operation.result }.join
+      expect(result).to eq(:foo)
+    end
+
+    context "child thread performs" do
+      it "exposes the result to the child thread" do
+        result = nil
+        Thread.new { result = operation.perform(:foo).result }.join
+        expect(result).to eq(:foo)
+      end
+
+      it "exposes the result to the parent thread" do
+        Thread.new { operation.perform(:foo) }.join
+        expect(operation.result).to eq(:foo)
+      end
+
+      it "does not change an existing result in the parent thread" do
+        operation.perform(:foo)
+        Thread.new { operation.perform(:bar) }.join
+        expect(operation.result).to eq(:foo)
+      end
+    end
+  end
+end

--- a/pakyow-core/spec/unit/logger/thread_local_spec.rb
+++ b/pakyow-core/spec/unit/logger/thread_local_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Pakyow::Logger::ThreadLocal do
       it "defaults to :pakyow_logger" do
         instance.set :foo
 
-        expect(Thread.current[:pakyow_logger]).to be(:foo)
+        expect(instance.thread_localized(:logger_thread_local_pakyow_logger)).to be(:foo)
       end
     end
   end

--- a/pakyow-presenter/spec/integration/empty_binding_scope_spec.rb
+++ b/pakyow-presenter/spec/integration/empty_binding_scope_spec.rb
@@ -1,3 +1,6 @@
+require "pakyow/presenter/significant_nodes"
+require "pakyow/presenter/view"
+
 RSpec.describe "empty binding scope that has no props" do
   let :view do
     Pakyow::Presenter::View.new(

--- a/pakyow-realtime/spec/features/persisting_state_spec.rb
+++ b/pakyow-realtime/spec/features/persisting_state_spec.rb
@@ -1,4 +1,5 @@
 require "pakyow/support/serializer"
+require "pakyow/logger/thread_local"
 
 RSpec.describe "persisting state on shutdown" do
   include_context "app"

--- a/pakyow-support/CHANGELOG.md
+++ b/pakyow-support/CHANGELOG.md
@@ -1,5 +1,9 @@
 # v1.1.0 (unreleased)
 
+  * `add` **Support halting and rejecting from the pipeline.**
+
+  * `chg` **Return the last pipeline action's return value.**
+
   * `add` **Support `extends` in definable objects.**
 
     *Related links:*

--- a/pakyow-support/CHANGELOG.md
+++ b/pakyow-support/CHANGELOG.md
@@ -1,5 +1,7 @@
 # v1.1.0 (unreleased)
 
+  * `add` **Introduce `ThreadLocalizer` for managing thread localized instance state.**
+
   * `add` **Support halting and rejecting from the pipeline.**
 
   * `chg` **Return the last pipeline action's return value.**

--- a/pakyow-support/lib/pakyow/support/deprecator.rb
+++ b/pakyow-support/lib/pakyow/support/deprecator.rb
@@ -2,6 +2,7 @@
 
 require_relative "deprecation"
 require_relative "deprecator/reporters/null"
+require_relative "thread_localizer"
 
 module Pakyow
   module Support
@@ -38,6 +39,8 @@ module Pakyow
     #   end
     #
     class Deprecator
+      include ThreadLocalizer
+
       def initialize(reporter:)
         @reporter = reporter
       end
@@ -84,15 +87,11 @@ module Pakyow
       end
 
       private def reporter
-        Thread.current[thread_local_key] || @reporter
+        thread_localized(:reporter) || @reporter
       end
 
       private def replace(reporter)
-        Thread.current[thread_local_key] = reporter
-      end
-
-      private def thread_local_key
-        @thread_local_key ||= :"pakyow_deprecator_#{object_id}_reporter"
+        thread_localize(:reporter, reporter)
       end
 
       class << self

--- a/pakyow-support/lib/pakyow/support/inspectable.rb
+++ b/pakyow-support/lib/pakyow/support/inspectable.rb
@@ -2,6 +2,7 @@
 
 require_relative "class_state"
 require_relative "extension"
+require_relative "thread_localizer"
 
 module Pakyow
   module Support
@@ -113,7 +114,7 @@ module Pakyow
       end
 
       def inspected_objects
-        Thread.current[:inspected_objects] ||= {}
+        ThreadLocalizer.thread_localized_store[:__pw_inspected_objects] ||= {}
       end
 
       def prevent_inspect_recursion

--- a/pakyow-support/lib/pakyow/support/pipeline.rb
+++ b/pakyow-support/lib/pakyow/support/pipeline.rb
@@ -6,44 +6,30 @@ require_relative "extension"
 
 module Pakyow
   module Support
-    # Provides pipeline behavior. Pipeline objects can define actions to be called in order on an
-    # instance of the pipelined object. Each action can act on the object passed to it. Any action
-    # can halt the pipeline, causing the result to be immediately returned without calling other
-    # actions. Objects passed through the pipeline should include {Pipeline::Object}.
-    #
-    # See {Pakyow::Application} and {Pakyow::Routing::Controller} for more examples.
+    # Pipelines define actions that are performed in order on an instance of the pipelined object.
+    # Each action can act on the arguments passed to it. Any action can halt the pipeline, causing
+    # the result to be immediately returned without calling other actions.
     #
     # @example
     #   class Application
     #     include Pakyow::Support::Pipeline
     #
-    #     action :foo
-    #     action :bar
-    #
-    #     def foo(result)
+    #     action :foo do |result|
     #       result << "foo"
     #     end
     #
-    #     def bar(result)
+    #     action :bar do |result|
     #       result << "bar"
+    #
+    #       halt result
+    #     end
+    #
+    #     action :baz do |result|
+    #       result << "baz"
     #     end
     #   end
     #
-    #   class Result
-    #     include Pakyow::Support::Pipeline::Object
-    #
-    #     attr_reader :results
-    #
-    #     def initialize
-    #       @results = []
-    #     end
-    #
-    #     def <<(result)
-    #       @results << result
-    #     end
-    #   end
-    #
-    #   Application.new.call(Result.new).results
+    #   Application.new.call([])
     #   => ["foo", "bar"]
     #
     module Pipeline
@@ -68,6 +54,14 @@ module Pakyow
         @__pipeline = @__pipeline.dup
 
         super
+      end
+
+      def reject(value = nil)
+        throw :reject, value
+      end
+
+      def halt(value = nil)
+        throw :halt, value
       end
 
       apply_extension do

--- a/pakyow-support/lib/pakyow/support/pipeline/internal.rb
+++ b/pakyow-support/lib/pakyow/support/pipeline/internal.rb
@@ -91,19 +91,24 @@ module Pakyow
         private def call_actions(actions, context, *args, **kwargs)
           Thread.current[:__pw_pipeline] ||= object_id
 
+          value = nil
           finished = false
 
-          catch :halt do
-            call_each_action(actions, context, *args, **kwargs)
+          halted = catch :halt do
+            value = call_each_action(actions, context, *args, **kwargs)
 
             finished = true
           end
 
-          unless finished || Thread.current[:__pw_pipeline] == object_id
-            throw :halt
+          unless finished
+            value = halted
+
+            unless Thread.current[:__pw_pipeline] == object_id
+              throw :halt, value
+            end
           end
 
-          args.first
+          value
         ensure
           if Thread.current[:__pw_pipeline] == object_id
             Thread.current[:__pw_pipeline] = nil
@@ -111,13 +116,24 @@ module Pakyow
         end
 
         private def call_each_action(actions, context, *args, **kwargs)
+          value = nil
+          finished = false
+
           until actions.empty?
-            catch :reject do
-              actions.shift.call(context, *args, **kwargs) do
+            rejected = catch :reject do
+              value = actions.shift.call(context, *args, **kwargs) do
                 call_each_action(actions, context, *args, **kwargs)
               end
+
+              finished = true
+            end
+
+            unless finished
+              value = rejected
             end
           end
+
+          value
         end
       end
     end

--- a/pakyow-support/lib/pakyow/support/pipeline/internal.rb
+++ b/pakyow-support/lib/pakyow/support/pipeline/internal.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "../deep_freeze"
+require_relative "../thread_localizer"
 
 module Pakyow
   module Support
@@ -89,7 +90,7 @@ module Pakyow
         end
 
         private def call_actions(actions, context, *args, **kwargs)
-          Thread.current[:__pw_pipeline] ||= object_id
+          ThreadLocalizer.thread_localized_store[:__pw_pipeline_object_id] ||= object_id
 
           value = nil
           finished = false
@@ -103,15 +104,15 @@ module Pakyow
           unless finished
             value = halted
 
-            unless Thread.current[:__pw_pipeline] == object_id
+            unless ThreadLocalizer.thread_localized_store[:__pw_pipeline_object_id] == object_id
               throw :halt, value
             end
           end
 
           value
         ensure
-          if Thread.current[:__pw_pipeline] == object_id
-            Thread.current[:__pw_pipeline] = nil
+          if ThreadLocalizer.thread_localized_store[:__pw_pipeline_object_id] == object_id
+            ThreadLocalizer.thread_localized_store.delete(:__pw_pipeline_object_id)
           end
         end
 

--- a/pakyow-support/lib/pakyow/support/pipeline/object.rb
+++ b/pakyow-support/lib/pakyow/support/pipeline/object.rb
@@ -19,7 +19,8 @@ module Pakyow
         end
 
         def reject
-          throw :reject, @__rejected = true
+          @__rejected = true
+          throw :reject, self
         end
 
         def rejected?
@@ -27,7 +28,8 @@ module Pakyow
         end
 
         def halt
-          throw :halt, @__halted = true
+          @__halted = true
+          throw :halt, self
         end
 
         def halted?

--- a/pakyow-support/lib/pakyow/support/thread_localizer.rb
+++ b/pakyow-support/lib/pakyow/support/thread_localizer.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require_relative "extension"
+
+module Pakyow
+  module Support
+    # Manages thread local state on classes and instances.
+    #
+    module ThreadLocalizer
+      require_relative "thread_localizer/store"
+
+      extend Support::Extension
+
+      # Localize `value` for `key` in the current thread.
+      #
+      def thread_localize(key, value)
+        key = thread_local_key(key)
+
+        ThreadLocalizer.thread_localized_store[key] = value
+
+        ObjectSpace.define_finalizer(self, ThreadLocalizer.cleanup_thread_localized(key))
+      end
+
+      # Returns the localized value for `key`, or `fallback`.
+      #
+      def thread_localized(key, fallback = nil)
+        key = thread_local_key(key)
+
+        ThreadLocalizer.thread_localized_store.fetch(key, fallback)
+      end
+
+      private def thread_local_key(name)
+        :"__pw_#{object_id}_#{name}"
+      end
+
+      def self.thread_localized_store
+        Thread.current[:__pw] ||= Store.new
+      end
+
+      # @api private
+      def self.cleanup_thread_localized(key)
+        proc { ThreadLocalizer.thread_localized_store.delete(key) }
+      end
+    end
+  end
+end

--- a/pakyow-support/lib/pakyow/support/thread_localizer.rb
+++ b/pakyow-support/lib/pakyow/support/thread_localizer.rb
@@ -18,7 +18,9 @@ module Pakyow
 
         ThreadLocalizer.thread_localized_store[key] = value
 
-        ObjectSpace.define_finalizer(self, ThreadLocalizer.cleanup_thread_localized(key))
+        unless frozen?
+          ObjectSpace.define_finalizer(self, ThreadLocalizer.cleanup_thread_localized(key))
+        end
       end
 
       # Returns the localized value for `key`, or `fallback`.

--- a/pakyow-support/lib/pakyow/support/thread_localizer.rb
+++ b/pakyow-support/lib/pakyow/support/thread_localizer.rb
@@ -29,6 +29,12 @@ module Pakyow
         ThreadLocalizer.thread_localized_store.fetch(key, fallback)
       end
 
+      # Deletes the localized value for `key`.
+      #
+      def delete_thread_localized(key)
+        ThreadLocalizer.thread_localized_store.delete(thread_local_key(key))
+      end
+
       private def thread_local_key(name)
         :"__pw_#{object_id}_#{name}"
       end

--- a/pakyow-support/lib/pakyow/support/thread_localizer/store.rb
+++ b/pakyow-support/lib/pakyow/support/thread_localizer/store.rb
@@ -7,7 +7,7 @@ module Pakyow
     module ThreadLocalizer
       class Store
         extend Forwardable
-        def_delegators :@state, :[], :[]=, :fetch, :delete
+        def_delegators :@state, :[], :[]=, :fetch, :delete, :clear
 
         def initialize
           @state = {}

--- a/pakyow-support/lib/pakyow/support/thread_localizer/store.rb
+++ b/pakyow-support/lib/pakyow/support/thread_localizer/store.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "forwardable"
+
+module Pakyow
+  module Support
+    module ThreadLocalizer
+      class Store
+        extend Forwardable
+        def_delegators :@state, :[], :[]=, :fetch, :delete
+
+        def initialize
+          @state = {}
+        end
+      end
+    end
+  end
+end

--- a/pakyow-support/spec/integration/pipeline/arguments_spec.rb
+++ b/pakyow-support/spec/integration/pipeline/arguments_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "passing arguments through pipelines" do
   context "action accepts state as well as a required argument" do
     shared_examples :common do
       it "accepts arguments" do
-        expect(call("foo").results).to eq(["foo"])
+        expect(call("foo")).to eq(["foo"])
       end
 
       it "fails when no arguments are passed" do
@@ -63,7 +63,7 @@ RSpec.describe "passing arguments through pipelines" do
       }
 
       it "accepts arguments" do
-        expect(call("foo").results).to eq(["foo"])
+        expect(call("foo")).to eq(["foo"])
       end
 
       it "does not fail when no arguments are passed" do
@@ -109,7 +109,7 @@ RSpec.describe "passing arguments through pipelines" do
   context "action accepts state as well as an optional argument" do
     shared_examples :common do
       it "accepts arguments" do
-        expect(call("foo").results).to eq(["foo"])
+        expect(call("foo")).to eq(["foo"])
       end
 
       it "does not fail when no arguments are passed" do
@@ -185,7 +185,7 @@ RSpec.describe "passing arguments through pipelines" do
   context "action accepts state as the only argument" do
     shared_examples :common do
       it "does not pass arguments" do
-        expect(call.results).to eq([])
+        expect(call).to eq(nil)
       end
 
       it "does not fail when passing arguments" do
@@ -253,7 +253,7 @@ RSpec.describe "passing arguments through pipelines" do
   context "action does not accept any arguments" do
     shared_examples :common do
       it "does not pass arguments" do
-        expect(call.results).to eq([])
+        expect(call).to eq(nil)
       end
 
       it "does not fail when passing arguments" do

--- a/pakyow-support/spec/integration/pipeline/instance_spec.rb
+++ b/pakyow-support/spec/integration/pipeline/instance_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "defining an action on a pipeline instance" do
   end
 
   it "calls the pipeline" do
-    expect(instance.call(result.new).results).to eq(["foo", "bar"])
+    expect(instance.call(result.new)).to eq(["foo", "bar"])
   end
 
   describe "duping the instance" do
@@ -54,8 +54,8 @@ RSpec.describe "defining an action on a pipeline instance" do
     end
 
     it "maintains its own pipeline" do
-      expect(instance.call(result.new).results).to eq(["foo", "bar"])
-      expect(duped.call(result.new).results).to eq(["foo", "bar", "baz"])
+      expect(instance.call(result.new)).to eq(["foo", "bar"])
+      expect(duped.call(result.new)).to eq(["foo", "bar", "baz"])
     end
   end
 end

--- a/pakyow-support/spec/integration/pipeline/keyword_arguments_spec.rb
+++ b/pakyow-support/spec/integration/pipeline/keyword_arguments_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "passing keyword arguments through pipelines" do
   context "action accepts state as well as a required keyword argument" do
     shared_examples :common do
       it "accepts keyword arguments" do
-        expect(call(foo: "foo").results).to eq(["foo"])
+        expect(call(foo: "foo")).to eq(["foo"])
       end
 
       it "fails when no arguments are passed" do
@@ -105,7 +105,7 @@ RSpec.describe "passing keyword arguments through pipelines" do
   context "action accepts state as well as an optional keyword argument" do
     shared_examples :common do
       it "accepts keyword arguments" do
-        expect(call(foo: "foo").results).to eq(["foo"])
+        expect(call(foo: "foo")).to eq(["foo"])
       end
 
       it "does not fail when no arguments are passed" do
@@ -361,7 +361,7 @@ RSpec.describe "passing keyword arguments through pipelines" do
   context "action accepts state as the only argument" do
     shared_examples :common do
       it "does not pass arguments" do
-        expect(call.results).to eq([])
+        expect(call).to eq(nil)
       end
 
       it "does not fail when passing keyword arguments" do
@@ -429,7 +429,7 @@ RSpec.describe "passing keyword arguments through pipelines" do
   context "action does not accept any arguments" do
     shared_examples :common do
       it "does not pass arguments" do
-        expect(call.results).to eq([])
+        expect(call).to eq(nil)
       end
 
       it "does not fail when passing keyword arguments" do

--- a/pakyow-support/spec/integration/pipeline/mixed_arguments_spec.rb
+++ b/pakyow-support/spec/integration/pipeline/mixed_arguments_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "passing mixed arguments through pipelines" do
   context "action accepts state as well as a required argument and a required keyword argument" do
     shared_examples :common do
       it "accepts expected arguments" do
-        expect(call("foo", bar: "bar").results).to eq(["foo", "bar"])
+        expect(call("foo", bar: "bar")).to eq(["foo", "bar"])
       end
 
       it "fails when no argument is passed" do
@@ -121,11 +121,11 @@ RSpec.describe "passing mixed arguments through pipelines" do
   context "action accepts state as well as an optional argument and a required keyword argument" do
     shared_examples :common do
       it "accepts an argument and keyword argument" do
-        expect(call("foo", bar: "bar").results).to eq(["foo", "bar"])
+        expect(call("foo", bar: "bar")).to eq(["foo", "bar"])
       end
 
       it "accepts just a keyword argument" do
-        expect(call(bar: "bar").results).to eq([nil, "bar"])
+        expect(call(bar: "bar")).to eq([nil, "bar"])
       end
 
       it "fails when no keyword argument is passed" do
@@ -211,23 +211,23 @@ RSpec.describe "passing mixed arguments through pipelines" do
   context "action accepts state as well as a required argument and an optional keyword argument" do
     shared_examples :common do
       it "accepts an argument and keyword argument" do
-        expect(call("foo", bar: "bar").results).to eq(["foo", "bar"])
+        expect(call("foo", bar: "bar")).to eq(["foo", "bar"])
       end
 
       it "accepts just an argument" do
-        expect(call("foo").results).to eq(["foo", nil])
+        expect(call("foo")).to eq(["foo", nil])
       end
 
       it "behaves as expected when no argument is passed" do
         # This is counter-intuitive, but it's how normal methods behave.
         #
-        expect(call(bar: "bar").results).to eq([{ bar: "bar" }, nil])
+        expect(call(bar: "bar")).to eq([{ bar: "bar" }, nil])
       end
 
       it "behaves as expected when no argument is passed" do
         # This is counter-intuitive, but it's the expected behavior.
         #
-        expect(call.results).to eq([{}, nil])
+        expect(call).to eq([{}, nil])
       end
     end
 
@@ -301,19 +301,19 @@ RSpec.describe "passing mixed arguments through pipelines" do
   context "action accepts state as well as an optional argument and an optional keyword argument" do
     shared_examples :common do
       it "accepts an argument and keyword argument" do
-        expect(call("foo", bar: "bar").results).to eq(["foo", "bar"])
+        expect(call("foo", bar: "bar")).to eq(["foo", "bar"])
       end
 
       it "accepts just an argument" do
-        expect(call("foo").results).to eq(["foo", nil])
+        expect(call("foo")).to eq(["foo", nil])
       end
 
       it "behaves as expected when no argument is passed" do
-        expect(call(bar: "bar").results).to eq([nil, "bar"])
+        expect(call(bar: "bar")).to eq([nil, "bar"])
       end
 
       it "behaves as expected when no argument is passed" do
-        expect(call.results).to eq([nil, nil])
+        expect(call).to eq([nil, nil])
       end
     end
 

--- a/pakyow-support/spec/integration/pipeline/nested_spec.rb
+++ b/pakyow-support/spec/integration/pipeline/nested_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe "calling a pipeline within another pipeline" do
       Class.new {
         include Pakyow::Support::Pipeline
 
-        action do
-          throw :halt
+        action do |result|
+          throw :halt, result
         end
       }
     }

--- a/pakyow-support/spec/integration/pipeline/reverse_spec.rb
+++ b/pakyow-support/spec/integration/pipeline/reverse_spec.rb
@@ -36,6 +36,6 @@ RSpec.describe "calling a pipeline in reverse" do
   end
 
   it "calls the pipeline" do
-    expect(pipelined.new.rcall(result.new).results).to eq(["bar", "foo"])
+    expect(pipelined.new.rcall(result.new)).to eq(["bar", "foo"])
   end
 end

--- a/pakyow-support/spec/integration/pipeline/stateless_spec.rb
+++ b/pakyow-support/spec/integration/pipeline/stateless_spec.rb
@@ -43,7 +43,8 @@ RSpec.describe "calling a pipeline without a pipeline object" do
     }
 
     it "calls the pipeline" do
-      expect(instance.call).to be(nil)
+      instance.call
+
       expect(instance.results[0]).to eq(["foo", nil])
       expect(instance.results[1]).to eq(["bar", nil])
     end
@@ -57,7 +58,7 @@ RSpec.describe "calling a pipeline without a pipeline object" do
         action :foo do |result|
           result << "foo"
 
-          throw :halt
+          throw :halt, result
         end
 
         action :bar do |result|

--- a/pakyow-support/spec/integration/pipeline/value_spec.rb
+++ b/pakyow-support/spec/integration/pipeline/value_spec.rb
@@ -1,0 +1,104 @@
+require "pakyow/support/pipeline"
+require "pakyow/support/pipeline/object"
+
+RSpec.describe "return values from pipelines" do
+  let(:pipelined) {
+    Class.new do
+      include Pakyow::Support::Pipeline
+    end
+  }
+
+  let(:instance) {
+    instance = pipelined.new
+
+    instance.action :foo do
+      :foo
+    end
+
+    instance.action :bar do
+      :bar
+    end
+
+    instance
+  }
+
+  it "returns the value from the last action" do
+    expect(instance.call).to eq(:bar)
+  end
+
+  context "action halts" do
+    let(:instance) {
+      instance = pipelined.new
+
+      instance.action :foo do
+        halt :foo
+      end
+
+      instance
+    }
+
+    it "returns the halted value" do
+      expect(instance.call).to eq(:foo)
+    end
+  end
+
+  context "action rejects" do
+    let(:instance) {
+      instance = pipelined.new
+
+      instance.action :foo do
+        reject :foo
+      end
+
+      instance
+    }
+
+    it "returns the rejected value" do
+      expect(instance.call).to eq(:foo)
+    end
+  end
+
+  context "passing an object" do
+    let(:result) {
+      Class.new do
+        include Pakyow::Support::Pipeline::Object
+      end
+    }
+
+    let(:result_instance) {
+      result.new
+    }
+
+    context "action halts an object" do
+      let(:instance) {
+        instance = pipelined.new
+
+        instance.action :foo do |result|
+          result.halt
+        end
+
+        instance
+      }
+
+      it "returns the halting value" do
+        expect(instance.call(result_instance)).to be(result_instance)
+      end
+    end
+
+    context "action rejects an object" do
+      let(:instance) {
+        instance = pipelined.new
+
+        instance.action :foo do |result|
+          result.reject
+        end
+
+        instance
+      }
+
+      it "returns the rejected value" do
+        expect(instance.call(result_instance)).to be(result_instance)
+      end
+    end
+  end
+end

--- a/pakyow-support/spec/integration/pipeline_spec.rb
+++ b/pakyow-support/spec/integration/pipeline_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "pipelines" do
     end
 
     it "calls the pipeline" do
-      expect(pipelined.new.call(result.new).results).to eq(["foo", "bar"])
+      expect(pipelined.new.call(result.new)).to eq(["foo", "bar"])
     end
 
     describe "call context" do
@@ -53,7 +53,7 @@ RSpec.describe "pipelines" do
       end
 
       it "calls the action in context of the pipelined instance" do
-        pipelined.new.call(result.new).results.each do |result|
+        pipelined.new.call(result.new).each do |result|
           expect(result).to be_instance_of(pipelined)
         end
       end
@@ -72,7 +72,7 @@ RSpec.describe "pipelines" do
     end
 
     it "calls the pipeline" do
-      expect(pipelined.new.call(result.new).results).to eq(["foo"])
+      expect(pipelined.new.call(result.new)).to eq(["foo"])
     end
 
     describe "call context" do
@@ -87,7 +87,7 @@ RSpec.describe "pipelines" do
       end
 
       it "calls the action in context of the pipelined instance" do
-        pipelined.new.call(result.new).results.each do |result|
+        pipelined.new.call(result.new).each do |result|
           expect(result).to be_instance_of(pipelined)
         end
       end
@@ -106,7 +106,7 @@ RSpec.describe "pipelines" do
     end
 
     it "calls the pipeline" do
-      expect(pipelined.new.call(result.new).results).to eq(["foo"])
+      expect(pipelined.new.call(result.new)).to eq(["foo"])
     end
 
     describe "call context" do
@@ -121,7 +121,7 @@ RSpec.describe "pipelines" do
       end
 
       it "calls the action in context of the pipelined instance" do
-        pipelined.new.call(result.new).results.each do |result|
+        pipelined.new.call(result.new).each do |result|
           expect(result).to be_instance_of(pipelined)
         end
       end
@@ -142,7 +142,7 @@ RSpec.describe "pipelines" do
     end
 
     it "calls the pipeline" do
-      expect(pipelined.new.call(result.new).results).to eq(["foo"])
+      expect(pipelined.new.call(result.new)).to eq(["foo"])
     end
 
     context "action is defined with options" do
@@ -163,7 +163,7 @@ RSpec.describe "pipelines" do
       end
 
       it "passes the options to the instance" do
-        expect(pipelined.new.call(result.new).results).to eq(["option"])
+        expect(pipelined.new.call(result.new)).to eq(["option"])
       end
     end
 
@@ -176,6 +176,7 @@ RSpec.describe "pipelines" do
             def call(result)
               result << @foo
               @foo = :foo
+              result
             end
           }
         end
@@ -208,7 +209,7 @@ RSpec.describe "pipelines" do
     end
 
     it "calls the pipeline" do
-      expect(pipelined.new.call(result.new).results).to eq(["foo"])
+      expect(pipelined.new.call(result.new)).to eq(["foo"])
     end
 
     context "action is defined with options" do
@@ -229,7 +230,7 @@ RSpec.describe "pipelines" do
       end
 
       it "passes the options to the instance" do
-        expect(pipelined.new.call(result.new).results).to eq(["option"])
+        expect(pipelined.new.call(result.new)).to eq(["option"])
       end
     end
 
@@ -250,7 +251,7 @@ RSpec.describe "pipelines" do
       end
 
       it "calls the pipeline" do
-        expect(pipelined.new.call(result.new).results).to eq(["foo"])
+        expect(pipelined.new.call(result.new)).to eq(["foo"])
       end
     end
   end
@@ -267,7 +268,7 @@ RSpec.describe "pipelines" do
     end
 
     it "calls the pipeline" do
-      expect(pipelined.new.call(result.new).results).to eq(["foo"])
+      expect(pipelined.new.call(result.new)).to eq(["foo"])
     end
   end
 
@@ -283,7 +284,7 @@ RSpec.describe "pipelines" do
     end
 
     it "calls the pipeline" do
-      expect(pipelined.new.call(result.new).results).to eq(["foo"])
+      expect(pipelined.new.call(result.new)).to eq(["foo"])
     end
   end
 
@@ -301,7 +302,7 @@ RSpec.describe "pipelines" do
     end
 
     it "calls the pipeline" do
-      expect(pipelined.new.call(result.new).results).to eq(["foo"])
+      expect(pipelined.new.call(result.new)).to eq(["foo"])
     end
   end
 
@@ -319,7 +320,7 @@ RSpec.describe "pipelines" do
     end
 
     it "calls the pipeline" do
-      expect(pipelined.new.call(result.new).results).to eq(["foo"])
+      expect(pipelined.new.call(result.new)).to eq(["foo"])
     end
   end
 
@@ -350,8 +351,8 @@ RSpec.describe "pipelines" do
 
     it "calls the pipeline" do
       instance = pipelined.new
-      instance.call(result.new)
-      expect(instance.results).to eq(["foo", "bar"])
+
+      expect(instance.call(result.new)).to eq(["foo", "bar"])
     end
   end
 
@@ -369,7 +370,7 @@ RSpec.describe "pipelines" do
         end
 
         def bar(result)
-          result.halt
+          halt result
         end
 
         def baz(result)
@@ -408,7 +409,7 @@ RSpec.describe "pipelines" do
     end
 
     it "skips to the next action" do
-      expect(pipelined.new.call(result.new).results).to eq(["bar", "baz"])
+      expect(pipelined.new.call(result.new)).to eq(["bar", "baz"])
     end
   end
 
@@ -438,7 +439,7 @@ RSpec.describe "pipelines" do
     end
 
     it "wraps the next actions" do
-      expect(pipelined.new.call(result.new).results).to eq(["foo", "bar1", "baz", "bar2"])
+      expect(pipelined.new.call(result.new)).to eq(["foo", "bar1", "baz", "bar2"])
     end
 
     context "action does not accept an argument" do
@@ -475,8 +476,8 @@ RSpec.describe "pipelines" do
 
       it "wraps the next actions" do
         instance = pipelined.new
-        instance.call(result.new)
-        expect(instance.results).to eq(["foo", "bar1", "baz", "bar2"])
+
+        expect(instance.call(result.new)).to eq(["foo", "bar1", "baz", "bar2"])
       end
     end
   end
@@ -509,7 +510,7 @@ RSpec.describe "pipelines" do
     end
 
     it "wraps the next actions" do
-      expect(pipelined.new.call(result.new).results).to eq(["foo", "bar1", "baz", "bar2"])
+      expect(pipelined.new.call(result.new)).to eq(["foo", "bar1", "baz", "bar2"])
     end
   end
 
@@ -541,7 +542,7 @@ RSpec.describe "pipelines" do
     end
 
     it "wraps the next actions" do
-      expect(pipelined.new.call(result.new).results).to eq(["foo", "bar1", "baz", "bar2"])
+      expect(pipelined.new.call(result.new)).to eq(["foo", "bar1", "baz", "bar2"])
     end
   end
 
@@ -567,10 +568,10 @@ RSpec.describe "pipelines" do
     end
 
     it "replaces the actions of the current pipeline" do
-      expect(pipelined.new.call(result.new).results).to eq(["foo"])
+      expect(pipelined.new.call(result.new)).to eq(["foo"])
 
       pipelined.use_pipeline :bar
-      expect(pipelined.new.call(result.new).results).to eq(["bar"])
+      expect(pipelined.new.call(result.new)).to eq(["bar"])
     end
   end
 
@@ -596,10 +597,10 @@ RSpec.describe "pipelines" do
     end
 
     it "includes the actions into the current pipeline" do
-      expect(pipelined.new.call(result.new).results).to eq(["foo"])
+      expect(pipelined.new.call(result.new)).to eq(["foo"])
 
       pipelined.include_pipeline :bar
-      expect(pipelined.new.call(result.new).results).to eq(["foo", "bar"])
+      expect(pipelined.new.call(result.new)).to eq(["foo", "bar"])
     end
   end
 
@@ -626,10 +627,10 @@ RSpec.describe "pipelines" do
     end
 
     it "excludes the actions from the current pipeline" do
-      expect(pipelined.new.call(result.new).results).to eq(["foo", "bar"])
+      expect(pipelined.new.call(result.new)).to eq(["foo", "bar"])
 
       pipelined.exclude_pipeline :bar
-      expect(pipelined.new.call(result.new).results).to eq(["foo"])
+      expect(pipelined.new.call(result.new)).to eq(["foo"])
     end
   end
 
@@ -678,12 +679,12 @@ RSpec.describe "pipelines" do
       end
 
       before do
-        expect(pipelined.new.call(result.new).results).to eq(["current"])
+        expect(pipelined.new.call(result.new)).to eq(["current"])
       end
 
       it "replaces the actions of the current pipeline" do
         pipelined.use_pipeline pipeline_module
-        expect(pipelined.new.call(result.new).results).to eq(["foo", "bar", "baz", "qux", "unnamed"])
+        expect(pipelined.new.call(result.new)).to eq(["foo", "bar", "baz", "qux", "unnamed"])
       end
 
       describe "using a pipeline module in two different classes" do
@@ -701,10 +702,10 @@ RSpec.describe "pipelines" do
 
         it "works for both pipelines objects" do
           pipelined.use_pipeline pipeline_module
-          expect(pipelined.new.call(result.new).results).to eq(["foo", "bar", "baz", "qux", "unnamed"])
+          expect(pipelined.new.call(result.new)).to eq(["foo", "bar", "baz", "qux", "unnamed"])
 
           pipelined_2.use_pipeline pipeline_module
-          expect(pipelined_2.new.call(result.new).results).to eq(["foo", "bar", "baz", "qux", "unnamed"])
+          expect(pipelined_2.new.call(result.new)).to eq(["foo", "bar", "baz", "qux", "unnamed"])
         end
       end
     end
@@ -723,10 +724,10 @@ RSpec.describe "pipelines" do
       end
 
       it "includes the actions into the current pipeline" do
-        expect(pipelined.new.call(result.new).results).to eq(["current"])
+        expect(pipelined.new.call(result.new)).to eq(["current"])
 
         pipelined.include_pipeline pipeline_module
-        expect(pipelined.new.call(result.new).results).to eq(["current", "foo", "bar", "baz", "qux", "unnamed"])
+        expect(pipelined.new.call(result.new)).to eq(["current", "foo", "bar", "baz", "qux", "unnamed"])
       end
     end
 
@@ -744,11 +745,11 @@ RSpec.describe "pipelines" do
       end
 
       it "excludes the actions from the current pipeline" do
-        expect(pipelined.new.call(result.new).results).to eq(["current"])
+        expect(pipelined.new.call(result.new)).to eq(["current"])
 
         pipelined.include_pipeline pipeline_module
         pipelined.exclude_pipeline pipeline_module
-        expect(pipelined.new.call(result.new).results).to eq(["current"])
+        expect(pipelined.new.call(result.new)).to eq(["current"])
       end
     end
 
@@ -795,7 +796,7 @@ RSpec.describe "pipelines" do
       end
 
       it "adds the action after" do
-        expect(pipelined.new.call(result.new).results).to eq(["foo", "baz", "bar"])
+        expect(pipelined.new.call(result.new)).to eq(["foo", "baz", "bar"])
       end
     end
 
@@ -823,7 +824,7 @@ RSpec.describe "pipelines" do
       end
 
       it "adds the action after" do
-        expect(pipelined.new.call(result.new).results).to eq(["foo", "baz", "bar"])
+        expect(pipelined.new.call(result.new)).to eq(["foo", "baz", "bar"])
       end
     end
 
@@ -847,7 +848,7 @@ RSpec.describe "pipelines" do
       end
 
       it "adds the action after" do
-        expect(pipelined.new.call(result.new).results).to eq(["foo", "baz", "bar"])
+        expect(pipelined.new.call(result.new)).to eq(["foo", "baz", "bar"])
       end
     end
 
@@ -871,7 +872,7 @@ RSpec.describe "pipelines" do
       end
 
       it "adds the action at the end" do
-        expect(pipelined.new.call(result.new).results).to eq(["foo", "bar", "baz"])
+        expect(pipelined.new.call(result.new)).to eq(["foo", "bar", "baz"])
       end
     end
   end
@@ -897,7 +898,7 @@ RSpec.describe "pipelines" do
       end
 
       it "adds the action before" do
-        expect(pipelined.new.call(result.new).results).to eq(["foo", "baz", "bar"])
+        expect(pipelined.new.call(result.new)).to eq(["foo", "baz", "bar"])
       end
     end
 
@@ -925,7 +926,7 @@ RSpec.describe "pipelines" do
       end
 
       it "adds the action before" do
-        expect(pipelined.new.call(result.new).results).to eq(["foo", "baz", "bar"])
+        expect(pipelined.new.call(result.new)).to eq(["foo", "baz", "bar"])
       end
     end
 
@@ -949,7 +950,7 @@ RSpec.describe "pipelines" do
       end
 
       it "adds the action before" do
-        expect(pipelined.new.call(result.new).results).to eq(["foo", "baz", "bar"])
+        expect(pipelined.new.call(result.new)).to eq(["foo", "baz", "bar"])
       end
     end
 
@@ -973,7 +974,7 @@ RSpec.describe "pipelines" do
       end
 
       it "adds the action at the beginning" do
-        expect(pipelined.new.call(result.new).results).to eq(["baz", "foo", "bar"])
+        expect(pipelined.new.call(result.new)).to eq(["baz", "foo", "bar"])
       end
     end
   end
@@ -1004,7 +1005,7 @@ RSpec.describe "pipelines" do
     end
 
     it "calls the pipeline" do
-      expect(pipelined.new.call(result.new).results).to eq(["foo", "bar", "qux"])
+      expect(pipelined.new.call(result.new)).to eq(["foo", "bar", "qux"])
     end
   end
 
@@ -1034,7 +1035,7 @@ RSpec.describe "pipelines" do
     end
 
     it "calls the pipeline" do
-      expect(pipelined.new.call(result.new).results).to eq(["bar", "qux"])
+      expect(pipelined.new.call(result.new)).to eq(["bar", "qux"])
     end
   end
 
@@ -1059,13 +1060,13 @@ RSpec.describe "pipelines" do
 
     it "can be called twice on the same instance" do
       pipeline = pipelined.new
-      expect(pipeline.call(result.new).results).to eq(["foo", "bar", "baz"])
-      expect(pipeline.call(result.new).results).to eq(["foo", "bar", "baz"])
+      expect(pipeline.call(result.new)).to eq(["foo", "bar", "baz"])
+      expect(pipeline.call(result.new)).to eq(["foo", "bar", "baz"])
     end
 
     it "can be called on different instances" do
-      expect(pipelined.new.call(result.new).results).to eq(["foo", "bar", "baz"])
-      expect(pipelined.new.call(result.new).results).to eq(["foo", "bar", "baz"])
+      expect(pipelined.new.call(result.new)).to eq(["foo", "bar", "baz"])
+      expect(pipelined.new.call(result.new)).to eq(["foo", "bar", "baz"])
     end
   end
 
@@ -1091,7 +1092,7 @@ RSpec.describe "pipelines" do
     end
 
     it "calls the pipeline" do
-      expect(pipelined.new.call(result.new).results).to eq(["foo", "bar"])
+      expect(pipelined.new.call(result.new)).to eq(["foo", "bar"])
     end
   end
 
@@ -1115,7 +1116,7 @@ RSpec.describe "pipelines" do
     end
 
     it "does not call the new action" do
-      expect(pipelined.new.call(result.new).results).to eq(["foo"])
+      expect(pipelined.new.call(result.new)).to eq(["foo"])
     end
   end
 
@@ -1145,7 +1146,7 @@ RSpec.describe "pipelines" do
     end
 
     it "calls the new action" do
-      expect(callable.call(result.new).results).to eq(["foo", "bar"])
+      expect(callable.call(result.new)).to eq(["foo", "bar"])
     end
   end
 end

--- a/pakyow-support/spec/unit/thread_localizer_spec.rb
+++ b/pakyow-support/spec/unit/thread_localizer_spec.rb
@@ -1,0 +1,86 @@
+require "pakyow/support/thread_localizer"
+
+RSpec.describe Pakyow::Support::ThreadLocalizer do
+  let(:object) {
+    Class.new {
+      include Pakyow::Support::ThreadLocalizer
+    }
+  }
+
+  let(:instance) {
+    object.new
+  }
+
+  before do
+    allow(Thread.current).to receive(:[]=).and_call_original
+  end
+
+  describe "#thread_localize" do
+    let(:key) {
+      :foo
+    }
+
+    let(:value) {
+      :bar
+    }
+
+    it "sets the thread local" do
+      expect(described_class.thread_localized_store).to receive(:[]=).with(:"__pw_#{instance.object_id}_#{key}", value)
+
+      instance.thread_localize(key, value)
+    end
+
+    it "defines a finalizer for the key" do
+      allow(described_class).to receive(:cleanup_thread_localized).with(:"__pw_#{instance.object_id}_#{key}").and_return(:proc)
+      expect(ObjectSpace).to receive(:define_finalizer).with(instance, :proc)
+
+      instance.thread_localize(key, value)
+    end
+
+    describe "the finalizer" do
+      let(:finalizer) {
+        @finalizer
+      }
+
+      before do
+        allow(described_class).to receive(:cleanup_thread_localized).with(:"__pw_#{instance.object_id}_#{key}").and_wrap_original do |method|
+          @finalizer = method.call(:"__pw_#{instance.object_id}_#{key}")
+        end
+
+        instance.thread_localize(key, value)
+      end
+
+      it "removes the localized value" do
+        expect(described_class.thread_localized_store).to receive(:delete).with(:"__pw_#{instance.object_id}_#{key}")
+
+        finalizer.call
+      end
+    end
+  end
+
+  describe "#thread_localized" do
+    before do
+      instance.thread_localize(:foo, :bar)
+    end
+
+    it "returns the value from the current thread" do
+      expect(instance.thread_localized(:foo)).to eq(:bar)
+    end
+
+    it "does not return the value from other instances" do
+      expect(object.new.thread_localized(:foo)).to be(nil)
+    end
+
+    it "does not return the value from a child thread" do
+      value = nil
+      Thread.new { value = instance.thread_localized(:foo) }.join
+      expect(value).to be(nil)
+    end
+
+    context "no value exists for the current thread" do
+      it "returns nil" do
+        expect(instance.thread_localized(:bar)).to be(nil)
+      end
+    end
+  end
+end

--- a/pakyow-support/spec/unit/thread_localizer_spec.rb
+++ b/pakyow-support/spec/unit/thread_localizer_spec.rb
@@ -83,4 +83,16 @@ RSpec.describe Pakyow::Support::ThreadLocalizer do
       end
     end
   end
+
+  describe "#delete_thread_localized" do
+    before do
+      instance.thread_localize(:foo, :bar)
+    end
+
+    it "deletes the localized value" do
+      instance.delete_thread_localized(:foo)
+
+      expect(instance.thread_localized(:foo)).to be(nil)
+    end
+  end
 end

--- a/spec/spec_config.rb
+++ b/spec/spec_config.rb
@@ -182,7 +182,9 @@ RSpec.configure do |config|
       remove_constants(["Generators"], Pakyow, false)
     end
 
-    Thread.current[:pakyow_logger] = nil
+    if defined?(Pakyow::Support::ThreadLocalizer)
+      Pakyow::Support::ThreadLocalizer.thread_localized_store&.clear
+    end
 
     if ENV["RSS"]
       GC.start


### PR DESCRIPTION
When operations are called, the return value of the last action is now exposed as `result`:

```ruby
operation :foo do
  action do |value|
    value.reverse
  end
end

operation = operations(:foo).new
operation.perform("foo")
operation.result
=> "oof"
```

## Behavior across threads

Operations use the new `Pakyow::Support::ThreadLocalizer` module for making results thread safe.

Child threads inherit the latest result from the operation:

```ruby
operation.perform("foo")

Thread.new do
  operation.result
  => "oof"
end
```

If the operation is performed in a thread, a new result is stored for the thread without altering the parent:

```ruby
operation.perform("foo")

Thread.new do
  operation.perform("bar").result
  => "rab"
end

operation.result
=> "oof"
```

`Pakyow::Support::ThreadLocalizer` takes care of cleaning up instance-localized state with finalizers.