### PR TITLE
Return multi-level subdomains from the connection

### DIFF
--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -1,5 +1,15 @@
 # v1.1.0 (unreleased)
 
+  * `add` **Introduce `Connection#subdomains` for getting subdomains as an array.**
+
+    *Related links:*
+    - [Pull Request #503][pr-503]
+
+  * `fix` **Return multi-level subdomains from the connection.**
+
+    *Related links:*
+    - [Pull Request #503][pr-503]
+
   * `fix` **Create applications correctly in existing multiapp projects.**
 
     *Related links:*
@@ -625,6 +635,7 @@
     *Related links:*
     - [Pull Request #338][pr-338]
 
+[pr-503]: https://github.com/pakyow/pakyow/pull/503
 [pr-502]: https://github.com/pakyow/pakyow/pull/502
 [pr-501]: https://github.com/pakyow/pakyow/pull/501
 [pr-500]: https://github.com/pakyow/pakyow/pull/500

--- a/pakyow-core/spec/unit/connection/shared_examples/subdomains.rb
+++ b/pakyow-core/spec/unit/connection/shared_examples/subdomains.rb
@@ -1,7 +1,7 @@
-RSpec.shared_examples :connection_subdomain do
-  describe "#subdomain" do
+RSpec.shared_examples :connection_subdomains do
+  describe "#subdomains" do
     it "returns the expected value" do
-      expect(connection.subdomain).to eq(subdomain)
+      expect(connection.subdomains).to eq(["www"])
     end
 
     context "multi-level subdomain" do
@@ -10,7 +10,7 @@ RSpec.shared_examples :connection_subdomain do
       }
 
       it "returns the expected value" do
-        expect(connection.subdomain).to eq(subdomain)
+        expect(connection.subdomains).to eq(["dev", "www"])
       end
     end
 
@@ -20,12 +20,12 @@ RSpec.shared_examples :connection_subdomain do
       }
 
       it "returns the expected value" do
-        expect(connection.subdomain(2)).to eq("dev")
+        expect(connection.subdomains(2)).to eq(["dev"])
       end
 
       it "memoizes correctly" do
-        expect(connection.subdomain(2)).to be(connection.subdomain(2))
-        expect(connection.subdomain(2)).not_to eq(connection.subdomain)
+        expect(connection.subdomains(2)).to be(connection.subdomains(2))
+        expect(connection.subdomains(2)).not_to eq(connection.subdomains)
       end
     end
   end

--- a/pakyow-core/spec/unit/connection_spec.rb
+++ b/pakyow-core/spec/unit/connection_spec.rb
@@ -21,6 +21,7 @@ require_relative "./connection/shared_examples/sleep"
 require_relative "./connection/shared_examples/status"
 require_relative "./connection/shared_examples/stream"
 require_relative "./connection/shared_examples/subdomain"
+require_relative "./connection/shared_examples/subdomains"
 require_relative "./connection/shared_examples/type"
 require_relative "./connection/shared_examples/write"
 
@@ -34,7 +35,7 @@ RSpec.shared_examples :connection do
   end
 
   let :host do
-    "localhost"
+    "localhost.dev"
   end
 
   let :port do
@@ -249,6 +250,7 @@ RSpec.shared_examples :connection do
   it_behaves_like :connection_status
   it_behaves_like :connection_stream
   it_behaves_like :connection_subdomain
+  it_behaves_like :connection_subdomains
   it_behaves_like :connection_type
   it_behaves_like :connection_write
 end


### PR DESCRIPTION
Also introduces `Connection#subdomains` for getting subdomains as an array.