### PR TITLE
Improve the reliability of service restarts

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     branches:
     - master
-  push:
-  repository_dispatch:
 
 jobs:
   smoke-tests:

--- a/.github/workflows/standardrb.yml
+++ b/.github/workflows/standardrb.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     branches:
     - master
-  push:
-  repository_dispatch:
 
 jobs:
   test-ruby:

--- a/.github/workflows/test-node.yml
+++ b/.github/workflows/test-node.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     branches:
     - master
-  push:
-  repository_dispatch:
 
 jobs:
   test-node:

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     branches:
     - master
-  push:
-  repository_dispatch:
 
 jobs:
   test-ruby:

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `fix` **Improve the reliability of service restarts.**
+
+    *Related links:*
+    - [Pull Request #558][pr-558]
+
   * `fix` **Report errors to houston only when they are unhandled.**
 
     *Related links:*
@@ -840,6 +845,7 @@
     *Related links:*
     - [Pull Request #338][pr-338]
 
+[pr-558]: https://github.com/pakyow/pakyow/pull/558
 [pr-557]: https://github.com/pakyow/pakyow/pull/557
 [pr-556]: https://github.com/pakyow/pakyow/pull/556
 [pr-555]: https://github.com/pakyow/pakyow/pull/555

--- a/core/lib/pakyow/runnable/container/strategies/base.rb
+++ b/core/lib/pakyow/runnable/container/strategies/base.rb
@@ -93,13 +93,11 @@ module Pakyow
                     @failed = true
                   end
 
-                  @services.delete(service)
-
-                  if !stopping? && container.running? && service.restartable?
-                    if service.status.success?
-                      manage_service(service)
-                    else
+                  if @services.delete(service) && container.running? && service.restartable? && !stopping?
+                    if service.status.failed?
                       backoff_service(service)
+                    else
+                      manage_service(service)
                     end
                   end
                 end

--- a/core/lib/pakyow/runnable/container/strategies/forked.rb
+++ b/core/lib/pakyow/runnable/container/strategies/forked.rb
@@ -36,14 +36,6 @@ module Pakyow
               service.status.success!
             end
 
-            # This seems to resolve an issue where services aren't identified as exited fast enough
-            # in `watch_forks`, so shutting down at the same time a service exits can cause the
-            # service to appear failed when it in fact succeeeded.
-            #
-            await do
-              @notifier.notify(:exit, service: service.id, status: service.status)
-            end
-
             ::Process.exit(service.status.success?)
           end
 

--- a/core/lib/pakyow/runnable/service.rb
+++ b/core/lib/pakyow/runnable/service.rb
@@ -199,12 +199,14 @@ module Pakyow
         end
 
         await do
-          async do
+          future = async do
             perform
           rescue => error
             Pakyow.houston(error)
 
             failed!
+          ensure
+            future&.cancel
           end
 
           @__blocked = false


### PR DESCRIPTION
Solves two problems related to service restarts:

1. Automatically cancels any async work that was not waited on by `Service#perform`. This means that a service is responsible for blocking in its `perform` method—if `perform` returns the container assumes it is finished.
2. Prevents multiple exit notifications for forked services. This was causing exponential growth in services in some cases.