### PR TITLE
Deprecate ./backend/lib

### DIFF
--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -627,6 +627,11 @@
 
 ## Deprecations
 
+  * `./backend/lib` is deprecated in favor of `./lib`.
+
+    *Related links:*
+    - [Pull Request #519][pr-519]
+
   * `Pakyow::ProcessManager` is deprecated in favor of `Pakyow::Runnable::Container`.
 
     *Related links:*

--- a/pakyow-core/lib/pakyow/application.rb
+++ b/pakyow-core/lib/pakyow/application.rb
@@ -144,6 +144,8 @@ module Pakyow
       File.join(config.src, "lib")
     end
 
+    config.deprecate :lib
+
     configurable :tasks do
       setting :prelaunch, []
 
@@ -201,7 +203,15 @@ module Pakyow
             end
 
             performing :load do
-              $LOAD_PATH.unshift(config.lib)
+              lib_path = Pakyow.deprecator.ignore do
+                config.lib
+              end
+
+              if File.exist?(lib_path)
+                Pakyow.deprecated "application lib", solution: "use the environment lib"
+              end
+
+              $LOAD_PATH.unshift(lib_path)
             end
 
             config.version = Support::PathVersion.build(config.src)


### PR DESCRIPTION
Prefer `./lib` or `./common/lib` (in context of multiapp projects).