### PR TITLE
Load comment-only files

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `fix` **Load comment-only files.**
+
+    *Related links:*
+    - [Pull Request #555][pr-555]
+
   * `fix` **Load files with the expected module nesting.**
 
     *Related links:*
@@ -825,6 +830,7 @@
     *Related links:*
     - [Pull Request #338][pr-338]
 
+[pr-555]: https://github.com/pakyow/pakyow/pull/555
 [pr-554]: https://github.com/pakyow/pakyow/pull/554
 [pr-553]: https://github.com/pakyow/pakyow/pull/553
 [pr-551]: https://github.com/pakyow/pakyow/pull/551

--- a/core/lib/pakyow/loader/context.rb
+++ b/core/lib/pakyow/loader/context.rb
@@ -114,12 +114,14 @@ module Pakyow
       private def split_comments(code)
         lines = code.lines
 
-        line_number = first_nonblank_or_commented_line_number(lines)
-
-        if lines.empty? || line_number == 1
-          ["", code]
+        if (line_number = first_nonblank_or_commented_line_number(lines))
+          if lines.empty? || line_number == 1
+            ["", code]
+          else
+            [lines[0...(line_number - 1)].join, lines[(line_number - 1)..].join]
+          end
         else
-          [lines[0...(line_number - 1)].join, lines[(line_number - 1)..].join]
+          [lines.join, ""]
         end
       end
 

--- a/core/spec/integration/loader/definable_state_spec.rb
+++ b/core/spec/integration/loader/definable_state_spec.rb
@@ -69,6 +69,16 @@ RSpec.describe "loading definable state" do
     end
   end
 
+  describe "comments only definition" do
+    let(:loader_path) {
+      File.expand_path("../support/definable_state/comments_only.rb", __FILE__)
+    }
+
+    it "defines correctly" do
+      expect(target.state.definitions).to be_empty
+    end
+  end
+
   describe "unnamed target" do
     let(:target) {
       Class.new(super())

--- a/core/spec/integration/loader/support/definable_state/comments_only.rb
+++ b/core/spec/integration/loader/support/definable_state/comments_only.rb
@@ -1,0 +1,1 @@
+# frozen_string_literal: true


### PR DESCRIPTION
Fixes a bug rebuilding the source for loaded files when the file only contained comments.