### PR TITLE
Disable the filewatcher in production and ludicrous modes

### DIFF
--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `chg` **Disable the filewatcher in production and ludicrous modes.**
+
+    *Related links:*
+    - [Pull Request #511][pr-511]
+
   * `fix` **Load empty files without failing.**
 
     *Related links:*
@@ -680,6 +685,7 @@
     *Related links:*
     - [Pull Request #338][pr-338]
 
+[pr-511]: https://github.com/pakyow/pakyow/pull/511
 [pr-510]: https://github.com/pakyow/pakyow/pull/510
 [pr-509]: https://github.com/pakyow/pakyow/pull/509
 [pr-508]: https://github.com/pakyow/pakyow/pull/508

--- a/pakyow-core/lib/pakyow/environment.rb
+++ b/pakyow-core/lib/pakyow/environment.rb
@@ -182,6 +182,14 @@ module Pakyow
       setting :count do
         config.runnable.watcher.enabled ? 1 : 0
       end
+
+      defaults :production do
+        setting :enabled, false
+      end
+
+      defaults :ludicrous do
+        setting :enabled, false
+      end
     end
   end
 

--- a/pakyow-core/spec/unit/environment/config/runnable/watcher_spec.rb
+++ b/pakyow-core/spec/unit/environment/config/runnable/watcher_spec.rb
@@ -5,6 +5,26 @@ RSpec.describe Pakyow, "config.runnable.watcher" do
     it "has a default value" do
       expect(subject).to be(true)
     end
+
+    context "in production" do
+      before do
+        Pakyow.configure!(:production)
+      end
+
+      it "defaults to false" do
+        expect(subject).to be(false)
+      end
+    end
+
+    context "in ludicrous" do
+      before do
+        Pakyow.configure!(:ludicrous)
+      end
+
+      it "defaults to false" do
+        expect(subject).to be(false)
+      end
+    end
   end
 
   describe "count" do


### PR DESCRIPTION
Disable this by default since most deployments won't use this feature and it consumes a noticeable amount of resources.