### PR TITLE
Stop services with the notifier pattern

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `chg` **Stop services with the notifier pattern.**
+
+    *Related links:*
+    - [Pull Request #548][pr-548]
+
   * `chg` **Drop Ruby 2.5 support.**
 
     *Related links:*
@@ -790,6 +795,7 @@
     *Related links:*
     - [Pull Request #338][pr-338]
 
+[pr-548]: https://github.com/pakyow/pakyow/pull/548
 [pr-547]: https://github.com/pakyow/pakyow/pull/547
 [pr-546]: https://github.com/pakyow/pakyow/pull/546
 [pr-543]: https://github.com/pakyow/pakyow/pull/543

--- a/core/lib/pakyow/behavior/running.rb
+++ b/core/lib/pakyow/behavior/running.rb
@@ -49,8 +49,14 @@ module Pakyow
               ensure_booted do
                 GC.start
 
-                Pakyow.container(:environment).run(parent: self, **options)
+                Pakyow.container(:environment).run(parent: self, **options) do |instance|
+                  @container = instance
+                end
               end
+            end
+
+            def shutdown
+              @container&.stop
             end
           end
         end
@@ -88,8 +94,14 @@ module Pakyow
                 GC.start
 
                 options[:strategy] = :threaded
-                Pakyow.container(:server).run(parent: self, **options)
+                Pakyow.container(:server).run(parent: self, **options) do |instance|
+                  @container = instance
+                end
               end
+            end
+
+            def shutdown
+              @container&.stop
             end
           end
         end

--- a/core/lib/pakyow/runnable/container/strategies/async.rb
+++ b/core/lib/pakyow/runnable/container/strategies/async.rb
@@ -20,15 +20,8 @@ module Pakyow
             end
           end
 
-          private def stop_service(service, signal)
-            case signal
-            when :int
-              Pakyow.async {
-                service.stop
-              }
-            else
-              service.reference.stop
-            end
+          private def terminate_service(service)
+            service.reference.stop
           end
 
           private def wrap_service_run

--- a/core/lib/pakyow/runnable/container/strategies/hybrid.rb
+++ b/core/lib/pakyow/runnable/container/strategies/hybrid.rb
@@ -26,8 +26,12 @@ module Pakyow
             end
           end
 
-          private def stop_service(service, signal)
-            service_strategy(service).send(:stop_service, service, signal)
+          private def terminate_service(service)
+            service_strategy(service).send(:terminate_service, service)
+          end
+
+          private def quit_service(service)
+            service_strategy(service).send(:quit_service, service)
           end
 
           private def wait_for_service(service)

--- a/core/lib/pakyow/runnable/container/strategies/threaded.rb
+++ b/core/lib/pakyow/runnable/container/strategies/threaded.rb
@@ -20,15 +20,8 @@ module Pakyow
             end
           end
 
-          private def stop_service(service, signal)
-            case signal
-            when :int
-              Pakyow.async {
-                service.stop
-              }
-            else
-              service.reference.kill
-            end
+          private def terminate_service(service)
+            service.reference.kill
           end
         end
       end

--- a/core/lib/pakyow/runnable/notifier.rb
+++ b/core/lib/pakyow/runnable/notifier.rb
@@ -7,7 +7,7 @@ require "pakyow/support/deep_freeze"
 
 module Pakyow
   module Runnable
-    # Send notifications to a container from any process.
+    # Send notifications to a container or service from any process.
     #
     # @api private
     class Notifier
@@ -17,7 +17,6 @@ module Pakyow
       attr_reader :child, :parent
 
       def initialize
-        @stopped = false
         @messages = []
         @path = File.join(Dir.tmpdir, "pakyow-#{::Process.pid}-#{SecureRandom.hex(4)}.sock")
         @notification = ::Async::Notification.new
@@ -67,7 +66,6 @@ module Pakyow
       def stop
         return unless running?
 
-        @stopped = true
         @notification.signal
 
         Pakyow.async {
@@ -82,8 +80,8 @@ module Pakyow
         @endpoint = nil
       end
 
-      private def running?
-        @stopped == false
+      def running?
+        File.exist?(@path)
       end
 
       private def receive

--- a/core/spec/integration/runnable/container/restarting_spec.rb
+++ b/core/spec/integration/runnable/container/restarting_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "restarting runnable containers", :repeatable, runnable: true do
           end
         end
 
-        define_method :stop do
+        define_method :shutdown do
           @stopped = true
         end
       end
@@ -371,7 +371,7 @@ RSpec.describe "running an unrestartable service in a restartable container", :r
           end
         end
 
-        define_method :stop do
+        define_method :shutdown do
           @stopped = true
         end
       end

--- a/core/spec/integration/runnable/container/signaling_spec.rb
+++ b/core/spec/integration/runnable/container/signaling_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "signaling runnable containers", :repeatable, runnable: true do
           end
         end
 
-        define_method :stop do
+        define_method :shutdown do
           @stopped = true
 
           options[:toplevel].notify("bar: stop")
@@ -188,7 +188,7 @@ RSpec.describe "signaling runnable containers", :repeatable, runnable: true do
               end
             end
 
-            define_method :stop do
+            define_method :shutdown do
               ::Async::Task.current.sleep(10)
             end
           end

--- a/core/spec/integration/runnable/container/stopping_spec.rb
+++ b/core/spec/integration/runnable/container/stopping_spec.rb
@@ -74,10 +74,51 @@ RSpec.describe "stopping down runnable containers", :repeatable, runnable: true 
       }
 
       it "stops within the same async context as perform" do
-        # This does not work for threaded containers, as fibers cannot be resumed across threads.
-        #
-        next if run_options[:strategy] == :threaded
+        run_container do |instance|
+          listen_for length: 1, timeout: 1 do |result|
+            expect(result.count("started")).to eq(1)
+          end
 
+          stop(instance)
+
+          listen_for length: 3, timeout: 1 do |result|
+            expect(result).to eq(%w(started shutdown finished))
+          end
+        end
+      end
+    end
+
+    describe "avoiding the trap context" do
+      let(:perform_block) {
+        Proc.new {
+          @lock = Mutex.new
+          options[:toplevel].notify("started")
+
+          @stopped = false
+
+          until @stopped do
+            ::Async::Task.current.sleep(0.25)
+          end
+
+          options[:toplevel].notify("finished")
+        }
+      }
+
+      let(:shutdown_block) {
+        Proc.new {
+          begin
+            @lock.synchronize do; end
+
+            options[:toplevel].notify("shutdown")
+
+            @stopped = true
+          rescue
+            options[:toplevel].notify("errored")
+          end
+        }
+      }
+
+      it "does not call the stop handler within the trap context" do
         run_container do |instance|
           listen_for length: 1, timeout: 1 do |result|
             expect(result.count("started")).to eq(1)

--- a/core/spec/unit/runnable/service_spec.rb
+++ b/core/spec/unit/runnable/service_spec.rb
@@ -13,6 +13,21 @@ RSpec.describe Pakyow::Runnable::Service do
     {}
   }
 
+  def start_service
+    instance.prepare
+
+    @notifier = Thread.new do
+      instance.run
+    end
+
+    sleep(0.25)
+  end
+
+  def stop_service
+    instance.stop
+    @notifier.join
+  end
+
   describe "options" do
     let(:options) {
       { foo: 'bar' }
@@ -33,18 +48,18 @@ RSpec.describe Pakyow::Runnable::Service do
 
   describe "#stop" do
     before do
-      instance.run
+      start_service
     end
 
     it "shuts down" do
       expect(instance).to receive(:shutdown)
 
-      instance.stop
+      stop_service
     end
 
     it "causes the service to appear stopped" do
       expect {
-        instance.stop
+        stop_service
       }.to change {
         instance.stopped?
       }.from(false).to(true)
@@ -52,13 +67,13 @@ RSpec.describe Pakyow::Runnable::Service do
 
     context "service is already stopped" do
       before do
-        instance.stop
+        stop_service
       end
 
       it "does not shut down" do
         expect(instance).not_to receive(:shutdown)
 
-        instance.stop
+        stop_service
       end
     end
   end
@@ -70,7 +85,8 @@ RSpec.describe Pakyow::Runnable::Service do
 
     context "service is stopped" do
       before do
-        instance.stop
+        start_service
+        stop_service
       end
 
       it "is true" do


### PR DESCRIPTION
Introduces service notifiers, allowing messages to be passed to a service from anywhere.

This change also fixes an issue where shutdown hooks for forked services are called in the trap context.