### PR TITLE
Resolve an issue causing params to be parsed twice

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `fix` **Resolve an issue causing params to be parsed twice.**
+
+    *Related links:*
+    - [Pull Request #530][pr-530]
+
   * `fix` **Reset params after setting an input parser on the connection.**
 
     *Related links:*
@@ -735,6 +740,7 @@
     *Related links:*
     - [Pull Request #338][pr-338]
 
+[pr-530]: https://github.com/pakyow/pakyow/pull/530
 [pr-529]: https://github.com/pakyow/pakyow/pull/529
 [pr-528]: https://github.com/pakyow/pakyow/pull/528
 [pr-523]: https://github.com/pakyow/pakyow/pull/523

--- a/core/lib/pakyow/actions/restart.rb
+++ b/core/lib/pakyow/actions/restart.rb
@@ -6,7 +6,7 @@ module Pakyow
     #
     class Restart
       def call(connection)
-        if connection.path == "/pw-restart" && connection.method == :post && (environment = connection.params[:environment])
+        if connection.path == "/pw-restart" && connection.request_method == "POST" && (environment = connection.params[:environment])
           Pakyow.restart(env: environment)
 
           connection.halt


### PR DESCRIPTION
Fixes a double-param parsing issue introduced by #529, while continuing to solve the original bug.