### PR TITLE
Run containers in their own process groups

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `chg` **Run containers in their own process groups.**
+
+    *Related links:*
+    - [Pull Request #550][pr-550]
+
   * `chg` **Gracefully stop services that have blocked the reactor.**
 
     *Related links:*
@@ -800,6 +805,7 @@
     *Related links:*
     - [Pull Request #338][pr-338]
 
+[pr-550]: https://github.com/pakyow/pakyow/pull/550
 [pr-549]: https://github.com/pakyow/pakyow/pull/549
 [pr-548]: https://github.com/pakyow/pakyow/pull/548
 [pr-547]: https://github.com/pakyow/pakyow/pull/547

--- a/core/lib/pakyow/runnable/container.rb
+++ b/core/lib/pakyow/runnable/container.rb
@@ -186,6 +186,10 @@ module Pakyow
             @strategy.terminate
           end
 
+          unless toplevel_pid?
+            ::Process.setsid
+          end
+
           yield self if block_given?
 
           Pakyow.async {

--- a/core/lib/pakyow/runnable/notifier.rb
+++ b/core/lib/pakyow/runnable/notifier.rb
@@ -40,7 +40,7 @@ module Pakyow
               socket.connect(Socket.pack_sockaddr_un(@path))
               socket.sendmsg(Marshal.dump(message))
             ensure
-              socket.close
+              socket&.close
             end
           end
         end

--- a/core/spec/unit/runnable/container_spec.rb
+++ b/core/spec/unit/runnable/container_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe Pakyow::Runnable::Container do
 
     before do
       allow(::Process).to receive(:pid).and_return(4242)
+      allow(::Process).to receive(:setsid)
     end
   end
 


### PR DESCRIPTION
Improves the reliability of signaling container processes.

The other commit are inconsequential and came out of some debugging related to the functional change.