### PR TITLE
Introduce the limiter action for limiting request body size

### DIFF
--- a/pakyow-core/CHANGELOG.md
+++ b/pakyow-core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `add` **Introduce the limiter action for limiting request body size.**
+
+    *Related links:*
+    - [Pull Request #528][pr-528]
+
   * `fix` **Don't register multiple deprecators with the global deprecator.**
 
     *Related links:*
@@ -725,6 +730,7 @@
     *Related links:*
     - [Pull Request #338][pr-338]
 
+[pr-528]: https://github.com/pakyow/pakyow/pull/528
 [pr-523]: https://github.com/pakyow/pakyow/pull/523
 [pr-518]: https://github.com/pakyow/pakyow/pull/518
 [pr-517]: https://github.com/pakyow/pakyow/pull/517

--- a/pakyow-core/lib/pakyow/actions/limiter.rb
+++ b/pakyow-core/lib/pakyow/actions/limiter.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "protocol/http/body/wrapper"
+
+module Pakyow
+  module Actions
+    # Limits the connection body to a particular size.
+    #
+    class Limiter
+      attr_reader :length
+
+      def initialize(length: 0)
+        @length = length
+      end
+
+      def call(connection)
+        connection.wrap_input do |body|
+          LimitedInput.new(body, limit: @length)
+        end
+      end
+
+      # @api private
+      class LimitedInput < Protocol::HTTP::Body::Wrapper
+        def initialize(body, limit:)
+          @limit = limit
+
+          super(body)
+        end
+
+        def read
+          chunk = super
+
+          if length && length > @limit
+            raise RequestTooLarge.new_with_message(length: length, limit: @limit)
+          end
+
+          chunk
+        end
+      end
+    end
+  end
+end

--- a/pakyow-core/lib/pakyow/behavior/restarting.rb
+++ b/pakyow-core/lib/pakyow/behavior/restarting.rb
@@ -35,6 +35,12 @@ module Pakyow
             end
           end
         end
+
+        before "setup" do
+          if env?(:development) || env?(:prototype)
+            action :restart, Actions::Restart
+          end
+        end
       end
 
       class_methods do

--- a/pakyow-core/lib/pakyow/connection.rb
+++ b/pakyow-core/lib/pakyow/connection.rb
@@ -116,7 +116,12 @@ module Pakyow
     end
 
     def input
-      @request.body
+      @__input ||= @request.body
+    end
+
+    # @api private
+    def wrap_input
+      @__input = yield(@request.body)
     end
 
     def parsed_input
@@ -551,7 +556,7 @@ module Pakyow
     def parse_input
       if instance_variable_defined?(:@input_parser) && input
         if @input_parser[:rewindable]
-          request.body = Async::HTTP::Body::Rewindable.new(request.body)
+          @__input = Async::HTTP::Body::Rewindable.new(input)
         end
 
         parser = @input_parser[:block].call(input, self)

--- a/pakyow-core/lib/pakyow/errors.rb
+++ b/pakyow-core/lib/pakyow/errors.rb
@@ -18,6 +18,12 @@ module Pakyow
     }.freeze
   end
 
+  class RequestTooLarge < Error
+    class_state :messages, default: {
+      default: "Request length `{length}' exceeds the defined limit of `{limit}'"
+    }
+  end
+
   class InvalidData < Error
     class_state :messages, default: {
       verification: "Provided data didn't pass verification"

--- a/pakyow-core/lib/pakyow/handleable/behavior/defaults/request_too_large.rb
+++ b/pakyow-core/lib/pakyow/handleable/behavior/defaults/request_too_large.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "pakyow/support/extension"
+
+module Pakyow
+  module Handleable
+    module Behavior
+      module Defaults
+        module RequestTooLarge
+          extend Support::Extension
+
+          apply_extension do
+            handle Pakyow::RequestTooLarge, as: 413 do |_error, connection:|
+              connection.headers.clear
+              connection.body = StringIO.new("413 Payload Too Large")
+              connection.halt
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/pakyow-core/spec/features/limiting_spec.rb
+++ b/pakyow-core/spec/features/limiting_spec.rb
@@ -1,0 +1,62 @@
+RSpec.describe "limiting the connection input size" do
+  include_context "app"
+
+  let(:env_def) {
+    Proc.new {
+      configure do
+        config.limiter.length = 1024
+      end
+
+      action do |connection|
+        connection.body = connection.params[:value]
+        connection.halt
+      end
+    }
+  }
+
+  let(:response) {
+    call(params: params)
+  }
+
+  context "input equals the limit" do
+    let(:params) {
+      { value: " " * 1012 }
+    }
+
+    it "allows the input" do
+      expect(response[0]).to eq(200)
+      expect(response[2]).to eq(params[:value])
+    end
+  end
+
+  context "input is over the limit" do
+    let(:params) {
+      { value: " " * 1013 }
+    }
+
+    it "responds 413" do
+      expect(response[0]).to eq(413)
+      expect(response[2]).to eq("413 Payload Too Large")
+    end
+
+    describe "raised error" do
+      let(:env_def) {
+        super_def = super()
+
+        Proc.new {
+          instance_eval(&super_def)
+
+          handle Pakyow::RequestTooLarge do |error, connection:|
+            connection.body = error.message
+            connection.halt
+          end
+        }
+      }
+
+      it "raises a RequestTooLarge error" do
+        expect(response[0]).to eq(200)
+        expect(response[2]).to eq("Request length `1025' exceeds the defined limit of `1024'")
+      end
+    end
+  end
+end

--- a/pakyow-core/spec/unit/environment/config/limiter_spec.rb
+++ b/pakyow-core/spec/unit/environment/config/limiter_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe Pakyow, "config.limiter" do
+  describe "length" do
+    subject { Pakyow.config.limiter.length }
+
+    it "has a default value" do
+      expect(subject).to eq(0)
+    end
+  end
+end

--- a/pakyow-core/spec/unit/environment_spec.rb
+++ b/pakyow-core/spec/unit/environment_spec.rb
@@ -832,6 +832,30 @@ RSpec.describe Pakyow do
     end
   end
 
+  describe "limit action" do
+    let(:pipeline) {
+      Pakyow.instance_variable_get(:@__pipeline)
+    }
+
+    it "is not included by default" do
+      expect(pipeline.actions.map(&:name)).not_to include(:limit)
+    end
+
+    context "limiter length is greater than 0" do
+      before do
+        Pakyow.configure do
+          config.limiter.length = 1024
+        end
+
+        Pakyow.setup
+      end
+
+      it "is included" do
+        expect(pipeline.actions.map(&:name)).to include(:limit)
+      end
+    end
+  end
+
   describe "::output" do
     it "is memoized" do
       expect(Pakyow.output).to be(Pakyow.output)

--- a/pakyow-presenter/lib/pakyow/presenter/view.rb
+++ b/pakyow-presenter/lib/pakyow/presenter/view.rb
@@ -9,6 +9,8 @@ require "pakyow/support/safe_string"
 
 require_relative "../../string_doc"
 
+require_relative "attributes"
+
 module Pakyow
   module Presenter
     # Provides an interface for manipulating view templates.

--- a/pakyow-presenter/spec/integration/accessing_view_attributes_spec.rb
+++ b/pakyow-presenter/spec/integration/accessing_view_attributes_spec.rb
@@ -1,3 +1,6 @@
+require "pakyow/presenter/significant_nodes"
+require "pakyow/presenter/view"
+
 RSpec.describe "accessing view attributes" do
   let :html do
     "<div binding=\"post\" style=\"color: blue\" class=\"foo bar\" title=\"baz\" checked=\"checked\"></div>"


### PR DESCRIPTION
The new limiter action provides a way to limit the size of requests accepted by the Pakyow Environment. It can be used by setting the new `config.limiter.length` option to the maximum request length (expressed in bytes).