### PR TITLE
Restructure containers to support running other services alongside servers

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `chg` **Restructure containers to support running other services alongside servers.**
+
+    *Related links:*
+    - [Pull Request #543][pr-543]
+
   * `add` **Introduce an async container strategy.**
 
     *Related links:*
@@ -775,6 +780,7 @@
     *Related links:*
     - [Pull Request #338][pr-338]
 
+[pr-543]: https://github.com/pakyow/pakyow/pull/543
 [pr-542]: https://github.com/pakyow/pakyow/pull/542
 [pr-541]: https://github.com/pakyow/pakyow/pull/541
 [pr-540]: https://github.com/pakyow/pakyow/pull/540

--- a/core/spec/unit/containers/environment/services/server_spec.rb
+++ b/core/spec/unit/containers/environment/services/server_spec.rb
@@ -11,57 +11,6 @@ RSpec.describe "environment.server service" do
     service.new(**options)
   }
 
-  it_behaves_like "service error handling" do
-    before do
-      expect(Pakyow).to receive(:boot).and_raise(error)
-    end
-
-    let(:options) {
-      super().tap do |options|
-        options[:endpoint] = double(:endpoint, accept: nil)
-      end
-    }
-  end
-
-  before do
-    allow(Async::HTTP::Endpoint).to receive(:parse).with(
-      "#{scheme}://#{host}:#{port}"
-    ).and_return(endpoint)
-
-    allow(Async::Reactor).to receive(:run) do |&block|
-      allow(Async::IO::SharedEndpoint).to receive(:bound).with(endpoint).and_return(bound_endpoint)
-      allow(bound_endpoint).to receive(:wait).and_return(bound_endpoint)
-
-      block.call
-    end
-
-    allow(Pakyow.logger).to receive(:<<)
-  end
-
-  let(:scheme) {
-    "https"
-  }
-
-  let(:host) {
-    "localhost"
-  }
-
-  let(:port) {
-    3000
-  }
-
-  let(:endpoint) {
-    double(:endpoint, protocol: protocol)
-  }
-
-  let(:protocol) {
-    double(:protocol)
-  }
-
-  let(:bound_endpoint) {
-    double(:bound_endpoint, accept: nil)
-  }
-
   let(:options) {
     { config: config, env: "development" }
   }
@@ -71,64 +20,54 @@ RSpec.describe "environment.server service" do
   }
 
   let(:server_config) {
-    double(:server_config, scheme: scheme, host: host, port: port, count: count)
+    double(:server_config, count: count)
   }
 
   let(:count) {
     42
   }
 
+  before do
+    allow(Pakyow.container(:server)).to receive(:run)
+  end
+
+  it_behaves_like "service error handling" do
+    before do
+      expect(Pakyow).to receive(:boot).and_raise(error)
+    end
+  end
+
   describe "::prerun" do
-    it "sets the endpoint option" do
-      service.prerun(options)
-
-      expect(options[:endpoint]).to be(bound_endpoint)
+    before do
+      expect(Pakyow.container(:server).services.each.count).not_to eq(0)
     end
 
-    it "sets the protocol option" do
-      service.prerun(options)
+    let(:options) {
+      { foo: "bar" }
+    }
 
-      expect(options[:protocol]).to be(protocol)
-    end
-
-    it "logs the running text" do
-      expect(Pakyow.logger).to receive(:<<).with("\e[34;1mPakyow › Development › https://localhost:3000\e[0m\e[3m\nUse Ctrl-C to shut down the environment.\e[0m")
+    it "calls prerun for each service in the server container" do
+      Pakyow.container(:server).services.each do |service|
+        expect(service).to receive(:prerun).with(**options)
+      end
 
       service.prerun(options)
-    end
-
-    context "stdout is not a tty" do
-      before do
-        allow($stdout).to receive(:tty?).and_return(false)
-      end
-
-      it "logs simpler running text" do
-        expect(Pakyow.logger).to receive(:<<).with("Pakyow › Development › https://localhost:3000")
-
-        service.prerun(options)
-      end
-    end
-
-    context "environment is impolite" do
-      before do
-        Pakyow.config.polite = false
-      end
-
-      it "logs simpler running text" do
-        expect(Pakyow.logger).not_to receive(:<<)
-
-        service.prerun(options)
-      end
     end
   end
 
   describe "::postrun" do
     before do
-      service.prerun(options)
+      expect(Pakyow.container(:server).services.each.count).not_to eq(0)
     end
 
-    it "closes the endpoint" do
-      expect(bound_endpoint).to receive(:close)
+    let(:options) {
+      { foo: "bar" }
+    }
+
+    it "calls postrun for each service in the server container" do
+      Pakyow.container(:server).services.each do |service|
+        expect(service).to receive(:postrun).with(**options)
+      end
 
       service.postrun(options)
     end
@@ -146,16 +85,10 @@ RSpec.describe "environment.server service" do
     end
   end
 
-  describe "#logger" do
-    it "returns nil" do
-      expect(instance.logger).to be(nil)
-    end
-  end
-
   describe "#perform" do
-    before do
-      service.prerun(options)
-    end
+    let(:options) {
+      { env: "development" }
+    }
 
     it "boots with the env option" do
       expect(Pakyow).to receive(:boot).with(env: options[:env])
@@ -169,78 +102,16 @@ RSpec.describe "environment.server service" do
       instance.perform
     end
 
-    it "runs the server" do
-      expect(Pakyow::Server).to receive(:run).with(
-        Pakyow,
-        endpoint: bound_endpoint,
-        protocol: protocol,
-        scheme: scheme
-      )
+    it "runs the garbage collector" do
+      expect(GC).to receive(:start)
 
       instance.perform
     end
 
-    context "environment is already booted" do
-      before do
-        Pakyow.boot(env: "development")
-      end
+    it "runs the server container using the threaded strategy" do
+      expect(Pakyow.container(:server)).to receive(:run).with(parent: instance, strategy: :threaded, **options)
 
-      it "does not boot the environment" do
-        expect(Pakyow).not_to receive(:boot)
-
-        instance.perform
-      end
-
-      it "does not deep freeze the environment" do
-        expect(Pakyow).not_to receive(:deep_freeze)
-
-        instance.perform
-      end
-
-      it "runs the server" do
-        expect(Pakyow::Server).to receive(:run).with(
-          Pakyow,
-          endpoint: bound_endpoint,
-          protocol: protocol,
-          scheme: scheme
-        )
-
-        instance.perform
-      end
-    end
-  end
-
-  describe "#shutdown" do
-    before do
-      allow(Pakyow).to receive(:apps).and_return(apps)
-    end
-
-    let(:apps) {
-      [instance_double(Pakyow::Application)]
-    }
-
-    it "shuts down each application" do
-      apps.each do |app|
-        expect(app).to receive(:shutdown)
-      end
-
-      instance.shutdown
-    end
-
-    context "application fails to shutdown" do
-      before do
-        allow(apps[0]).to receive(:shutdown).and_raise(error)
-      end
-
-      let(:error) {
-        Pakyow::ApplicationError.new
-      }
-
-      it "rescues the application" do
-        expect(apps[0]).to receive(:rescue!).with(error)
-
-        instance.shutdown
-      end
+      instance.perform
     end
   end
 end

--- a/core/spec/unit/containers/server/services/endpoint_spec.rb
+++ b/core/spec/unit/containers/server/services/endpoint_spec.rb
@@ -1,0 +1,230 @@
+require_relative "../../shared/error_handling"
+
+RSpec.describe "server.endpoint service" do
+  include_context "runnable"
+
+  let(:service) {
+    Pakyow.container(:server).service(:endpoint)
+  }
+
+  let(:instance) {
+    service.new(**options)
+  }
+
+  it_behaves_like "service error handling" do
+    before do
+      expect(Pakyow).to receive(:boot).and_raise(error)
+    end
+
+    let(:options) {
+      super().tap do |options|
+        options[:endpoint] = double(:endpoint, accept: nil)
+      end
+    }
+  end
+
+  before do
+    allow(Async::HTTP::Endpoint).to receive(:parse).with(
+      "#{scheme}://#{host}:#{port}"
+    ).and_return(endpoint)
+
+    allow(Async::Reactor).to receive(:run) do |&block|
+      allow(Async::IO::SharedEndpoint).to receive(:bound).with(endpoint).and_return(bound_endpoint)
+      allow(bound_endpoint).to receive(:wait).and_return(bound_endpoint)
+
+      block.call
+    end
+
+    allow(Pakyow.logger).to receive(:<<)
+  end
+
+  let(:scheme) {
+    "https"
+  }
+
+  let(:host) {
+    "localhost"
+  }
+
+  let(:port) {
+    3000
+  }
+
+  let(:endpoint) {
+    double(:endpoint, protocol: protocol)
+  }
+
+  let(:protocol) {
+    double(:protocol)
+  }
+
+  let(:bound_endpoint) {
+    double(:bound_endpoint, accept: nil)
+  }
+
+  let(:options) {
+    { config: config, env: "development" }
+  }
+
+  let(:config) {
+    double(:config, server: server_config)
+  }
+
+  let(:server_config) {
+    double(:server_config, scheme: scheme, host: host, port: port)
+  }
+
+  describe "::prerun" do
+    it "sets the endpoint option" do
+      service.prerun(options)
+
+      expect(options[:endpoint]).to be(bound_endpoint)
+    end
+
+    it "sets the protocol option" do
+      service.prerun(options)
+
+      expect(options[:protocol]).to be(protocol)
+    end
+
+    it "logs the running text" do
+      expect(Pakyow.logger).to receive(:<<).with("\e[34;1mPakyow › Development › https://localhost:3000\e[0m\e[3m\nUse Ctrl-C to shut down the environment.\e[0m")
+
+      service.prerun(options)
+    end
+
+    context "stdout is not a tty" do
+      before do
+        allow($stdout).to receive(:tty?).and_return(false)
+      end
+
+      it "logs simpler running text" do
+        expect(Pakyow.logger).to receive(:<<).with("Pakyow › Development › https://localhost:3000")
+
+        service.prerun(options)
+      end
+    end
+
+    context "environment is impolite" do
+      before do
+        Pakyow.config.polite = false
+      end
+
+      it "logs simpler running text" do
+        expect(Pakyow.logger).not_to receive(:<<)
+
+        service.prerun(options)
+      end
+    end
+  end
+
+  describe "::postrun" do
+    before do
+      service.prerun(options)
+    end
+
+    it "closes the endpoint" do
+      expect(bound_endpoint).to receive(:close)
+
+      service.postrun(options)
+    end
+  end
+
+  describe "#logger" do
+    it "returns nil" do
+      expect(instance.logger).to be(nil)
+    end
+  end
+
+  describe "#perform" do
+    before do
+      service.prerun(options)
+    end
+
+    it "boots with the env option" do
+      expect(Pakyow).to receive(:boot).with(env: options[:env])
+
+      instance.perform
+    end
+
+    it "deep freezes the environment" do
+      expect(Pakyow).to receive(:deep_freeze)
+
+      instance.perform
+    end
+
+    it "runs the server" do
+      expect(Pakyow::Server).to receive(:run).with(
+        Pakyow,
+        endpoint: bound_endpoint,
+        protocol: protocol,
+        scheme: scheme
+      )
+
+      instance.perform
+    end
+
+    context "environment is already booted" do
+      before do
+        Pakyow.boot(env: "development")
+      end
+
+      it "does not boot the environment" do
+        expect(Pakyow).not_to receive(:boot)
+
+        instance.perform
+      end
+
+      it "does not deep freeze the environment" do
+        expect(Pakyow).not_to receive(:deep_freeze)
+
+        instance.perform
+      end
+
+      it "runs the server" do
+        expect(Pakyow::Server).to receive(:run).with(
+          Pakyow,
+          endpoint: bound_endpoint,
+          protocol: protocol,
+          scheme: scheme
+        )
+
+        instance.perform
+      end
+    end
+  end
+
+  describe "#shutdown" do
+    before do
+      allow(Pakyow).to receive(:apps).and_return(apps)
+    end
+
+    let(:apps) {
+      [instance_double(Pakyow::Application)]
+    }
+
+    it "shuts down each application" do
+      apps.each do |app|
+        expect(app).to receive(:shutdown)
+      end
+
+      instance.shutdown
+    end
+
+    context "application fails to shutdown" do
+      before do
+        allow(apps[0]).to receive(:shutdown).and_raise(error)
+      end
+
+      let(:error) {
+        Pakyow::ApplicationError.new
+      }
+
+      it "rescues the application" do
+        expect(apps[0]).to receive(:rescue!).with(error)
+
+        instance.shutdown
+      end
+    end
+  end
+end

--- a/spec/smoke/endpoint_service_siblings_spec.rb
+++ b/spec/smoke/endpoint_service_siblings_spec.rb
@@ -1,0 +1,56 @@
+require "smoke_helper"
+
+RSpec.describe "running sibling services alongside the endpoint service", :repeatable, smoke: true do
+  before do
+    File.open(project_path.join("config/environment.rb"), "w+") do |file|
+      file.write <<~SOURCE
+        Pakyow.class_state :queue, default: Queue.new
+
+        Pakyow.after "setup" do
+          container(:server).service(:reader, restartable: false) do
+            def perform
+              puts "!!! READER PERFORM"
+
+              while (item = Pakyow.queue.pop)
+                puts "!!! GOT item"
+
+                File.open("#{output_path}", "a") do |file|
+                  file.write(item)
+                end
+              end
+            end
+          end
+        end
+      SOURCE
+    end
+
+    File.open(project_path.join("config/application.rb"), "w+") do |file|
+      file.write <<~SOURCE
+        Pakyow.app :smoke_test, only: %i[routing] do
+          controller "/" do
+            default do
+              Pakyow.queue.push(:called)
+            end
+          end
+        end
+      SOURCE
+    end
+
+    FileUtils.touch(output_path)
+
+    boot
+  end
+
+  let(:output_path) {
+    project_path.join("output.txt")
+  }
+
+  it "shares data between services" do
+    response = http.get("http://localhost:#{port}")
+    expect(response.status).to eq(200)
+
+    sleep 2
+
+    expect(output_path.read).to eq("calledcalled")
+  end
+end

--- a/support/lib/pakyow/support/deep_dup.rb
+++ b/support/lib/pakyow/support/deep_dup.rb
@@ -40,7 +40,7 @@ module Pakyow
       end
 
       # Objects that can't be copied.
-      UNDUPABLE = [Symbol, Integer, NilClass, TrueClass, FalseClass, Class, Module].freeze
+      UNDUPABLE = [Symbol, Integer, NilClass, TrueClass, FalseClass, Class, Module, Queue].freeze
 
       [Object, Delegator].each do |klass|
         refine klass do

--- a/support/spec/unit/deep_dup_spec.rb
+++ b/support/spec/unit/deep_dup_spec.rb
@@ -75,6 +75,12 @@ RSpec.describe Pakyow::Support::DeepDup do
         expect(Pakyow::Support::DeepDup::UNDUPABLE).to include Module
       end
     end
+
+    describe "Queue" do
+      it "is undupable" do
+        expect(Pakyow::Support::DeepDup::UNDUPABLE).to include Queue
+      end
+    end
   end
 
   describe "recursive deep dupes" do


### PR DESCRIPTION
This change restructures containers to allow running other services alongside it. Here's the full map:

```
supervisor           (container)
  environment          (service)
    environment      (container)
      server           (service)
        server       (container)
          endpoint     (service)
          ...
      ...
  ...
```

The `server` container and `endpoint` service are completely new. The `endpoint` service takes the place of what the `server` service is currently, with the `server` service becoming simply a supervisor for the new `server` container.

The `server` container is run with the `threaded` strategy, meaning each service in the `server` container runs in a separate thread but within a single process. This allows services right alongside the endpoint, opening the door to some interesting patterns. For example, it's now possible to push data into a queue for processing outside the request/response lifecycle:

```ruby
Pakyow.container(:server).service(:tracker) do
  def self.queue
    @_queue ||= Queue.new
  end

  def perform
    while (object = self.class.queue.pop)
      # do some heavy processing
    end
  end

  def shutdown
    self.queue.close
  end
end

Pakyow.app(:foo) do
  controller "/" do
    get "/:value" do
      Pakyow.container(:server).service(:tracker).queue << params[:value]

      ...
    end
  end
end
```

We'll make use of this in some upcoming feature work.