### PR TITLE
Drop Ruby 2.5 Support

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -42,7 +42,6 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 2.5.8
           - 2.6.6
           - 2.7.1
 

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -43,7 +43,7 @@ jobs:
       matrix:
         ruby:
           - 2.6.6
-          - 2.7.1
+          - 2.7.2
 
         test:
           - assets

--- a/.github/workflows/standardrb.yml
+++ b/.github/workflows/standardrb.yml
@@ -14,7 +14,7 @@ jobs:
     name: Standard RB
 
     container:
-      image: pakyow/ci-ruby-2.5.8
+      image: pakyow/ci-ruby-2.6.6
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -19,7 +19,6 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 2.5.8
           - 2.6.6
           - 2.7.1
 
@@ -65,7 +64,6 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 2.5.8
           - 2.6.6
           - 2.7.1
 
@@ -127,7 +125,6 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 2.5.8
           - 2.6.6
           - 2.7.1
 
@@ -188,7 +185,6 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 2.5.8
           - 2.6.6
           - 2.7.1
 

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         ruby:
           - 2.6.6
-          - 2.7.1
+          - 2.7.2
 
         gem:
           - assets
@@ -65,7 +65,7 @@ jobs:
       matrix:
         ruby:
           - 2.6.6
-          - 2.7.1
+          - 2.7.2
 
         gem:
           - form
@@ -126,7 +126,7 @@ jobs:
       matrix:
         ruby:
           - 2.6.6
-          - 2.7.1
+          - 2.7.2
 
         gem:
           - data
@@ -186,7 +186,7 @@ jobs:
       matrix:
         ruby:
           - 2.6.6
-          - 2.7.1
+          - 2.7.2
 
         gem:
           - data

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `chg` **Drop Ruby 2.5 support.**
+
+    *Related links:*
+    - [Pull Request #547][pr-547]
+
   * `chg` **Gracefully shutdown containers and their services.**
 
     *Related links:*
@@ -785,6 +790,7 @@
     *Related links:*
     - [Pull Request #338][pr-338]
 
+[pr-547]: https://github.com/pakyow/pakyow/pull/547
 [pr-546]: https://github.com/pakyow/pakyow/pull/546
 [pr-543]: https://github.com/pakyow/pakyow/pull/543
 [pr-542]: https://github.com/pakyow/pakyow/pull/542

--- a/core/pakyow-core.gemspec
+++ b/core/pakyow-core.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.email = "bryan@bryanp.org"
   spec.homepage = "https://pakyow.com"
 
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = ">= 2.6.0"
 
   spec.license = "LGPL-3.0"
 

--- a/frameworks/assets/CHANGELOG.md
+++ b/frameworks/assets/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `chg` **Drop Ruby 2.5 support.**
+
+    *Related links:*
+    - [Pull Request #547][pr-547]
+
   * `fix` **Correctly handle asset prefixes for clashing asset names.**
 
     *Related links:*
@@ -65,6 +70,7 @@
     - [Pull Request #376][pr-376]
     - [Commit ec13cdd][ec13cdd]
 
+[pr-547]: https://github.com/pakyow/pakyow/pull/547
 [pr-539]: https://github.com/pakyow/pakyow/pull/539
 [pr-515]: https://github.com/pakyow/pakyow/pull/515
 [pr-514]: https://github.com/pakyow/pakyow/pull/514

--- a/frameworks/assets/pakyow-assets.gemspec
+++ b/frameworks/assets/pakyow-assets.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.email = "bryan@bryanp.org"
   spec.homepage = "https://pakyow.com"
 
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = ">= 2.6.0"
 
   spec.license = "LGPL-3.0"
 

--- a/frameworks/data/CHANGELOG.md
+++ b/frameworks/data/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `chg` **Drop Ruby 2.5 support.**
+
+    *Related links:*
+    - [Pull Request #547][pr-547]
+
   * `fix` **Disconnect data connections when the environment is forked.**
 
     *Related links:*
@@ -20,6 +25,7 @@
     *Related links:*
     - [Pull Request #381][pr-381]
 
+[pr-547]: https://github.com/pakyow/pakyow/pull/547
 [pr-534]: https://github.com/pakyow/pakyow/pull/534
 [pr-532]: https://github.com/pakyow/pakyow/pull/532
 [pr-382]: https://github.com/pakyow/pakyow/pull/382

--- a/frameworks/data/pakyow-data.gemspec
+++ b/frameworks/data/pakyow-data.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.email = "bryan@bryanp.org"
   spec.homepage = "https://pakyow.com"
 
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = ">= 2.6.0"
 
   spec.license = "LGPL-3.0"
 

--- a/frameworks/form/CHANGELOG.md
+++ b/frameworks/form/CHANGELOG.md
@@ -1,3 +1,12 @@
+# v1.1.0 (unreleased)
+
+  * `chg` **Drop Ruby 2.5 support.**
+
+    *Related links:*
+    - [Pull Request #547][pr-547]
+
+[pr-547]: https://github.com/pakyow/pakyow/pull/547
+
 # v1.0.0
 
   * Hello, Web

--- a/frameworks/form/pakyow-form.gemspec
+++ b/frameworks/form/pakyow-form.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.email = "bryan@bryanp.org"
   spec.homepage = "https://pakyow.com"
 
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = ">= 2.6.0"
 
   spec.license = "LGPL-3.0"
 

--- a/frameworks/mailer/CHANGELOG.md
+++ b/frameworks/mailer/CHANGELOG.md
@@ -1,3 +1,12 @@
+# v1.1.0 (unreleased)
+
+  * `chg` **Drop Ruby 2.5 support.**
+
+    *Related links:*
+    - [Pull Request #547][pr-547]
+
+[pr-547]: https://github.com/pakyow/pakyow/pull/547
+
 # v1.0.0
 
   * Hello, Web

--- a/frameworks/mailer/pakyow-mailer.gemspec
+++ b/frameworks/mailer/pakyow-mailer.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.email = "bryan@bryanp.org"
   spec.homepage = "https://pakyow.com"
 
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = ">= 2.6.0"
 
   spec.license = "LGPL-3.0"
 

--- a/frameworks/presenter/CHANGELOG.md
+++ b/frameworks/presenter/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `chg` **Drop Ruby 2.5 support.**
+
+    *Related links:*
+    - [Pull Request #547][pr-547]
+
   * `chg` **Improve component rendering performance by avoiding connection duping.**
 
     *Related links:*
@@ -36,6 +41,7 @@
     - [Pull Request #297][pr-297]
     - [Commit 802295c][802295c]
 
+[pr-547]: https://github.com/pakyow/pakyow/pull/547
 [pr-538]: https://github.com/pakyow/pakyow/pull/538
 [pr-515]: https://github.com/pakyow/pakyow/pull/515
 [pr-502]: https://github.com/pakyow/pakyow/pull/502

--- a/frameworks/presenter/pakyow-presenter.gemspec
+++ b/frameworks/presenter/pakyow-presenter.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.email = "bryan@bryanp.org"
   spec.homepage = "https://pakyow.com"
 
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = ">= 2.6.0"
 
   spec.license = "LGPL-3.0"
 

--- a/frameworks/realtime/CHANGELOG.md
+++ b/frameworks/realtime/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `chg` **Drop Ruby 2.5 support.**
+
+    *Related links:*
+    - [Pull Request #547][pr-547]
+
   * `fix` **Refactor the websocket server to a service.**
 
     *Related links:*
@@ -24,6 +29,7 @@
     *Related links:*
     - [Pull Request #296][pr-296]
 
+[pr-547]: https://github.com/pakyow/pakyow/pull/547
 [pr-545]: https://github.com/pakyow/pakyow/pull/545
 [pr-304]: https://github.com/pakyow/pakyow/pull/304
 [pr-296]: https://github.com/pakyow/pakyow/pull/296

--- a/frameworks/realtime/pakyow-realtime.gemspec
+++ b/frameworks/realtime/pakyow-realtime.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.email = "bryan@bryanp.org"
   spec.homepage = "https://pakyow.com"
 
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = ">= 2.6.0"
 
   spec.license = "LGPL-3.0"
 

--- a/frameworks/reflection/CHANGELOG.md
+++ b/frameworks/reflection/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `chg` **Drop Ruby 2.5 support.**
+
+    *Related links:*
+    - [Pull Request #547][pr-547]
+
   * `fix` **Update reflection to support presenter templates defined with multiple paths.**
 
     *Related links:*
@@ -10,6 +15,7 @@
     *Related links:*
     - [Commit ce9a018][ce9a018]
 
+[pr-547]: https://github.com/pakyow/pakyow/pull/547
 [pr-524]: https://github.com/pakyow/pakyow/pull/524
 [ce9a018]: https://github.com/pakyow/pakyow/commit/ce9a0186b70f99aadb173fc37e1d9541ce9834da
 

--- a/frameworks/reflection/pakyow-reflection.gemspec
+++ b/frameworks/reflection/pakyow-reflection.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.email = "bryan@bryanp.org"
   spec.homepage = "https://pakyow.com"
 
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = ">= 2.6.0"
 
   spec.license = "LGPL-3.0"
 

--- a/frameworks/routing/CHANGELOG.md
+++ b/frameworks/routing/CHANGELOG.md
@@ -1,11 +1,17 @@
 # v1.1.0 (unreleased)
 
+  * `chg` **Drop Ruby 2.5 support.**
+
+    *Related links:*
+    - [Pull Request #547][pr-547]
+
   * `fix` **Build endpoints relative to the app mount path.**
 
     *Related links:*
     - [Pull Request #374][pr-374]
     - [Commit d7ef764][d7ef764]
 
+[pr-547]: https://github.com/pakyow/pakyow/pull/547
 [pr-374]: https://github.com/pakyow/pakyow/pull/374
 [d7ef764]: https://github.com/pakyow/pakyow/commit/d7ef76437f4c8948ac09d9b5be77bc02a44caa06
 

--- a/frameworks/routing/pakyow-routing.gemspec
+++ b/frameworks/routing/pakyow-routing.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.email = "bryan@bryanp.org"
   spec.homepage = "https://pakyow.com"
 
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = ">= 2.6.0"
 
   spec.license = "LGPL-3.0"
 

--- a/frameworks/ui/CHANGELOG.md
+++ b/frameworks/ui/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `chg` **Drop Ruby 2.5 support.**
+
+    *Related links:*
+    - [Pull Request #547][pr-547]
+
   * `add` **WebSocket message handler for logging from the ui.**
 
     *Related links:*
@@ -11,6 +16,7 @@
     *Related links:*
     - [Commit fa2f30b][fa2f30b]
 
+[pr-547]: https://github.com/pakyow/pakyow/pull/547
 [pr-304]: https://github.com/pakyow/pakyow/pull/304
 [89ccfde]: https://github.com/pakyow/pakyow/commit/89ccfde26896d2520650289e85b7e8274d128f55
 [fa2f30b]: https://github.com/pakyow/pakyow/commit/fa2f30b18b6302ab72ba832e601d877dc8231cb1

--- a/frameworks/ui/pakyow-ui.gemspec
+++ b/frameworks/ui/pakyow-ui.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.email = "bryan@bryanp.org"
   spec.homepage = "https://pakyow.com"
 
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = ">= 2.6.0"
 
   spec.license = "LGPL-3.0"
 

--- a/pakyow.gemspec
+++ b/pakyow.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.email = "bryan@bryanp.org"
   spec.homepage = "https://pakyow.com"
 
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = ">= 2.6.0"
 
   spec.license = "LGPL-3.0"
 

--- a/support/CHANGELOG.md
+++ b/support/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `chg` **Drop Ruby 2.5 support.**
+
+    *Related links:*
+    - [Pull Request #547][pr-547]
+
   * `fix` **Correctly deep dup recursive objects.**
 
     *Related links:*
@@ -354,6 +359,7 @@
     *Related links:*
     - [Pull Request #364][pr-364]
 
+[pr-547]: https://github.com/pakyow/pakyow/pull/547
 [pr-537]: https://github.com/pakyow/pakyow/pull/537
 [pr-531]: https://github.com/pakyow/pakyow/pull/531
 [pr-527]: https://github.com/pakyow/pakyow/pull/527

--- a/support/pakyow-support.gemspec
+++ b/support/pakyow-support.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.email = "bryan@bryanp.org"
   spec.homepage = "https://pakyow.com"
 
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = ">= 2.6.6"
 
   spec.license = "LGPL-3.0"
 


### PR DESCRIPTION
Ruby 2.5 will likely be EOL by the time the next release drops, so let's go ahead and drop support. This will also resolve some segfaults that I've only seen in Ruby 2.5 related to object finalizers.