### PR TITLE
Upgrade mini_racer, to compile on alpine

### DIFF
--- a/pakyow-assets/pakyow-assets.gemspec
+++ b/pakyow-assets/pakyow-assets.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "async-http", "~> 0.52.3"
   spec.add_dependency "mini_mime", "~> 1.0"
-  spec.add_dependency "mini_racer", "~> 0.2.11"
+  spec.add_dependency "mini_racer", "~> 0.3.1"
   spec.add_dependency "sassc", "~> 2.3"
   spec.add_dependency "source_map", "~> 3.0"
 end


### PR DESCRIPTION
Hi @bryanp,

This `PR` upgrade `mini_racer` to **0.3**.

It appears that **0.2** is not compilable on `alpine`, so `pakyow` is **NOT** usable if :
+ run on container (`kubernetes` or else)
+ use `alpine`

Regards,