### PR TITLE
Gracefully shutdown containers and their services

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `chg` **Gracefully shutdown containers and their services.**
+
+    *Related links:*
+    - [Pull Request #546][pr-546]
+
   * `chg` **Restructure containers to support running other services alongside servers.**
 
     *Related links:*
@@ -780,6 +785,7 @@
     *Related links:*
     - [Pull Request #338][pr-338]
 
+[pr-546]: https://github.com/pakyow/pakyow/pull/546
 [pr-543]: https://github.com/pakyow/pakyow/pull/543
 [pr-542]: https://github.com/pakyow/pakyow/pull/542
 [pr-541]: https://github.com/pakyow/pakyow/pull/541

--- a/core/lib/pakyow/behavior/running.rb
+++ b/core/lib/pakyow/behavior/running.rb
@@ -139,13 +139,19 @@ module Pakyow
               end
             end
 
+            def initialize(*, **)
+              super
+
+              @server = nil
+            end
+
             def logger
               nil
             end
 
             def perform
               ensure_booted do
-                Server.run(
+                @server = Server.run(
                   Pakyow,
                   endpoint: options[:endpoint],
                   protocol: options[:protocol],
@@ -155,6 +161,8 @@ module Pakyow
             end
 
             def shutdown
+              @server&.shutdown
+
               Pakyow.apps.each do |app|
                 app.shutdown
               rescue ApplicationError => error

--- a/core/lib/pakyow/runnable/container/strategies/async.rb
+++ b/core/lib/pakyow/runnable/container/strategies/async.rb
@@ -21,7 +21,14 @@ module Pakyow
           end
 
           private def stop_service(service, signal)
-            service.reference.stop
+            case signal
+            when :int
+              Pakyow.async {
+                service.stop
+              }
+            else
+              service.reference.stop
+            end
           end
 
           private def wrap_service_run

--- a/core/lib/pakyow/runnable/container/strategies/threaded.rb
+++ b/core/lib/pakyow/runnable/container/strategies/threaded.rb
@@ -20,8 +20,15 @@ module Pakyow
             end
           end
 
-          private def stop_service(service, _signal)
-            service.reference.kill
+          private def stop_service(service, signal)
+            case signal
+            when :int
+              Pakyow.async {
+                service.stop
+              }
+            else
+              service.reference.kill
+            end
           end
         end
       end

--- a/core/lib/pakyow/runnable/service.rb
+++ b/core/lib/pakyow/runnable/service.rb
@@ -221,8 +221,7 @@ module Pakyow
         def run(**options)
           instance = new(**options)
           instance.run
-        ensure
-          instance.stop
+          instance
         end
 
         def prerun(options)

--- a/core/lib/pakyow/server.rb
+++ b/core/lib/pakyow/server.rb
@@ -12,6 +12,24 @@ module Pakyow
 
     def initialize(context, endpoint:, protocol:, scheme:)
       super(context, endpoint, protocol, scheme)
+
+      @server = nil
+    end
+
+    def run
+      @endpoint.bind do |server|
+        @server = server
+        @server.listen(Socket::SOMAXCONN)
+        @server.accept_each(&method(:accept))
+      rescue Async::Wrapper::Cancelled
+        # the endpoint was closed
+      end
+
+      self
+    end
+
+    def shutdown
+      @server&.io&.close
     end
   end
 end

--- a/core/spec/integration/runnable/container/restarting_spec.rb
+++ b/core/spec/integration/runnable/container/restarting_spec.rb
@@ -11,9 +11,18 @@ RSpec.describe "restarting runnable containers", :repeatable, runnable: true do
 
       container.service :foo do
         define_method :perform do
+          @stopped = false
+
           message = local.message.dup
           options[:toplevel].notify(message)
-          ::Async::Task.current.sleep 10
+
+          until @stopped do
+            ::Async::Task.current.sleep(0.25)
+          end
+        end
+
+        define_method :stop do
+          @stopped = true
         end
       end
     end
@@ -355,7 +364,15 @@ RSpec.describe "running an unrestartable service in a restartable container", :r
 
       container.service :bar do
         define_method :perform do
-          ::Async::Task.current.sleep 10
+          @stopped = false
+
+          until @stopped do
+            ::Async::Task.current.sleep(0.25)
+          end
+        end
+
+        define_method :stop do
+          @stopped = true
         end
       end
     end

--- a/core/spec/integration/runnable/container/signaling_spec.rb
+++ b/core/spec/integration/runnable/container/signaling_spec.rb
@@ -3,98 +3,253 @@ require_relative "../shared"
 RSpec.describe "signaling runnable containers", :repeatable, runnable: true do
   include_context "runnable container"
 
-  before do
-    FileUtils.mkdir_p(path)
-  end
-
-  after do
-    FileUtils.rm_r(path)
-  end
-
-  let(:path) {
-    Pathname.new(File.expand_path("../tmp/#{SecureRandom.hex(4)}", __FILE__))
-  }
-
-  let(:result_path) {
-    path.join("result.txt")
-  }
-
-  # We can only test forked here because threaded services run in this process.
-  #
-  let(:run_options) {
-    { strategy: :forked }
-  }
-
-  let(:container_options) {
-    { restartable: false }
-  }
-
-  before do
-    local = self
-
-    container.service :foo, restartable: false do
-      define_method :perform do
-        local.run_container_raw(local.container2, context: self)
-
-        loop do
-          ::Async::Task.current.sleep 1
-        end
-      end
+  shared_examples :examples do
+    before do
+      FileUtils.mkdir_p(path)
     end
 
-    service
-  end
-
-  let(:container2) {
-    Pakyow::Runnable::Container.make(:test2, **container_options)
-  }
-
-  let(:service) {
-    container2.service :bar, restartable: false do
-      define_method :perform do
-        options[:toplevel].notify("bar: perform")
-
-        ::Async::Task.current.sleep 10
-      end
-
-      define_method :stop do
-        options[:toplevel].notify("bar: stop")
-      end
+    after do
+      FileUtils.rm_r(path)
     end
-  }
 
-  def run_then_kill
-    run_container do |instance|
-      listen_for length: 1, timeout: 1
-
-      @pid = instance.instance_variable_get(:@strategy).instance_variable_get(:@services).first.reference
-      ::Process.kill(signal, @pid)
-
-      yield
-    end
-  end
-
-  describe "signaling a container: INT" do
-    let(:signal) {
-      "INT"
+    let(:path) {
+      Pathname.new(File.expand_path("../tmp/#{SecureRandom.hex(4)}", __FILE__))
     }
 
-    it "cleanly stops each process" do
-      run_then_kill do
-        listen_for length: 2, timeout: 3 do |result|
-          expect(result).to eq(["bar: perform", "bar: stop"])
+    let(:result_path) {
+      path.join("result.txt")
+    }
+
+    # We can only test forked here because threaded services run in this process.
+    #
+    let(:run_options) {
+      { strategy: :forked }
+    }
+
+    let(:container_options) {
+      { restartable: false }
+    }
+
+    before do
+      local = self
+
+      container.service :foo, restartable: false do
+        define_method :perform do
+          local.run_container_raw(local.container2, context: self, **local.nested_run_options)
+
+          loop do
+            ::Async::Task.current.sleep 1
+          end
+        end
+      end
+
+      service
+    end
+
+    let(:container2) {
+      Pakyow::Runnable::Container.make(:test2, **container_options)
+    }
+
+    let(:service) {
+      container2.service :bar, restartable: false do
+        define_method :perform do
+          options[:toplevel].notify("bar: perform")
+
+          @stopped = false
+
+          until @stopped do
+            ::Async::Task.current.sleep(0.25)
+          end
+        end
+
+        define_method :stop do
+          @stopped = true
+
+          options[:toplevel].notify("bar: stop")
+        end
+      end
+    }
+
+    def run_then_kill
+      run_container do |instance|
+        listen_for length: 1, timeout: 1
+        @pid = instance.instance_variable_get(:@strategy).instance_variable_get(:@services).first.reference
+        ::Process.kill(signal, @pid)
+
+        yield
+      end
+    end
+
+    describe "signaling a container: INT" do
+      let(:signal) {
+        "INT"
+      }
+
+      it "cleanly stops each process" do
+        run_then_kill do
+          listen_for length: 2, timeout: 3 do |result|
+            expect(result).to eq(["bar: perform", "bar: stop"])
+          end
+        end
+      end
+
+      context "service in the container does not stop on int" do
+        let(:service) {
+          container2.service :bar, restartable: false do
+            define_method :perform do
+              at_exit do
+                options[:toplevel].notify("exited")
+              end
+
+              options[:toplevel].notify("running")
+
+              loop do
+                ::Async::Task.current.sleep 10
+              end
+            end
+          end
+        }
+
+        it "forces the service to stop" do
+          run_then_kill do
+            listen_for length: 2, timeout: 2
+
+            # Rely on the above timeout to cause the test to fail.
+          end
+        end
+      end
+
+      context "service in the container does not stop on int or term" do
+        let(:service) {
+          local = self
+
+          container2.service :bar, restartable: false do
+            define_method :perform do
+              Signal.trap(:TERM) do
+                # eat this one
+              end
+
+              options[:toplevel].notify("running")
+
+              loop do
+                local.result_path.write(Time.now.to_s)
+
+                ::Async::Task.current.sleep 0.25
+              end
+            end
+          end
+        }
+
+        it "force quits the service after the timeout" do
+          # Only the forked strategy get get itself into this state.
+          #
+          next unless nested_run_options[:strategy] == :forked
+
+          run_then_kill do
+            sleep 5
+
+            expect(Time.now - Time.parse(result_path.read)).to be > 3
+          end
         end
       end
     end
 
-    context "service in the container does not stop on int" do
+    describe "signaling a container: TERM" do
+      let(:signal) {
+        "TERM"
+      }
+
+      it "forces each process to stop" do
+        run_then_kill do
+          sleep 1
+
+          expect(messages).to eq(["bar: perform"])
+        end
+      end
+
+      context "service in the container does not stop on term" do
+        let(:service) {
+          local = self
+
+          container2.service :bar, restartable: false do
+            define_method :perform do
+              Signal.trap(:TERM) do
+                # eat this one
+              end
+
+              options[:toplevel].notify("running")
+
+              loop do
+                if local.result_path.dirname.exist?
+                  local.result_path.write(Time.now.to_s)
+                end
+
+                ::Async::Task.current.sleep 0.25
+              end
+            end
+
+            define_method :stop do
+              ::Async::Task.current.sleep(10)
+            end
+          end
+        }
+
+        it "force quits the service after the timeout" do
+          # Only the forked strategy get get itself into this state.
+          #
+          next unless nested_run_options[:strategy] == :forked
+
+          run_then_kill do
+            sleep 5
+
+            expect(Time.now - Time.parse(result_path.read)).to be > 4
+          end
+        end
+      end
+    end
+
+    describe "signaling a container: HUP" do
+      let(:signal) {
+        "HUP"
+      }
+
+      context "container is restartable" do
+        let(:container2) {
+          Pakyow::Runnable::Container.make(:test2, restartable: true)
+        }
+
+        it "restarts the container" do
+          run_then_kill do
+            listen_for length: 3, timeout: 1 do |result|
+              expect(result).to eq(["bar: perform", "bar: stop", "bar: perform"])
+            end
+          end
+        end
+      end
+
+      context "container is not restartable" do
+        let(:container2) {
+          Pakyow::Runnable::Container.make(:test2, restartable: false)
+        }
+
+        it "ignores the signal" do
+          run_then_kill do
+            sleep 1
+
+            expect(messages).to eq(["bar: perform"])
+          end
+        end
+      end
+    end
+
+    describe "sending two int signals" do
+      let(:signal) {
+        "INT"
+      }
+
       let(:service) {
         container2.service :bar, restartable: false do
           define_method :perform do
-            Signal.trap(:INT) do
-              # eat this one
-            end
-
             at_exit do
               options[:toplevel].notify("exited")
             end
@@ -108,8 +263,10 @@ RSpec.describe "signaling runnable containers", :repeatable, runnable: true do
         end
       }
 
-      it "sends term after the timeout" do
+      it "sends term on the second int" do
         run_then_kill do
+          ::Process.kill(signal, @pid)
+
           listen_for length: 2, timeout: 2
 
           # Rely on the above timeout to cause the test to fail.
@@ -117,18 +274,18 @@ RSpec.describe "signaling runnable containers", :repeatable, runnable: true do
       end
     end
 
-    context "service in the container does not stop on int or term" do
+    describe "sending three int signals" do
+      let(:signal) {
+        "INT"
+      }
+
       let(:service) {
         local = self
 
         container2.service :bar, restartable: false do
           define_method :perform do
-            Signal.trap(:INT) do
-              # eat this one
-            end
-
             Signal.trap(:TERM) do
-              # and this one
+              # eat this one
             end
 
             options[:toplevel].notify("running")
@@ -142,8 +299,15 @@ RSpec.describe "signaling runnable containers", :repeatable, runnable: true do
         end
       }
 
-      it "force quits the service after the timeout" do
+      it "force quits on the third int" do
+        # Only the forked strategy get get itself into this state.
+        #
+        next unless nested_run_options[:strategy] == :forked
+
         run_then_kill do
+          ::Process.kill(signal, @pid)
+          ::Process.kill(signal, @pid)
+
           sleep 5
 
           expect(Time.now - Time.parse(result_path.read)).to be > 3
@@ -152,162 +316,35 @@ RSpec.describe "signaling runnable containers", :repeatable, runnable: true do
     end
   end
 
-  describe "signaling a container: TERM" do
-    let(:signal) {
-      "TERM"
+  context "forked container" do
+    let(:nested_run_options) {
+      { strategy: :forked }
     }
 
-    it "forces each process to stop" do
-      run_then_kill do
-        sleep 1
-
-        expect(messages).to eq(["bar: perform"])
-      end
-    end
-
-    context "service in the container does not stop on term" do
-      let(:service) {
-        local = self
-
-        container2.service :bar, restartable: false do
-          define_method :perform do
-            Signal.trap(:INT) do
-              # eat this one
-            end
-
-            Signal.trap(:TERM) do
-              # and this one
-            end
-
-            options[:toplevel].notify("running")
-
-            loop do
-              local.result_path.write(Time.now.to_s)
-
-              ::Async::Task.current.sleep 0.25
-            end
-          end
-        end
-      }
-
-      it "force quits the service after the timeout" do
-        run_then_kill do
-          sleep 5
-
-          expect(Time.now - Time.parse(result_path.read)).to be > 4
-        end
-      end
-    end
+    include_examples :examples
   end
 
-  describe "signaling a container: HUP" do
-    let(:signal) {
-      "HUP"
+  context "threaded container" do
+    let(:nested_run_options) {
+      { strategy: :threaded }
     }
 
-    context "container is restartable" do
-      let(:container2) {
-        Pakyow::Runnable::Container.make(:test2, restartable: true)
-      }
-
-      it "restarts the container" do
-        run_then_kill do
-          listen_for length: 3, timeout: 1 do |result|
-            expect(result).to eq(["bar: perform", "bar: stop", "bar: perform"])
-          end
-        end
-      end
-    end
-
-    context "container is not restartable" do
-      let(:container2) {
-        Pakyow::Runnable::Container.make(:test2, restartable: false)
-      }
-
-      it "ignores the signal" do
-        run_then_kill do
-          sleep 1
-
-          expect(messages).to eq(["bar: perform"])
-        end
-      end
-    end
+    include_examples :examples
   end
 
-  describe "sending two int signals" do
-    let(:signal) {
-      "INT"
+  context "hybrid container" do
+    let(:nested_run_options) {
+      { strategy: :hybrid }
     }
 
-    let(:service) {
-      container2.service :bar, restartable: false do
-        define_method :perform do
-          Signal.trap(:INT) do
-            # eat this one
-          end
-
-          at_exit do
-            options[:toplevel].notify("exited")
-          end
-
-          options[:toplevel].notify("running")
-
-          loop do
-            ::Async::Task.current.sleep 10
-          end
-        end
-      end
-    }
-
-    it "sends term on the second int" do
-      run_then_kill do
-        ::Process.kill(signal, @pid)
-
-        listen_for length: 2, timeout: 2
-
-        # Rely on the above timeout to cause the test to fail.
-      end
-    end
+    include_examples :examples
   end
 
-  describe "sending three int signals" do
-    let(:signal) {
-      "INT"
+  context "async container" do
+    let(:nested_run_options) {
+      { strategy: :async }
     }
 
-    let(:service) {
-      local = self
-
-      container2.service :bar, restartable: false do
-        define_method :perform do
-          Signal.trap(:INT) do
-            # eat this one
-          end
-
-          Signal.trap(:TERM) do
-            # and this one
-          end
-
-          options[:toplevel].notify("running")
-
-          loop do
-            local.result_path.write(Time.now.to_s)
-
-            ::Async::Task.current.sleep 0.25
-          end
-        end
-      end
-    }
-
-    it "force quits on the third int" do
-      run_then_kill do
-        ::Process.kill(signal, @pid)
-        ::Process.kill(signal, @pid)
-
-        sleep 5
-
-        expect(Time.now - Time.parse(result_path.read)).to be > 3
-      end
-    end
+    include_examples :examples
   end
 end

--- a/core/spec/integration/runnable/container/stopping_spec.rb
+++ b/core/spec/integration/runnable/container/stopping_spec.rb
@@ -1,0 +1,127 @@
+require_relative "../shared"
+
+RSpec.describe "stopping down runnable containers", :repeatable, runnable: true do
+  include_context "runnable container"
+
+  shared_examples :examples do
+    before do
+      local = self
+
+      container.service :foo do
+        define_method(:perform, &local.perform_block)
+        define_method(:shutdown, &local.shutdown_block)
+      end
+    end
+
+    let(:perform_block) {
+      Proc.new {
+        options[:toplevel].notify("started")
+
+        @stopped = false
+
+        until @stopped do
+          ::Async::Task.current.sleep(0.25)
+        end
+
+        options[:toplevel].notify("finished")
+      }
+    }
+
+    let(:shutdown_block) {
+      Proc.new {
+        options[:toplevel].notify("shutdown")
+
+        @stopped = true
+      }
+    }
+
+    def stop(instance)
+      instance.stop
+    end
+
+    it "stops the container" do
+      run_container do |instance|
+        listen_for length: 1, timeout: 1 do |result|
+          expect(result.count("started")).to eq(1)
+        end
+
+        stop(instance)
+
+        listen_for length: 3, timeout: 1 do |result|
+          expect(result).to eq(%w(started shutdown finished))
+        end
+      end
+    end
+
+    describe "async friendliness" do
+      let(:perform_block) {
+        Proc.new {
+          options[:toplevel].notify("started")
+
+          @condition = ::Async::Condition.new
+          @condition.wait
+
+          options[:toplevel].notify("finished")
+        }
+      }
+
+      let(:shutdown_block) {
+        Proc.new {
+          options[:toplevel].notify("shutdown")
+
+          @condition.signal
+        }
+      }
+
+      it "stops within the same async context as perform" do
+        # This does not work for threaded containers, as fibers cannot be resumed across threads.
+        #
+        next if run_options[:strategy] == :threaded
+
+        run_container do |instance|
+          listen_for length: 1, timeout: 1 do |result|
+            expect(result.count("started")).to eq(1)
+          end
+
+          stop(instance)
+
+          listen_for length: 3, timeout: 1 do |result|
+            expect(result).to eq(%w(started shutdown finished))
+          end
+        end
+      end
+    end
+  end
+
+  context "forked container" do
+    let(:run_options) {
+      { strategy: :forked }
+    }
+
+    include_examples :examples
+  end
+
+  context "threaded container" do
+    let(:run_options) {
+      { strategy: :threaded }
+    }
+
+    include_examples :examples
+  end
+
+  context "hybrid container" do
+    let(:run_options) {
+      { strategy: :hybrid }
+    }
+
+    include_examples :examples
+  end
+
+  context "async container" do
+    let(:run_options) {
+      { strategy: :async }
+    }
+
+    include_examples :examples
+  end
+end

--- a/core/spec/integration/runnable/shared.rb
+++ b/core/spec/integration/runnable/shared.rb
@@ -27,10 +27,10 @@ RSpec.shared_context "runnable container" do
     1
   }
 
-  def run_container_raw(container, context:)
+  def run_container_raw(container, context:, **options)
     final_options = context.options.merge(
       parent: context
-    )
+    ).merge(options)
 
     instance = container.new(**final_options)
     instance.options[:container] = instance

--- a/core/spec/unit/containers/server/services/endpoint_spec.rb
+++ b/core/spec/unit/containers/server/services/endpoint_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "server.endpoint service" do
 
     let(:options) {
       super().tap do |options|
-        options[:endpoint] = double(:endpoint, accept: nil)
+        options[:endpoint] = double(:endpoint, bind: nil)
       end
     }
   end
@@ -59,7 +59,7 @@ RSpec.describe "server.endpoint service" do
   }
 
   let(:bound_endpoint) {
-    double(:bound_endpoint, accept: nil)
+    double(:bound_endpoint, bind: nil)
   }
 
   let(:options) {
@@ -197,11 +197,24 @@ RSpec.describe "server.endpoint service" do
   describe "#shutdown" do
     before do
       allow(Pakyow).to receive(:apps).and_return(apps)
+      allow(Pakyow::Server).to receive(:run).and_return(server)
+      service.prerun(options)
+      instance.perform
     end
 
     let(:apps) {
-      [instance_double(Pakyow::Application)]
+      [instance_double(Pakyow::Application, shutdown: nil)]
     }
+
+    let(:server) {
+      instance_double(Pakyow::Server, shutdown: nil)
+    }
+
+    it "shuts down the server" do
+      expect(server).to receive(:shutdown)
+
+      instance.shutdown
+    end
 
     it "shuts down each application" do
       apps.each do |app|

--- a/core/spec/unit/server_spec.rb
+++ b/core/spec/unit/server_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Pakyow::Server do
   }
 
   let(:endpoint) {
-    instance_double(Async::HTTP::Endpoint, accept: nil)
+    instance_double(Async::HTTP::Endpoint, bind: nil)
   }
 
   let(:protocol) {

--- a/frameworks/assets/spec/integration/services/externals_spec.rb
+++ b/frameworks/assets/spec/integration/services/externals_spec.rb
@@ -61,10 +61,10 @@ RSpec.describe "external asset fetching service" do
       expect(File.exist?(File.join(tmp, "frontend/assets/packs/vendor", "jquery@3.3.1.js"))).to be(true)
     end
 
-    it "restarts" do
+    it "restarts on shutdown" do
       expect(Pakyow).to receive(:restart)
 
-      run_externals_service
+      run_externals_service.shutdown
     end
 
     context "external exists" do


### PR DESCRIPTION
Improves the container shutdown process so that services are given an opportunity to shutdown gracefully. In brief:

* Ask the container to shutdown (e.g. by sending `INT` to the container process).
* Container stops each service, calling the `shutdown` hook defined by each service.
* If the service has not stopped within the configured timeout, force it to stop.

The `perform` loop is not interrupted for graceful shutdowns, giving `shutdown` a chance to stop the loop and cleanup. If a service is forced to stop, the `shutdown` hook is not invoked and the `perform` loop is interrupted immediately.

We now use this internally in the `endpoint` service to close the endpoint when the service stops. This sets us up to further improve endpoint shutdowns by waiting on connections to finish without accepting new connections.