### PR TITLE
Load the environment before determining the server service count

### DIFF
--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `fix` **Load the environment before determining the server service count.**
+
+    *Related links:*
+    - [Pull Request #513][pr-513]
+
   * `chg` **Introduce `Pakyow.config.impolite` for controlling intro/goodbye logging.**
 
     *Related links:*
@@ -690,6 +695,7 @@
     *Related links:*
     - [Pull Request #338][pr-338]
 
+[pr-513]: https://github.com/pakyow/pakyow/pull/513
 [pr-512]: https://github.com/pakyow/pakyow/pull/512
 [pr-511]: https://github.com/pakyow/pakyow/pull/511
 [pr-510]: https://github.com/pakyow/pakyow/pull/510

--- a/pakyow-core/lib/pakyow/behavior/running.rb
+++ b/pakyow-core/lib/pakyow/behavior/running.rb
@@ -105,6 +105,12 @@ module Pakyow
             end
 
             def count
+              handling do
+                # Load first so that the count is correctly configured.
+                #
+                Pakyow.load(env: options[:env])
+              end
+
               options[:config].server.count
             end
 

--- a/pakyow-core/lib/pakyow/runnable/container/strategies/base.rb
+++ b/pakyow-core/lib/pakyow/runnable/container/strategies/base.rb
@@ -28,7 +28,7 @@ module Pakyow
             @notifier&.stop
             @notifier = Notifier.new(container: container, &method(:handle_notification).to_proc)
 
-            container.formation.each.map {|service_name, desired_service_count|
+            container.formation.each.map { |service_name, desired_service_count|
               service_instance = container.services(service_name).new(**container.options)
               desired_service_count ||= (service_instance.count || 1)
               service_limit = service_instance.limit

--- a/pakyow-core/spec/unit/containers/environment/services/server_spec.rb
+++ b/pakyow-core/spec/unit/containers/environment/services/server_spec.rb
@@ -138,6 +138,12 @@ RSpec.describe "environment.server service" do
     it "returns the configured count" do
       expect(instance.count).to eq(count)
     end
+
+    it "loads the environment" do
+      expect(Pakyow).to receive(:load).with(env: "development")
+
+      instance.count
+    end
   end
 
   describe "#logger" do


### PR DESCRIPTION
Fixes an issue where running a formation that does not specify a service count falls back to the wrong value in production:

```
pakyow boot --formation "environment.server"
```

This now correctly runs `5` processes, while currently it runs only `1`.