### PR TITLE
Load files with the expected module nesting

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `fix` **Load files with the expected module nesting.**
+
+    *Related links:*
+    - [Pull Request #554][pr-554]
+
   * `chg` **Support Ruby 3, Drop 2.6.**
 
     *Related links:*
@@ -820,6 +825,7 @@
     *Related links:*
     - [Pull Request #338][pr-338]
 
+[pr-554]: https://github.com/pakyow/pakyow/pull/554
 [pr-553]: https://github.com/pakyow/pakyow/pull/553
 [pr-551]: https://github.com/pakyow/pakyow/pull/551
 [pr-550]: https://github.com/pakyow/pakyow/pull/550

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `fix` **Load comment-only files.**
+
+    *Related links:*
+    - [Pull Request #555][pr-555]
+
   * `fix` **Load files with the expected module nesting.**
 
     *Related links:*
@@ -825,6 +830,7 @@
     *Related links:*
     - [Pull Request #338][pr-338]
 
+[pr-555]: https://github.com/pakyow/pakyow/pull/555
 [pr-554]: https://github.com/pakyow/pakyow/pull/554
 [pr-553]: https://github.com/pakyow/pakyow/pull/553
 [pr-551]: https://github.com/pakyow/pakyow/pull/551

--- a/core/lib/pakyow/commands/boot.rb
+++ b/core/lib/pakyow/commands/boot.rb
@@ -10,10 +10,6 @@ command :boot, boot: false do
 
   option :mounts, "The application(s) to mount", default: -> { Pakyow.config.mounts }
 
-  verify do
-    optional :env
-  end
-
   action do
     Pakyow.config.mounts = case @mounts
     when String

--- a/core/lib/pakyow/commands/create.rb
+++ b/core/lib/pakyow/commands/create.rb
@@ -18,7 +18,7 @@ command :create, global: true do
       Pakyow.generator(:project, template.to_sym)
     end
 
-    generator.generate(@path, name: Generator.generatable_name(File.basename(@path)))
+    generator.generate(@path, name: Pakyow::Generator.generatable_name(File.basename(@path)))
 
     require "pakyow/support/cli/style"
     @cli.feedback.puts <<~OUTPUT

--- a/core/lib/pakyow/commands/create/application.rb
+++ b/core/lib/pakyow/commands/create/application.rb
@@ -43,7 +43,7 @@ command :create, :application do
       Pakyow.generator(:application, template.to_sym)
     end
 
-    generatable_name = Generator.generatable_name(@name)
+    generatable_name = Pakyow::Generator.generatable_name(@name)
     generator.generate(multiapp_path.join(generatable_name), name: generatable_name, path: @path)
   end
 

--- a/core/lib/pakyow/generators/application.rb
+++ b/core/lib/pakyow/generators/application.rb
@@ -25,6 +25,6 @@ generator :application do
   end
 
   def human_name
-    Support.inflector.humanize(name)
+    Pakyow::Support.inflector.humanize(name)
   end
 end

--- a/core/lib/pakyow/loader/context.rb
+++ b/core/lib/pakyow/loader/context.rb
@@ -1,9 +1,98 @@
 # frozen_string_literal: true
 
+class PakyowToplevel < BasicObject
+  def self.const_missing(name)
+    ::Object.const_get(name)
+  end
+
+  def self.load(code, path, lineno)
+    eval(code, binding, path, lineno)
+  end
+
+  def self.method_missing(name, *args, **kwargs, &block)
+    context = ::Thread.current[:__pw_loader_context]
+
+    if context.target.ancestors.include?(::Pakyow::Support::Definable) && context.target.__definable_registries.key?(name)
+      inner_source = if block
+        inner_source(block.source)
+      else
+        "\n"
+      end
+
+      defined = context.target.public_send(name, *args, **kwargs) do
+        # Intentionally blank.
+      end
+
+      if defined.name.nil?
+        defined.class_eval(&block)
+      else
+        code_to_eval = case defined
+        when ::Class
+          "#{context.comments}class #{defined}#{inner_source}end"
+        when ::Module
+          "#{context.comments}module #{defined}#{inner_source}end"
+        end
+
+        eval(code_to_eval, TOPLEVEL_BINDING, context.path, 1)
+      end
+    else
+      context.target.public_send(name, *args, **kwargs, &block)
+    end
+  end
+
+  def self.respond_to_missing?(name, include_private = false)
+    ::Thread.current[:__pw_loader_context].target.respond_to?(name, include_private) || super
+  end
+
+  TRAILING_WHITESPACE = /(\s+)$/
+
+  def self.inner_source(source)
+    trailing_whitespace = if (match = source.match(TRAILING_WHITESPACE))
+      match[1]
+    else
+      ""
+    end
+
+    source = source.rstrip
+
+    inner_source = if source.end_with?("end")
+      scan_to_complete_expression(source, "do", -4)
+    elsif source.end_with?("}")
+      scan_to_complete_expression(source, "{", -2)
+    else
+      # We should never get here, but raise an error just to be clear.
+      #
+      raise "could not parse inner source of `#{@path}'"
+    end
+
+    inner_source + trailing_whitespace
+  end
+
+  def self.scan_to_complete_expression(source, matcher, ending_offset)
+    source.scan(matcher) do
+      offset = $~.offset(0)[0] + 2
+
+      possible_inner_source = source[offset..ending_offset]
+
+      if ::MethodSource.complete_expression?(possible_inner_source)
+        return possible_inner_source
+      end
+    rescue ::SyntaxError
+      # It's fine to eat these since we're just trying to find a valid expression.
+    end
+
+    # We should never get here, but raise an error just to be clear.
+    #
+    raise "could not find a complete expression for `#{matcher}' in `#{@path}'"
+  end
+end
+
 module Pakyow
   class Loader
     # @api private
     class Context
+      attr_reader :target, :path, :comments
+
       def initialize(target, code, path)
         @target, @path = target, path
 
@@ -11,41 +100,11 @@ module Pakyow
       end
 
       def load
-        eval(@uncommented_code, binding, @path, @comments.lines.count + 1)
-      end
+        Thread.current[:__pw_loader_context] = self
 
-      def method_missing(name, *args, **kwargs, &block)
-        inner_source = if block
-          inner_source(block.source)
-        else
-          "\n"
-        end
-
-        local_comments = @comments
-        local_path = @path
-
-        @target.public_send(name, *args, **kwargs) do
-          if self.name
-            code_to_eval = case self
-            when Class
-              <<~CODE
-                #{local_comments}class #{self}#{inner_source}end
-              CODE
-            when Module
-              <<~CODE
-                #{local_comments}module #{self}#{inner_source}end
-              CODE
-            end
-
-            eval(code_to_eval, binding, local_path, 1)
-          else
-            class_eval(&block)
-          end
-        end
-      end
-
-      def respond_to_missing?(name, include_private = false)
-        @target.respond_to?(name, include_private) || super
+        PakyowToplevel.load(@uncommented_code, @path, @comments.lines.count + 1)
+      ensure
+        Thread.current[:__pw_loader_context] = nil
       end
 
       private def indent(code)
@@ -74,48 +133,6 @@ module Pakyow
         end
 
         nil
-      end
-
-      TRAILING_WHITESPACE = /(\s+)$/
-
-      private def inner_source(source)
-        trailing_whitespace = if (match = source.match(TRAILING_WHITESPACE))
-          match[1]
-        else
-          ""
-        end
-
-        source = source.rstrip
-
-        inner_source = if source.end_with?("end")
-          scan_to_complete_expression(source, "do", -4)
-        elsif source.end_with?("}")
-          scan_to_complete_expression(source, "{", -2)
-        else
-          # We should never get here, but raise an error just to be clear.
-          #
-          raise "could not parse inner source of `#{@path}'"
-        end
-
-        inner_source + trailing_whitespace
-      end
-
-      private def scan_to_complete_expression(source, matcher, ending_offset)
-        source.scan(matcher) do
-          offset = $~.offset(0)[0] + 2
-
-          possible_inner_source = source[offset..ending_offset]
-
-          if MethodSource.complete_expression?(possible_inner_source)
-            return possible_inner_source
-          end
-        rescue SyntaxError
-          # It's fine to eat these since we're just trying to find a valid expression.
-        end
-
-        # We should never get here, but raise an error just to be clear.
-        #
-        raise "could not find a complete expression for `#{matcher}' in `#{@path}'"
       end
     end
   end

--- a/core/lib/pakyow/loader/context.rb
+++ b/core/lib/pakyow/loader/context.rb
@@ -114,12 +114,14 @@ module Pakyow
       private def split_comments(code)
         lines = code.lines
 
-        line_number = first_nonblank_or_commented_line_number(lines)
-
-        if lines.empty? || line_number == 1
-          ["", code]
+        if (line_number = first_nonblank_or_commented_line_number(lines))
+          if lines.empty? || line_number == 1
+            ["", code]
+          else
+            [lines[0...(line_number - 1)].join, lines[(line_number - 1)..].join]
+          end
         else
-          [lines[0...(line_number - 1)].join, lines[(line_number - 1)..].join]
+          [lines.join, ""]
         end
       end
 

--- a/core/spec/expectations/commands/boot/help
+++ b/core/spec/expectations/commands/boot/help
@@ -5,9 +5,9 @@
 
 [1mOPTIONS[0m
   -e, --env=env              [33mThe environment to run this command under[0m
+  -c, --config=config        [33mPath to the environment config file (default: config/environment)[0m
       --host=host            [33mThe host the server runs on (default: localhost)[0m
   -p, --port=port            [33mThe port the server runs on (default: 3000)[0m
   -f, --formation=formation  [33mThe formation to boot (default: all)[0m
   -m, --mounts=mounts        [33mThe application(s) to mount (default: all)[0m
-  -c, --config=config        [33mPath to the environment config file (default: config/environment)[0m
       --debug                [33mShow low-level debugging information[0m

--- a/core/spec/expectations/commands/create/application/help
+++ b/core/spec/expectations/commands/create/application/help
@@ -8,7 +8,7 @@
 
 [1mOPTIONS[0m
   -e, --env=env            [33mThe environment to run this command under[0m
+  -c, --config=config      [33mPath to the environment config file (default: config/environment)[0m
   -p, --path=path          [33mThe mount path for the created application (default: /)[0m
   -t, --template=template  [33mThe template to create the application from (default: default)[0m
-  -c, --config=config      [33mPath to the environment config file (default: config/environment)[0m
       --debug              [33mShow low-level debugging information[0m

--- a/core/spec/expectations/commands/create/help
+++ b/core/spec/expectations/commands/create/help
@@ -8,6 +8,6 @@
 
 [1mOPTIONS[0m
   -e, --env=env            [33mThe environment to run this command under[0m
-  -t, --template=template  [33mThe template to create the project from (default: default)[0m
   -c, --config=config      [33mPath to the environment config file (default: config/environment)[0m
+  -t, --template=template  [33mThe template to create the project from (default: default)[0m
       --debug              [33mShow low-level debugging information[0m

--- a/core/spec/expectations/commands/prototype/help
+++ b/core/spec/expectations/commands/prototype/help
@@ -5,7 +5,7 @@
 
 [1mOPTIONS[0m
   -e, --env=env        [33mThe environment to run this command under[0m
+  -c, --config=config  [33mPath to the environment config file (default: config/environment)[0m
       --host=host      [33mThe host the server runs on (default: localhost)[0m
   -p, --port=port      [33mThe port the server runs on (default: 3000)[0m
-  -c, --config=config  [33mPath to the environment config file (default: config/environment)[0m
       --debug          [33mShow low-level debugging information[0m

--- a/core/spec/integration/loader/definable_state_spec.rb
+++ b/core/spec/integration/loader/definable_state_spec.rb
@@ -69,6 +69,16 @@ RSpec.describe "loading definable state" do
     end
   end
 
+  describe "comments only definition" do
+    let(:loader_path) {
+      File.expand_path("../support/definable_state/comments_only.rb", __FILE__)
+    }
+
+    it "defines correctly" do
+      expect(target.state.definitions).to be_empty
+    end
+  end
+
   describe "unnamed target" do
     let(:target) {
       Class.new(super())

--- a/core/spec/integration/loader/lexical_scope_spec.rb
+++ b/core/spec/integration/loader/lexical_scope_spec.rb
@@ -33,6 +33,16 @@ RSpec.describe "loading in the correct lexical scope" do
     end
   end
 
+  describe "nesting" do
+    let(:loader_path) {
+      File.expand_path("../support/lexical_scope/nesting.rb", __FILE__)
+    }
+
+    it "is correctly nested" do
+      expect(target.state(:foo).nesting).to eq([Target::States::Foo])
+    end
+  end
+
   context "with brackets" do
     let(:loader_path) {
       File.expand_path("../support/lexical_scope/brackets.rb", __FILE__)

--- a/core/spec/integration/loader/support/definable_state/comments_only.rb
+++ b/core/spec/integration/loader/support/definable_state/comments_only.rb
@@ -1,0 +1,1 @@
+# frozen_string_literal: true

--- a/core/spec/integration/loader/support/lexical_scope/nesting.rb
+++ b/core/spec/integration/loader/support/lexical_scope/nesting.rb
@@ -1,0 +1,5 @@
+state :foo do
+  def self.nesting
+    Module.nesting
+  end
+end

--- a/frameworks/data/spec/expectations/commands/bootstrap/help
+++ b/frameworks/data/spec/expectations/commands/bootstrap/help
@@ -5,7 +5,7 @@
 
 [1mOPTIONS[0m
   -e, --env=env                [33mThe environment to run this command under[0m
+  -c, --config=config          [33mPath to the environment config file (default: config/environment)[0m
       --adapter=adapter        [33mThe database adapter (default: sql)[0m
   -c, --connection=connection  [33mThe database connection (default: default)[0m
-  -c, --config=config          [33mPath to the environment config file (default: config/environment)[0m
       --debug                  [33mShow low-level debugging information[0m

--- a/frameworks/data/spec/expectations/commands/create/help
+++ b/frameworks/data/spec/expectations/commands/create/help
@@ -5,7 +5,7 @@
 
 [1mOPTIONS[0m
   -e, --env=env                [33mThe environment to run this command under[0m
+  -c, --config=config          [33mPath to the environment config file (default: config/environment)[0m
       --adapter=adapter        [33mThe database adapter (default: sql)[0m
   -c, --connection=connection  [33mThe database connection (default: default)[0m
-  -c, --config=config          [33mPath to the environment config file (default: config/environment)[0m
       --debug                  [33mShow low-level debugging information[0m

--- a/frameworks/data/spec/expectations/commands/drop/help
+++ b/frameworks/data/spec/expectations/commands/drop/help
@@ -5,7 +5,7 @@
 
 [1mOPTIONS[0m
   -e, --env=env                [33mThe environment to run this command under[0m
+  -c, --config=config          [33mPath to the environment config file (default: config/environment)[0m
       --adapter=adapter        [33mThe database adapter (default: sql)[0m
   -c, --connection=connection  [33mThe database connection (default: default)[0m
-  -c, --config=config          [33mPath to the environment config file (default: config/environment)[0m
       --debug                  [33mShow low-level debugging information[0m

--- a/frameworks/data/spec/expectations/commands/finalize/help
+++ b/frameworks/data/spec/expectations/commands/finalize/help
@@ -5,7 +5,7 @@
 
 [1mOPTIONS[0m
   -e, --env=env                [33mThe environment to run this command under[0m
+  -c, --config=config          [33mPath to the environment config file (default: config/environment)[0m
       --adapter=adapter        [33mThe database adapter (default: sql)[0m
   -c, --connection=connection  [33mThe database connection (default: default)[0m
-  -c, --config=config          [33mPath to the environment config file (default: config/environment)[0m
       --debug                  [33mShow low-level debugging information[0m

--- a/frameworks/data/spec/expectations/commands/migrate/help
+++ b/frameworks/data/spec/expectations/commands/migrate/help
@@ -5,7 +5,7 @@
 
 [1mOPTIONS[0m
   -e, --env=env                [33mThe environment to run this command under[0m
+  -c, --config=config          [33mPath to the environment config file (default: config/environment)[0m
       --adapter=adapter        [33mThe database adapter (default: sql)[0m
   -c, --connection=connection  [33mThe database connection (default: default)[0m
-  -c, --config=config          [33mPath to the environment config file (default: config/environment)[0m
       --debug                  [33mShow low-level debugging information[0m

--- a/frameworks/data/spec/expectations/commands/reset/help
+++ b/frameworks/data/spec/expectations/commands/reset/help
@@ -5,7 +5,7 @@
 
 [1mOPTIONS[0m
   -e, --env=env                [33mThe environment to run this command under[0m
+  -c, --config=config          [33mPath to the environment config file (default: config/environment)[0m
       --adapter=adapter        [33mThe database adapter (default: sql)[0m
   -c, --connection=connection  [33mThe database connection (default: default)[0m
-  -c, --config=config          [33mPath to the environment config file (default: config/environment)[0m
       --debug                  [33mShow low-level debugging information[0m

--- a/frameworks/data/spec/spec_helper.rb
+++ b/frameworks/data/spec/spec_helper.rb
@@ -1,3 +1,6 @@
+require "timeout"
+require "concurrent/executor/thread_pool_executor"
+
 start_simplecov do
   lib_path = File.expand_path("../../lib", __FILE__)
 


### PR DESCRIPTION
`Pakyow::Loader` has been loading files with a `Module.nesting` that includes `Pakyow`. This causes all kinds of unexpected behavior, such as constant lookups resolving to objects in the `Pakyow` namespace from application code.

This PR changes the loading approach to behave expectedly. Here's how it works:

1. Define the constant for the new object.
2. Build a string containing the internal source for the new object.
3. Eval the object source in context of `TOPLEVEL_BINDING`.

Step 3 is what this PR changes. Previously `eval` happened in context of the `Pakyow::Loader::Context` instance binding.

There's a secondary change in that loading happens in the new `PakyowToplevel` lexical scope. This change allows constant lookup to behave correctly for _anonymous state_, delegating all constant lookups to `::Object`.