### PR TITLE
Introduce an async container strategy

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `chg` **Restructure containers to support running other services alongside servers.**
+
+    *Related links:*
+    - [Pull Request #543][pr-543]
+
   * `add` **Introduce an async container strategy.**
 
     *Related links:*
@@ -775,6 +780,7 @@
     *Related links:*
     - [Pull Request #338][pr-338]
 
+[pr-543]: https://github.com/pakyow/pakyow/pull/543
 [pr-542]: https://github.com/pakyow/pakyow/pull/542
 [pr-541]: https://github.com/pakyow/pakyow/pull/541
 [pr-540]: https://github.com/pakyow/pakyow/pull/540

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,5 +1,15 @@
 # v1.1.0 (unreleased)
 
+  * `add` **Introduce an async container strategy.**
+
+    *Related links:*
+    - [Pull Request #542][pr-542]
+
+  * `chg` **Make containers compatible with fiber-based reactors.**
+
+    *Related links:*
+    - [Pull Request #542][pr-542]
+
   * `fix` **Resolve a concurrency-related performance regression.**
 
     *Related links:*
@@ -765,6 +775,7 @@
     *Related links:*
     - [Pull Request #338][pr-338]
 
+[pr-542]: https://github.com/pakyow/pakyow/pull/542
 [pr-541]: https://github.com/pakyow/pakyow/pull/541
 [pr-540]: https://github.com/pakyow/pakyow/pull/540
 [pr-536]: https://github.com/pakyow/pakyow/pull/536

--- a/core/lib/pakyow/runnable/container.rb
+++ b/core/lib/pakyow/runnable/container.rb
@@ -183,14 +183,17 @@ module Pakyow
 
           yield self if block_given?
 
-          while running?
-            @strategy.run(self)
-            @strategy.wait(self)
+          Pakyow.async {
+            while running?
+              @strategy.prepare(self)
+              @strategy.run(self)
+              @strategy.wait(self)
 
-            unless restartable?
-              stop
+              unless restartable?
+                stop
+              end
             end
-          end
+          }.wait
 
           if toplevel_pid?
             success?

--- a/core/lib/pakyow/runnable/container.rb
+++ b/core/lib/pakyow/runnable/container.rb
@@ -19,11 +19,13 @@ module Pakyow
     #
     # = Management Strategy
     #
-    # Processes are managed with one of two strategies:
+    # Processes are managed with one of four strategies:
     #
     #   * `:forked` - Each service runs in a fork of the current service.
     #
     #   * `:threaded` - Each service runs in a thread within the current service.
+    #
+    #   * `:async` - Each service runs in separate async task within the container's reactor.
     #
     #   * `:hybrid` - Each service runs in its defined strategy, or the best available default.
     #
@@ -103,6 +105,8 @@ module Pakyow
         end
       end
 
+      DEFAULT_TIMEOUT_IN_SECONDS = 5
+
       extend Support::ClassState
       class_state :restartable, default: true, inheritable: true
       class_state :toplevel_pid, default: ::Process.pid, inheritable: true
@@ -135,7 +139,8 @@ module Pakyow
       #
       #   * strategy: `:forked`, `:threaded`, or `:hybrid` (defaults to `:hybrid`)
       #   * formation: the formation to run (defaults to `Pakyow::Runnable::Formation.all`)
-      #   * parent: the parent service or container that this container is running in
+      #   * parent: the parent service that this container is running in
+      #   * timeout: how long to wait on services to stop before escalating the shutdown phase (defaults to `5`)
       #
       # All options are passed through to the `perform` method of each service run within this container.
       #
@@ -252,6 +257,18 @@ module Pakyow
         end
       end
 
+      # Sends a message to the container.
+      #
+      def notify(message)
+        @strategy.notify(message)
+      end
+
+      # Listens for messages sent to this container.
+      #
+      def listen(&block)
+        @strategy.listen(&block)
+      end
+
       private def restartable?
         return false unless running?
         return false if self.class.restartable == false
@@ -311,6 +328,7 @@ module Pakyow
       private def finalize_options(options)
         options[:strategy] = strategy_option(options[:strategy])
         options[:formation] = formation_option(options[:formation])
+        options[:timeout] ||= DEFAULT_TIMEOUT_IN_SECONDS
         options
       end
 

--- a/core/lib/pakyow/runnable/container/strategies/async.rb
+++ b/core/lib/pakyow/runnable/container/strategies/async.rb
@@ -7,9 +7,9 @@ module Pakyow
     class Container
       module Strategies
         # @api private
-        class Threaded < Base
-          private def invoke_service(service)
-            Thread.new do
+        class Async < Base
+          private def invoke_service(service, &block)
+            Pakyow.async do |t|
               yield
             ensure
               if service.status.unknown?
@@ -20,8 +20,12 @@ module Pakyow
             end
           end
 
-          private def stop_service(service, _signal)
-            service.reference.kill
+          private def stop_service(service, signal)
+            service.reference.stop
+          end
+
+          private def wrap_service_run
+            yield
           end
         end
       end

--- a/core/lib/pakyow/runnable/container/strategies/hybrid.rb
+++ b/core/lib/pakyow/runnable/container/strategies/hybrid.rb
@@ -30,10 +30,6 @@ module Pakyow
             service_strategy(service).send(:stop_service, service, signal)
           end
 
-          private def service_failed!(service)
-            service_strategy(service).send(:service_failed!, service)
-          end
-
           private def wait_for_service(service)
             service_strategy(service).send(:wait_for_service, service)
           end
@@ -42,6 +38,10 @@ module Pakyow
             service_strategy(service).send(:invoke_service, service) do
               yield
             end
+          end
+
+          private def service_finished(service)
+            service_strategy(service).send(:service_finished, service)
           end
 
           private def service_strategy(service)

--- a/core/lib/pakyow/runnable/container/strategies/hybrid.rb
+++ b/core/lib/pakyow/runnable/container/strategies/hybrid.rb
@@ -16,9 +16,13 @@ module Pakyow
             @strategies = {
               forked: Forked.new, threaded: Threaded.new
             }
+          end
+
+          def prepare(*)
+            super
 
             @strategies.each_value do |strategy|
-              strategy.instance_variable_set(:@queue, @queue)
+              strategy.instance_variable_set(:@notifier, @notifier)
             end
           end
 

--- a/core/lib/pakyow/runnable/container/strategies/threaded.rb
+++ b/core/lib/pakyow/runnable/container/strategies/threaded.rb
@@ -11,6 +11,7 @@ module Pakyow
           def initialize(*)
             super
 
+            @lock = Mutex.new
             @failed_threads = []
           end
 
@@ -41,8 +42,10 @@ module Pakyow
                   service.success!
                 end
               end
+            ensure
+              @notifier.notify(:exit, service: service.object_id)
 
-              @queue.push([:exit, service])
+              @failed_threads.delete(service.reference)
             end
           end
         end

--- a/core/lib/pakyow/runnable/service.rb
+++ b/core/lib/pakyow/runnable/service.rb
@@ -116,12 +116,13 @@ module Pakyow
       include Support::Inspectable
       inspectable :@options, :@metadata, :@status
 
-      attr_reader :options, :metadata, :reference, :status
+      attr_reader :id, :options, :metadata, :reference, :status
 
       # @api private
       attr_writer :reference
 
       def initialize(**options)
+        @id = SecureRandom.hex(4)
         @options = options
         @metadata = {}
         @reference = nil

--- a/core/spec/features/cli/system_spec.rb
+++ b/core/spec/features/cli/system_spec.rb
@@ -1,5 +1,7 @@
 require "fileutils"
 
+require "pakyow/cli"
+
 RSpec.describe "calling a system command through the cli" do
   after do
     FileUtils.rm_f("./touched.txt")

--- a/core/spec/features/watching_spec.rb
+++ b/core/spec/features/watching_spec.rb
@@ -41,7 +41,8 @@ RSpec.describe "watching files from the environment", :repeatable do
       end
     end
 
-    thread.kill; thread.join
+    Pakyow.shutdown
+    thread.join
   end
 
   let(:path) {

--- a/core/spec/integration/filewatcher_spec.rb
+++ b/core/spec/integration/filewatcher_spec.rb
@@ -62,8 +62,7 @@ RSpec.describe "using the filewatcher", :repeatable do
     end
 
     filewatcher.stop
-    sleep 0.25
-    thread.kill; thread.join
+    thread.join
   end
 
   describe "watching a pattern" do

--- a/core/spec/integration/runnable/container/forking_spec.rb
+++ b/core/spec/integration/runnable/container/forking_spec.rb
@@ -1,6 +1,6 @@
 require_relative "../shared"
 
-RSpec.describe "hooking into fork events" do
+RSpec.describe "hooking into fork events", runnable: true do
   include_context "runnable container"
 
   shared_examples :examples do
@@ -59,6 +59,14 @@ RSpec.describe "hooking into fork events" do
   context "hybrid container" do
     let(:run_options) {
       { strategy: :hybrid }
+    }
+
+    include_examples :examples
+  end
+
+  context "async container" do
+    let(:run_options) {
+      { strategy: :async }
     }
 
     include_examples :examples

--- a/core/spec/integration/runnable/container/service/logger_spec.rb
+++ b/core/spec/integration/runnable/container/service/logger_spec.rb
@@ -1,6 +1,6 @@
 require_relative "../../shared"
 
-RSpec.describe "defining the service logger", :repeatable do
+RSpec.describe "defining the service logger", :repeatable, runnable: true do
   include_context "runnable container"
 
   shared_examples :examples do
@@ -15,30 +15,26 @@ RSpec.describe "defining the service logger", :repeatable do
     }
 
     let(:definitions) {
-      local = self
-
       container.service :foo, restartable: false do
         define_method :perform do
-          local.write_to_parent(logger.class.name[0])
+          options[:toplevel].notify(logger.class.name)
         end
       end
     }
 
     it "defaults to the pakyow logger" do
       run_container do
-        wait_for length: 1, timeout: 1 do |result|
-          expect(result).to eq("P")
+        listen_for length: 1, timeout: 1 do |result|
+          expect(result).to eq(["Pakyow::Logger::ThreadLocal"])
         end
       end
     end
 
     context "service defines a logger" do
       let(:definitions) {
-        local = self
-
         container.service :foo, restartable: false do
           define_method :perform do
-            local.write_to_parent(logger.class.name[0])
+            options[:toplevel].notify(logger.class.name)
           end
 
           define_method :logger do
@@ -49,8 +45,8 @@ RSpec.describe "defining the service logger", :repeatable do
 
       it "uses the service logger" do
         run_container do
-          wait_for length: 1, timeout: 1 do |result|
-            expect(result).to eq("N")
+          listen_for length: 1, timeout: 1 do |result|
+            expect(result).to eq(["NilClass"])
           end
         end
       end
@@ -76,6 +72,14 @@ RSpec.describe "defining the service logger", :repeatable do
   context "hybrid container" do
     let(:run_options) {
       { strategy: :hybrid }
+    }
+
+    include_examples :examples
+  end
+
+  context "async container" do
+    let(:run_options) {
+      { strategy: :async }
     }
 
     include_examples :examples

--- a/core/spec/integration/runnable/container/signaling_spec.rb
+++ b/core/spec/integration/runnable/container/signaling_spec.rb
@@ -1,7 +1,23 @@
 require_relative "../shared"
 
-RSpec.describe "signaling runnable containers", :repeatable do
+RSpec.describe "signaling runnable containers", :repeatable, runnable: true do
   include_context "runnable container"
+
+  before do
+    FileUtils.mkdir_p(path)
+  end
+
+  after do
+    FileUtils.rm_r(path)
+  end
+
+  let(:path) {
+    Pathname.new(File.expand_path("../tmp/#{SecureRandom.hex(4)}", __FILE__))
+  }
+
+  let(:result_path) {
+    path.join("result.txt")
+  }
 
   # We can only test forked here because threaded services run in this process.
   #
@@ -18,36 +34,41 @@ RSpec.describe "signaling runnable containers", :repeatable do
 
     container.service :foo, restartable: false do
       define_method :perform do
-        local.run_container(local.container2, parent: self)
+        local.run_container_raw(local.container2, context: self)
+
+        loop do
+          ::Async::Task.current.sleep 1
+        end
       end
     end
 
-    container2.service :bar, restartable: false do
-      define_method :perform do
-        local.write_to_parent("bar: perform")
-
-        sleep
-      end
-
-      define_method :stop do
-        local.write_to_parent("bar: stop")
-      end
-    end
+    service
   end
 
   let(:container2) {
     Pakyow::Runnable::Container.make(:test2, **container_options)
   }
 
+  let(:service) {
+    container2.service :bar, restartable: false do
+      define_method :perform do
+        options[:toplevel].notify("bar: perform")
+
+        ::Async::Task.current.sleep 10
+      end
+
+      define_method :stop do
+        options[:toplevel].notify("bar: stop")
+      end
+    end
+  }
+
   def run_then_kill
     run_container do |instance|
-      sleep 0.1
+      listen_for length: 1, timeout: 1
 
       @pid = instance.instance_variable_get(:@strategy).instance_variable_get(:@services).first.reference
-
       ::Process.kill(signal, @pid)
-
-      sleep 0.1
 
       yield
     end
@@ -60,7 +81,73 @@ RSpec.describe "signaling runnable containers", :repeatable do
 
     it "cleanly stops each process" do
       run_then_kill do
-        expect(result).to eq("bar: performbar: stop")
+        listen_for length: 2, timeout: 3 do |result|
+          expect(result).to eq(["bar: perform", "bar: stop"])
+        end
+      end
+    end
+
+    context "service in the container does not stop on int" do
+      let(:service) {
+        container2.service :bar, restartable: false do
+          define_method :perform do
+            Signal.trap(:INT) do
+              # eat this one
+            end
+
+            at_exit do
+              options[:toplevel].notify("exited")
+            end
+
+            options[:toplevel].notify("running")
+
+            loop do
+              ::Async::Task.current.sleep 10
+            end
+          end
+        end
+      }
+
+      it "sends term after the timeout" do
+        run_then_kill do
+          listen_for length: 2, timeout: 2
+
+          # Rely on the above timeout to cause the test to fail.
+        end
+      end
+    end
+
+    context "service in the container does not stop on int or term" do
+      let(:service) {
+        local = self
+
+        container2.service :bar, restartable: false do
+          define_method :perform do
+            Signal.trap(:INT) do
+              # eat this one
+            end
+
+            Signal.trap(:TERM) do
+              # and this one
+            end
+
+            options[:toplevel].notify("running")
+
+            loop do
+              local.result_path.write(Time.now.to_s)
+
+              ::Async::Task.current.sleep 0.25
+            end
+          end
+        end
+      }
+
+      it "force quits the service after the timeout" do
+        run_then_kill do
+          sleep 5
+
+          expect(Time.now - Time.parse(result_path.read)).to be > 3
+        end
       end
     end
   end
@@ -72,7 +159,43 @@ RSpec.describe "signaling runnable containers", :repeatable do
 
     it "forces each process to stop" do
       run_then_kill do
-        expect(result).to eq("bar: perform")
+        sleep 1
+
+        expect(messages).to eq(["bar: perform"])
+      end
+    end
+
+    context "service in the container does not stop on term" do
+      let(:service) {
+        local = self
+
+        container2.service :bar, restartable: false do
+          define_method :perform do
+            Signal.trap(:INT) do
+              # eat this one
+            end
+
+            Signal.trap(:TERM) do
+              # and this one
+            end
+
+            options[:toplevel].notify("running")
+
+            loop do
+              local.result_path.write(Time.now.to_s)
+
+              ::Async::Task.current.sleep 0.25
+            end
+          end
+        end
+      }
+
+      it "force quits the service after the timeout" do
+        run_then_kill do
+          sleep 5
+
+          expect(Time.now - Time.parse(result_path.read)).to be > 4
+        end
       end
     end
   end
@@ -89,8 +212,8 @@ RSpec.describe "signaling runnable containers", :repeatable do
 
       it "restarts the container" do
         run_then_kill do
-          wait_for length: 33, timeout: 1 do |result|
-            expect(result).to eq("bar: performbar: stopbar: perform")
+          listen_for length: 3, timeout: 1 do |result|
+            expect(result).to eq(["bar: perform", "bar: stop", "bar: perform"])
           end
         end
       end
@@ -103,8 +226,87 @@ RSpec.describe "signaling runnable containers", :repeatable do
 
       it "ignores the signal" do
         run_then_kill do
-          expect(result).to eq("bar: perform")
+          sleep 1
+
+          expect(messages).to eq(["bar: perform"])
         end
+      end
+    end
+  end
+
+  describe "sending two int signals" do
+    let(:signal) {
+      "INT"
+    }
+
+    let(:service) {
+      container2.service :bar, restartable: false do
+        define_method :perform do
+          Signal.trap(:INT) do
+            # eat this one
+          end
+
+          at_exit do
+            options[:toplevel].notify("exited")
+          end
+
+          options[:toplevel].notify("running")
+
+          loop do
+            ::Async::Task.current.sleep 10
+          end
+        end
+      end
+    }
+
+    it "sends term on the second int" do
+      run_then_kill do
+        ::Process.kill(signal, @pid)
+
+        listen_for length: 2, timeout: 2
+
+        # Rely on the above timeout to cause the test to fail.
+      end
+    end
+  end
+
+  describe "sending three int signals" do
+    let(:signal) {
+      "INT"
+    }
+
+    let(:service) {
+      local = self
+
+      container2.service :bar, restartable: false do
+        define_method :perform do
+          Signal.trap(:INT) do
+            # eat this one
+          end
+
+          Signal.trap(:TERM) do
+            # and this one
+          end
+
+          options[:toplevel].notify("running")
+
+          loop do
+            local.result_path.write(Time.now.to_s)
+
+            ::Async::Task.current.sleep 0.25
+          end
+        end
+      end
+    }
+
+    it "force quits on the third int" do
+      run_then_kill do
+        ::Process.kill(signal, @pid)
+        ::Process.kill(signal, @pid)
+
+        sleep 5
+
+        expect(Time.now - Time.parse(result_path.read)).to be > 3
       end
     end
   end

--- a/core/spec/integration/runnable/shared.rb
+++ b/core/spec/integration/runnable/shared.rb
@@ -66,12 +66,14 @@ RSpec.shared_context "runnable container" do
 
   def write_to_parent(value)
     parent_socket.sendmsg(value)
+  rescue SystemCallError
   end
 
   def read_from_child
     with_timeout(3) do
       child_socket.recv(4096)
     end
+  rescue SystemCallError
   end
 
   def wait_for(length:, timeout: nil)

--- a/core/spec/integration/runnable/shared.rb
+++ b/core/spec/integration/runnable/shared.rb
@@ -19,81 +19,78 @@ RSpec.shared_context "runnable container" do
     {}
   }
 
-  let!(:sockets) {
-    Socket.pair(:UNIX, :STREAM, 0)
+  let(:messages) {
+    []
   }
 
-  let(:child_socket) {
-    sockets[0]
+  let(:container_timeout) {
+    1
   }
 
-  let(:parent_socket) {
-    sockets[1]
-  }
+  def run_container_raw(container, context:)
+    final_options = context.options.merge(
+      parent: context
+    )
 
-  let(:result) {
-    read_from_child
-  }
+    instance = container.new(**final_options)
+    instance.options[:container] = instance
+
+    Pakyow.async {
+      instance.run
+    }.wait
+  end
 
   def run_container(container = self.container, timeout: nil, **options)
     final_options = run_options.merge(options)
+    final_options[:timeout] ||= container_timeout
 
-    container_instance = container.new(**final_options)
-    container_instance.options[:container_instance] = container_instance
+    instance = container.new(**final_options)
+    instance.options[:toplevel] = instance
+    instance.options[:container] = instance
+
+    instance.listen do |message|
+      messages << message
+    end
 
     thread = Thread.new {
-      container_instance.run
+      Pakyow.async { |task|
+        instance.run
+      }.wait
     }
 
-    yield container_instance if block_given?
+    until instance.running?
+      sleep 0.25
+    end
+
+    yield instance if block_given?
     sleep timeout if timeout
 
-    container_instance.stop
-
-    begin
-      with_timeout 1 do
-        thread.join
-      end
-    rescue Timeout::Error
-      thread.kill
+    Timeout.timeout(15) do
+      instance.stop
+      thread.join
+      instance
     end
-
-    container_instance
-  rescue Timeout::Error => error
-    container_instance.stop
-    thread.kill; raise error
   end
 
-  def write_to_parent(value)
-    parent_socket.sendmsg(value)
-  rescue SystemCallError
-  end
-
-  def read_from_child
-    with_timeout(3) do
-      child_socket.recv(4096)
-    end
-  rescue SystemCallError
-  end
-
-  def wait_for(length:, timeout: nil)
-    with_timeout(timeout) do
+  def listen_for(length:, timeout: nil)
+    with_timeout(timeout) do |task|
       start = Time.now
-      result = String.new
 
-      until result.length >= length
-        result << child_socket.recv(4096)
+      until messages.length >= length
+        task.sleep 0.1
       end
 
-      if block_given?
-        yield result[0...length], Time.now - start
-      end
+      yield messages.take(length), Time.now - start if block_given?
     end
   end
 
-  def with_timeout(timeout, &block)
+  def with_timeout(timeout)
     if timeout
-      Timeout.timeout(timeout, &block)
+      Pakyow.async { |task|
+        task.with_timeout(timeout) do
+          yield task
+        end
+      }.wait
     else
       yield
     end

--- a/core/spec/unit/containers/environment/services/server_spec.rb
+++ b/core/spec/unit/containers/environment/services/server_spec.rb
@@ -11,57 +11,6 @@ RSpec.describe "environment.server service" do
     service.new(**options)
   }
 
-  it_behaves_like "service error handling" do
-    before do
-      expect(Pakyow).to receive(:boot).and_raise(error)
-    end
-
-    let(:options) {
-      super().tap do |options|
-        options[:endpoint] = double(:endpoint, accept: nil)
-      end
-    }
-  end
-
-  before do
-    allow(Async::HTTP::Endpoint).to receive(:parse).with(
-      "#{scheme}://#{host}:#{port}"
-    ).and_return(endpoint)
-
-    allow(Async::Reactor).to receive(:run) do |&block|
-      allow(Async::IO::SharedEndpoint).to receive(:bound).with(endpoint).and_return(bound_endpoint)
-      allow(bound_endpoint).to receive(:wait).and_return(bound_endpoint)
-
-      block.call
-    end
-
-    allow(Pakyow.logger).to receive(:<<)
-  end
-
-  let(:scheme) {
-    "https"
-  }
-
-  let(:host) {
-    "localhost"
-  }
-
-  let(:port) {
-    3000
-  }
-
-  let(:endpoint) {
-    double(:endpoint, protocol: protocol)
-  }
-
-  let(:protocol) {
-    double(:protocol)
-  }
-
-  let(:bound_endpoint) {
-    double(:bound_endpoint, accept: nil)
-  }
-
   let(:options) {
     { config: config, env: "development" }
   }
@@ -71,64 +20,54 @@ RSpec.describe "environment.server service" do
   }
 
   let(:server_config) {
-    double(:server_config, scheme: scheme, host: host, port: port, count: count)
+    double(:server_config, count: count)
   }
 
   let(:count) {
     42
   }
 
+  before do
+    allow(Pakyow.container(:server)).to receive(:run)
+  end
+
+  it_behaves_like "service error handling" do
+    before do
+      expect(Pakyow).to receive(:boot).and_raise(error)
+    end
+  end
+
   describe "::prerun" do
-    it "sets the endpoint option" do
-      service.prerun(options)
-
-      expect(options[:endpoint]).to be(bound_endpoint)
+    before do
+      expect(Pakyow.container(:server).services.each.count).not_to eq(0)
     end
 
-    it "sets the protocol option" do
-      service.prerun(options)
+    let(:options) {
+      { foo: "bar" }
+    }
 
-      expect(options[:protocol]).to be(protocol)
-    end
-
-    it "logs the running text" do
-      expect(Pakyow.logger).to receive(:<<).with("\e[34;1mPakyow › Development › https://localhost:3000\e[0m\e[3m\nUse Ctrl-C to shut down the environment.\e[0m")
+    it "calls prerun for each service in the server container" do
+      Pakyow.container(:server).services.each do |service|
+        expect(service).to receive(:prerun).with(**options)
+      end
 
       service.prerun(options)
-    end
-
-    context "stdout is not a tty" do
-      before do
-        allow($stdout).to receive(:tty?).and_return(false)
-      end
-
-      it "logs simpler running text" do
-        expect(Pakyow.logger).to receive(:<<).with("Pakyow › Development › https://localhost:3000")
-
-        service.prerun(options)
-      end
-    end
-
-    context "environment is impolite" do
-      before do
-        Pakyow.config.polite = false
-      end
-
-      it "logs simpler running text" do
-        expect(Pakyow.logger).not_to receive(:<<)
-
-        service.prerun(options)
-      end
     end
   end
 
   describe "::postrun" do
     before do
-      service.prerun(options)
+      expect(Pakyow.container(:server).services.each.count).not_to eq(0)
     end
 
-    it "closes the endpoint" do
-      expect(bound_endpoint).to receive(:close)
+    let(:options) {
+      { foo: "bar" }
+    }
+
+    it "calls postrun for each service in the server container" do
+      Pakyow.container(:server).services.each do |service|
+        expect(service).to receive(:postrun).with(**options)
+      end
 
       service.postrun(options)
     end
@@ -146,16 +85,10 @@ RSpec.describe "environment.server service" do
     end
   end
 
-  describe "#logger" do
-    it "returns nil" do
-      expect(instance.logger).to be(nil)
-    end
-  end
-
   describe "#perform" do
-    before do
-      service.prerun(options)
-    end
+    let(:options) {
+      { env: "development" }
+    }
 
     it "boots with the env option" do
       expect(Pakyow).to receive(:boot).with(env: options[:env])
@@ -169,78 +102,16 @@ RSpec.describe "environment.server service" do
       instance.perform
     end
 
-    it "runs the server" do
-      expect(Pakyow::Server).to receive(:run).with(
-        Pakyow,
-        endpoint: bound_endpoint,
-        protocol: protocol,
-        scheme: scheme
-      )
+    it "runs the garbage collector" do
+      expect(GC).to receive(:start)
 
       instance.perform
     end
 
-    context "environment is already booted" do
-      before do
-        Pakyow.boot(env: "development")
-      end
+    it "runs the server container using the threaded strategy" do
+      expect(Pakyow.container(:server)).to receive(:run).with(parent: instance, strategy: :threaded, **options)
 
-      it "does not boot the environment" do
-        expect(Pakyow).not_to receive(:boot)
-
-        instance.perform
-      end
-
-      it "does not deep freeze the environment" do
-        expect(Pakyow).not_to receive(:deep_freeze)
-
-        instance.perform
-      end
-
-      it "runs the server" do
-        expect(Pakyow::Server).to receive(:run).with(
-          Pakyow,
-          endpoint: bound_endpoint,
-          protocol: protocol,
-          scheme: scheme
-        )
-
-        instance.perform
-      end
-    end
-  end
-
-  describe "#shutdown" do
-    before do
-      allow(Pakyow).to receive(:apps).and_return(apps)
-    end
-
-    let(:apps) {
-      [instance_double(Pakyow::Application)]
-    }
-
-    it "shuts down each application" do
-      apps.each do |app|
-        expect(app).to receive(:shutdown)
-      end
-
-      instance.shutdown
-    end
-
-    context "application fails to shutdown" do
-      before do
-        allow(apps[0]).to receive(:shutdown).and_raise(error)
-      end
-
-      let(:error) {
-        Pakyow::ApplicationError.new
-      }
-
-      it "rescues the application" do
-        expect(apps[0]).to receive(:rescue!).with(error)
-
-        instance.shutdown
-      end
+      instance.perform
     end
   end
 end

--- a/core/spec/unit/containers/server/services/endpoint_spec.rb
+++ b/core/spec/unit/containers/server/services/endpoint_spec.rb
@@ -1,0 +1,230 @@
+require_relative "../../shared/error_handling"
+
+RSpec.describe "server.endpoint service" do
+  include_context "runnable"
+
+  let(:service) {
+    Pakyow.container(:server).service(:endpoint)
+  }
+
+  let(:instance) {
+    service.new(**options)
+  }
+
+  it_behaves_like "service error handling" do
+    before do
+      expect(Pakyow).to receive(:boot).and_raise(error)
+    end
+
+    let(:options) {
+      super().tap do |options|
+        options[:endpoint] = double(:endpoint, accept: nil)
+      end
+    }
+  end
+
+  before do
+    allow(Async::HTTP::Endpoint).to receive(:parse).with(
+      "#{scheme}://#{host}:#{port}"
+    ).and_return(endpoint)
+
+    allow(Async::Reactor).to receive(:run) do |&block|
+      allow(Async::IO::SharedEndpoint).to receive(:bound).with(endpoint).and_return(bound_endpoint)
+      allow(bound_endpoint).to receive(:wait).and_return(bound_endpoint)
+
+      block.call
+    end
+
+    allow(Pakyow.logger).to receive(:<<)
+  end
+
+  let(:scheme) {
+    "https"
+  }
+
+  let(:host) {
+    "localhost"
+  }
+
+  let(:port) {
+    3000
+  }
+
+  let(:endpoint) {
+    double(:endpoint, protocol: protocol)
+  }
+
+  let(:protocol) {
+    double(:protocol)
+  }
+
+  let(:bound_endpoint) {
+    double(:bound_endpoint, accept: nil)
+  }
+
+  let(:options) {
+    { config: config, env: "development" }
+  }
+
+  let(:config) {
+    double(:config, server: server_config)
+  }
+
+  let(:server_config) {
+    double(:server_config, scheme: scheme, host: host, port: port)
+  }
+
+  describe "::prerun" do
+    it "sets the endpoint option" do
+      service.prerun(options)
+
+      expect(options[:endpoint]).to be(bound_endpoint)
+    end
+
+    it "sets the protocol option" do
+      service.prerun(options)
+
+      expect(options[:protocol]).to be(protocol)
+    end
+
+    it "logs the running text" do
+      expect(Pakyow.logger).to receive(:<<).with("\e[34;1mPakyow › Development › https://localhost:3000\e[0m\e[3m\nUse Ctrl-C to shut down the environment.\e[0m")
+
+      service.prerun(options)
+    end
+
+    context "stdout is not a tty" do
+      before do
+        allow($stdout).to receive(:tty?).and_return(false)
+      end
+
+      it "logs simpler running text" do
+        expect(Pakyow.logger).to receive(:<<).with("Pakyow › Development › https://localhost:3000")
+
+        service.prerun(options)
+      end
+    end
+
+    context "environment is impolite" do
+      before do
+        Pakyow.config.polite = false
+      end
+
+      it "logs simpler running text" do
+        expect(Pakyow.logger).not_to receive(:<<)
+
+        service.prerun(options)
+      end
+    end
+  end
+
+  describe "::postrun" do
+    before do
+      service.prerun(options)
+    end
+
+    it "closes the endpoint" do
+      expect(bound_endpoint).to receive(:close)
+
+      service.postrun(options)
+    end
+  end
+
+  describe "#logger" do
+    it "returns nil" do
+      expect(instance.logger).to be(nil)
+    end
+  end
+
+  describe "#perform" do
+    before do
+      service.prerun(options)
+    end
+
+    it "boots with the env option" do
+      expect(Pakyow).to receive(:boot).with(env: options[:env])
+
+      instance.perform
+    end
+
+    it "deep freezes the environment" do
+      expect(Pakyow).to receive(:deep_freeze)
+
+      instance.perform
+    end
+
+    it "runs the server" do
+      expect(Pakyow::Server).to receive(:run).with(
+        Pakyow,
+        endpoint: bound_endpoint,
+        protocol: protocol,
+        scheme: scheme
+      )
+
+      instance.perform
+    end
+
+    context "environment is already booted" do
+      before do
+        Pakyow.boot(env: "development")
+      end
+
+      it "does not boot the environment" do
+        expect(Pakyow).not_to receive(:boot)
+
+        instance.perform
+      end
+
+      it "does not deep freeze the environment" do
+        expect(Pakyow).not_to receive(:deep_freeze)
+
+        instance.perform
+      end
+
+      it "runs the server" do
+        expect(Pakyow::Server).to receive(:run).with(
+          Pakyow,
+          endpoint: bound_endpoint,
+          protocol: protocol,
+          scheme: scheme
+        )
+
+        instance.perform
+      end
+    end
+  end
+
+  describe "#shutdown" do
+    before do
+      allow(Pakyow).to receive(:apps).and_return(apps)
+    end
+
+    let(:apps) {
+      [instance_double(Pakyow::Application)]
+    }
+
+    it "shuts down each application" do
+      apps.each do |app|
+        expect(app).to receive(:shutdown)
+      end
+
+      instance.shutdown
+    end
+
+    context "application fails to shutdown" do
+      before do
+        allow(apps[0]).to receive(:shutdown).and_raise(error)
+      end
+
+      let(:error) {
+        Pakyow::ApplicationError.new
+      }
+
+      it "rescues the application" do
+        expect(apps[0]).to receive(:rescue!).with(error)
+
+        instance.shutdown
+      end
+    end
+  end
+end

--- a/core/spec/unit/environment_spec.rb
+++ b/core/spec/unit/environment_spec.rb
@@ -4,6 +4,8 @@ require "pakyow/cli"
 require "pakyow/logger/thread_local"
 
 RSpec.describe Pakyow do
+  include_context "runnable"
+
   describe "::register_framework" do
     it "registers a framework by name and module" do
       class FooFramework
@@ -906,8 +908,6 @@ RSpec.describe Pakyow do
   end
 
   describe "::run" do
-    include_context "runnable"
-
     it "runs the supervisor container with the expected options" do
       stub_container_run(:supervisor)
 

--- a/core/spec/unit/environment_spec.rb
+++ b/core/spec/unit/environment_spec.rb
@@ -1029,6 +1029,8 @@ RSpec.describe Pakyow do
 
     context "environment is already running" do
       before do
+        stub_container_run(:supervisor)
+
         Pakyow.run
       end
 

--- a/core/spec/unit/runnable/container_spec.rb
+++ b/core/spec/unit/runnable/container_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe Pakyow::Runnable::Container do
       @calls = []
     end
 
+    def prepare(container)
+      @calls << :prepare
+    end
+
     def run(container)
       @calls << :run
     end
@@ -145,10 +149,16 @@ RSpec.describe Pakyow::Runnable::Container do
       expect(strategy.calls.count(:wait)).to eq(3)
     end
 
+    it "prepares the strategy" do
+      instance.run
+
+      expect(strategy.calls.count(:prepare)).to eq(3)
+    end
+
     it "continues running until stopped" do
       instance.run
 
-      expect(strategy.calls).to eq([:run, :wait, :run, :wait, :run, :wait, :interrupt, :success])
+      expect(strategy.calls).to eq([:prepare, :run, :wait, :prepare, :run, :wait, :prepare, :run, :wait, :interrupt, :success])
     end
 
     describe "running strategies" do
@@ -192,7 +202,7 @@ RSpec.describe Pakyow::Runnable::Container do
         it "continues running until stopped" do
           instance.run
 
-          expect(strategy.calls).to eq([:run, :wait, :run, :wait, :run, :wait, :interrupt, :success])
+          expect(strategy.calls).to eq([:prepare, :run, :wait, :prepare, :run, :wait, :prepare, :run, :wait, :interrupt, :success])
         end
 
         context "restartable option is passed as false" do
@@ -203,7 +213,7 @@ RSpec.describe Pakyow::Runnable::Container do
           it "only runs once" do
             instance.run
 
-            expect(strategy.calls).to eq([:run, :wait, :interrupt, :success])
+            expect(strategy.calls).to eq([:prepare, :run, :wait, :interrupt, :success])
           end
         end
       end
@@ -216,7 +226,7 @@ RSpec.describe Pakyow::Runnable::Container do
         it "only runs once" do
           instance.run
 
-          expect(strategy.calls).to eq([:run, :wait, :interrupt, :success])
+          expect(strategy.calls).to eq([:prepare, :run, :wait, :interrupt, :success])
         end
 
         context "restartable option is passed as true" do
@@ -227,7 +237,7 @@ RSpec.describe Pakyow::Runnable::Container do
           it "only runs once" do
             instance.run
 
-            expect(strategy.calls).to eq([:run, :wait, :interrupt, :success])
+            expect(strategy.calls).to eq([:prepare, :run, :wait, :interrupt, :success])
           end
         end
       end

--- a/spec/smoke/endpoint_service_siblings_spec.rb
+++ b/spec/smoke/endpoint_service_siblings_spec.rb
@@ -1,0 +1,56 @@
+require "smoke_helper"
+
+RSpec.describe "running sibling services alongside the endpoint service", :repeatable, smoke: true do
+  before do
+    File.open(project_path.join("config/environment.rb"), "w+") do |file|
+      file.write <<~SOURCE
+        Pakyow.class_state :queue, default: Queue.new
+
+        Pakyow.after "setup" do
+          container(:server).service(:reader, restartable: false) do
+            def perform
+              puts "!!! READER PERFORM"
+
+              while (item = Pakyow.queue.pop)
+                puts "!!! GOT item"
+
+                File.open("#{output_path}", "a") do |file|
+                  file.write(item)
+                end
+              end
+            end
+          end
+        end
+      SOURCE
+    end
+
+    File.open(project_path.join("config/application.rb"), "w+") do |file|
+      file.write <<~SOURCE
+        Pakyow.app :smoke_test, only: %i[routing] do
+          controller "/" do
+            default do
+              Pakyow.queue.push(:called)
+            end
+          end
+        end
+      SOURCE
+    end
+
+    FileUtils.touch(output_path)
+
+    boot
+  end
+
+  let(:output_path) {
+    project_path.join("output.txt")
+  }
+
+  it "shares data between services" do
+    response = http.get("http://localhost:#{port}")
+    expect(response.status).to eq(200)
+
+    sleep 2
+
+    expect(output_path.read).to eq("calledcalled")
+  end
+end

--- a/spec/spec_config.rb
+++ b/spec/spec_config.rb
@@ -34,7 +34,6 @@ RSpec.configure do |config|
 
   if ENV.key?("CI")
     require "rspec/repeat"
-
     config.include RSpec::Repeat
 
     config.around :each, :repeatable do |example|

--- a/support/lib/pakyow/support/deep_dup.rb
+++ b/support/lib/pakyow/support/deep_dup.rb
@@ -40,7 +40,7 @@ module Pakyow
       end
 
       # Objects that can't be copied.
-      UNDUPABLE = [Symbol, Integer, NilClass, TrueClass, FalseClass, Class, Module].freeze
+      UNDUPABLE = [Symbol, Integer, NilClass, TrueClass, FalseClass, Class, Module, Queue].freeze
 
       [Object, Delegator].each do |klass|
         refine klass do

--- a/support/spec/unit/deep_dup_spec.rb
+++ b/support/spec/unit/deep_dup_spec.rb
@@ -75,6 +75,12 @@ RSpec.describe Pakyow::Support::DeepDup do
         expect(Pakyow::Support::DeepDup::UNDUPABLE).to include Module
       end
     end
+
+    describe "Queue" do
+      it "is undupable" do
+        expect(Pakyow::Support::DeepDup::UNDUPABLE).to include Queue
+      end
+    end
   end
 
   describe "recursive deep dupes" do


### PR DESCRIPTION
Refactors containers to be runnable within a fiber-based reactor without blocking. This change made it possible to add an async container strategy that runs one or more services run within a single reactor. Services running in an async container can share data through a queue, or coordinate access to a shared resource through a semaphore. Like the other strategies, async containers manage multiple instances of a service and handle service restarts with automatic backoff on failure.