### PR TITLE
Configure through environment variables

### DIFF
--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # v1.1.0 (unreleased)
 
+  * `add` **Configure the environment and applications through environment variables.**
+
   * `chg` **Don't use a service logger for the server service.**
 
     *Related links:*

--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -2,6 +2,9 @@
 
   * `add` **Configure the environment and applications through environment variables.**
 
+    *Related links:*
+    - [Pull Request #497][pr-497]
+
   * `chg` **Don't use a service logger for the server service.**
 
     *Related links:*
@@ -597,6 +600,7 @@
     *Related links:*
     - [Pull Request #338][pr-338]
 
+[pr-497]: https://github.com/pakyow/pakyow/pull/497
 [pr-496]: https://github.com/pakyow/pakyow/pull/496
 [pr-495]: https://github.com/pakyow/pakyow/pull/495
 [pr-494]: https://github.com/pakyow/pakyow/pull/494

--- a/pakyow-core/lib/pakyow/environment.rb
+++ b/pakyow-core/lib/pakyow/environment.rb
@@ -107,6 +107,8 @@ module Pakyow
 
   include Support::Configurable
 
+  envar :pwenv
+
   setting :default_env, :development
   setting :freeze_on_boot, true
   setting :exit_on_boot_failure, false
@@ -585,6 +587,8 @@ module Pakyow
         local = self
         require "pakyow/application"
         Pakyow::Application.make(Support::ObjectName.build(app_name, "application")) {
+          envar "PWAPP__#{app_name.to_s.upcase}"
+
           # Change the name only if it's still the default. It's possible the app has already been
           # defined and we're simply extending it.
           #

--- a/pakyow-core/spec/features/app/envar_config_spec.rb
+++ b/pakyow-core/spec/features/app/envar_config_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe "configuring an application with environment variables" do
+  before do
+    ENV["PWAPP__TEST__NAME"] = "env test"
+  end
+
+  after do
+    ENV.delete("PWAPP__TEST__NAME")
+  end
+
+  include_context "app"
+
+  it "configures" do
+    expect(Pakyow.apps.first.config.name).to eq("env test")
+  end
+end

--- a/pakyow-core/spec/features/envar_config_spec.rb
+++ b/pakyow-core/spec/features/envar_config_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe "configuring the environment with environment variables" do
+  before do
+    ENV["PWENV__DEFAULT_ENV"] = "test"
+  end
+
+  after do
+    ENV.delete("PWENV__DEFAULT_ENV")
+  end
+
+  it "configures" do
+    expect(Pakyow.config.default_env).to eq("test")
+  end
+end

--- a/pakyow-support/CHANGELOG.md
+++ b/pakyow-support/CHANGELOG.md
@@ -1,5 +1,7 @@
 # v1.1.0 (unreleased)
 
+  * `add` **Set config settings through environment variables.**
+
   * `add` **Introduce `ThreadLocalizer` for managing thread localized instance state.**
 
   * `add` **Support halting and rejecting from the pipeline.**

--- a/pakyow-support/CHANGELOG.md
+++ b/pakyow-support/CHANGELOG.md
@@ -2,6 +2,9 @@
 
   * `add` **Set config settings through environment variables.**
 
+    *Related links:*
+    - [Pull Request #497][pr-497]
+
   * `add` **Introduce `ThreadLocalizer` for managing thread localized instance state.**
 
   * `add` **Support halting and rejecting from the pipeline.**
@@ -321,6 +324,7 @@
     *Related links:*
     - [Pull Request #364][pr-364]
 
+[pr-497]: https://github.com/pakyow/pakyow/pull/497
 [pr-479]: https://github.com/pakyow/pakyow/pull/479
 [pr-478]: https://github.com/pakyow/pakyow/pull/478
 [pr-456]: https://github.com/pakyow/pakyow/pull/456

--- a/pakyow-support/lib/pakyow/support/configurable/config.rb
+++ b/pakyow-support/lib/pakyow/support/configurable/config.rb
@@ -76,6 +76,14 @@ module Pakyow
             super(target, solution: solution)
           end
 
+          def envar_prefix
+            if object_name.name == :config
+              nil
+            else
+              "#{object_name.parts.map { |part| part.to_s.upcase }.join("__")}"
+            end
+          end
+
           private def find_setting(name)
             @__settings[name]
           end
@@ -144,6 +152,10 @@ module Pakyow
 
         def object_name
           self.class.object_name
+        end
+
+        def envar_prefix
+          self.class.envar_prefix
         end
 
         # @api private

--- a/pakyow-support/lib/pakyow/support/configurable/config/behavior/defining.rb
+++ b/pakyow-support/lib/pakyow/support/configurable/config/behavior/defining.rb
@@ -68,6 +68,7 @@ module Pakyow
                   name: name,
                   default: default.deep_dup,
                   configurable: __configurable,
+                  envar_prefix: envar_prefix,
                   &block
                 )
 

--- a/pakyow-support/spec/integration/configurable/environment_variables_spec.rb
+++ b/pakyow-support/spec/integration/configurable/environment_variables_spec.rb
@@ -1,0 +1,91 @@
+require "pakyow/support/configurable"
+
+RSpec.describe "configuring with environment variables" do
+  let(:object) {
+    Class.new {
+      include Pakyow::Support::Configurable
+
+      envar :pwtest
+    }
+  }
+
+  before do
+    ENV["PWTEST__FOO"] = "env_foo"
+    ENV["PWTEST__BAR__BAZ"] = "env_bar_baz"
+    ENV["PWTEST__BAZ__QUX__QUUX"] = "env_baz_qux_quux"
+
+    object.setting :foo
+
+    object.configurable :bar do
+      setting :baz
+    end
+
+    object.configurable :baz do
+      configurable :qux do
+        setting :quux
+      end
+    end
+  end
+
+  it "uses the environment variable value for a setting" do
+    expect(object.config.foo).to eq("env_foo")
+  end
+
+  it "uses the environment variable value for a setting in a group" do
+    expect(object.config.bar.baz).to eq("env_bar_baz")
+  end
+
+  it "uses the environment variable value for a setting in a nested group" do
+    expect(object.config.baz.qux.quux).to eq("env_baz_qux_quux")
+  end
+
+  describe "instance config" do
+    let(:instance) {
+      object.new
+    }
+
+    it "uses the environment variable value for an instance-level setting" do
+      expect(instance.config.foo).to eq("env_foo")
+    end
+  end
+
+  context "object is configured" do
+    def configure
+      object.configure do
+        config.foo = "configured_foo"
+      end
+
+      object.configure!
+    end
+
+    it "gives precedence to the environment variable" do
+      configure
+
+      expect(object.config.foo).to eq("env_foo")
+    end
+
+    context "environment variable is not passed" do
+      before do
+        ENV.delete("PWTEST__FOO")
+      end
+
+      it "uses the configured value" do
+        configure
+
+        expect(object.config.foo).to eq("configured_foo")
+      end
+    end
+  end
+
+  context "configurable does not define an envar prefix" do
+    let(:object) {
+      Class.new {
+        include Pakyow::Support::Configurable
+      }
+    }
+
+    it "does not configure the setting" do
+      expect(object.config.foo).to eq(nil)
+    end
+  end
+end


### PR DESCRIPTION
Allows configuration to be set through environment variables. This is supported for both the environment and applications.

Here's how to set the default server count in the environment:

```
PWENV__RUNNABLE__SERVER__COUNT=3
```

Here's how to set the application root for an application named `example`:

```
PWAPP__EXAMPLE__ROOT=some/path
```

Environment variables always take precedence over locally configured values.