### PR TITLE
Gracefully stop services that have blocked the reactor

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `chg` **Gracefully stop services that have blocked the reactor.**
+
+    *Related links:*
+    - [Pull Request #549][pr-549]
+
   * `chg` **Stop services with the notifier pattern.**
 
     *Related links:*
@@ -795,6 +800,7 @@
     *Related links:*
     - [Pull Request #338][pr-338]
 
+[pr-549]: https://github.com/pakyow/pakyow/pull/549
 [pr-548]: https://github.com/pakyow/pakyow/pull/548
 [pr-547]: https://github.com/pakyow/pakyow/pull/547
 [pr-546]: https://github.com/pakyow/pakyow/pull/546

--- a/core/lib/pakyow/runnable/container/strategies/forked.rb
+++ b/core/lib/pakyow/runnable/container/strategies/forked.rb
@@ -16,6 +16,11 @@ module Pakyow
             @forked_services = {}
           end
 
+          private def stop_service(service)
+            ::Process.kill(:INT, service.reference)
+          rescue Errno::ESRCH
+          end
+
           private def terminate_service(service)
             ::Process.kill(:TERM, service.reference)
           rescue Errno::ESRCH

--- a/core/lib/pakyow/runnable/container/strategies/hybrid.rb
+++ b/core/lib/pakyow/runnable/container/strategies/hybrid.rb
@@ -26,6 +26,10 @@ module Pakyow
             end
           end
 
+          private def stop_service(service)
+            service_strategy(service).send(:stop_service, service)
+          end
+
           private def terminate_service(service)
             service_strategy(service).send(:terminate_service, service)
           end

--- a/core/lib/pakyow/runnable/service.rb
+++ b/core/lib/pakyow/runnable/service.rb
@@ -196,13 +196,11 @@ module Pakyow
 
         Pakyow.async { |task|
           task.async do
-            begin
-              perform
-            rescue => error
-              Pakyow.houston(error)
+            perform
+          rescue => error
+            Pakyow.houston(error)
 
-              failed!
-            end
+            failed!
           end
 
           @__blocked = false

--- a/core/lib/pakyow/server.rb
+++ b/core/lib/pakyow/server.rb
@@ -13,14 +13,15 @@ module Pakyow
     def initialize(context, endpoint:, protocol:, scheme:)
       super(context, endpoint, protocol, scheme)
 
-      @server = nil
+      @wrappers = []
     end
 
     def run
-      @endpoint.bind do |server|
-        @server = server
-        @server.listen(Socket::SOMAXCONN)
-        @server.accept_each(&method(:accept))
+      @endpoint.bind do |wrapper|
+        @wrappers << wrapper
+
+        wrapper.listen(Socket::SOMAXCONN)
+        wrapper.accept_each(&method(:accept))
       rescue Async::Wrapper::Cancelled
         # the endpoint was closed
       end
@@ -29,7 +30,7 @@ module Pakyow
     end
 
     def shutdown
-      @server&.io&.close
+      @wrappers.each(&:close)
     end
   end
 end

--- a/frameworks/realtime/lib/pakyow/realtime.rb
+++ b/frameworks/realtime/lib/pakyow/realtime.rb
@@ -34,12 +34,18 @@ module Pakyow
   end
 
   container(:server).service(:websockets) do
-    def perform
-      @server = Realtime::Server.run(
+    def initialize(*, **)
+      super
+
+      @server = Realtime::Server.new(
         Pakyow.config.realtime.adapter,
         Pakyow.config.realtime.adapter_settings.to_h,
         Pakyow.config.realtime.timeouts
       )
+    end
+
+    def perform
+      @server.run
     end
 
     def shutdown

--- a/frameworks/realtime/spec/unit/containers/server/websockets_spec.rb
+++ b/frameworks/realtime/spec/unit/containers/server/websockets_spec.rb
@@ -12,20 +12,20 @@ RSpec.describe "server.websockets service" do
   }
 
   let(:server) {
-    instance_double(Pakyow::Realtime::Server)
+    instance_double(Pakyow::Realtime::Server, run: nil)
   }
 
   before do
-    allow(Pakyow::Realtime::Server).to receive(:run).and_return(server)
+    allow(Pakyow::Realtime::Server).to receive(:new).with(
+      Pakyow.config.realtime.adapter,
+      Pakyow.config.realtime.adapter_settings.to_h,
+      Pakyow.config.realtime.timeouts
+    ).and_return(server)
   end
 
   describe "#perform" do
     it "runs the realtime server" do
-      expect(Pakyow::Realtime::Server).to receive(:run).with(
-        Pakyow.config.realtime.adapter,
-        Pakyow.config.realtime.adapter_settings.to_h,
-        Pakyow.config.realtime.timeouts
-      )
+      expect(server).to receive(:run)
 
       instance.perform
     end


### PR DESCRIPTION
Some services (like the `websockets` service) block the async reactor, preventing the stop message from being received. We now detect what services have blocked the reactor and shut them down from the main shutdown context.