### PR TITLE
Don't attempt to coerce nils in the verifier

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `fix` **Don't attempt to coerce nils in the verifier.**
+
+    *Related links:*
+    - [Pull Request #559][pr-559]
+
   * `fix` **Improve the reliability of service restarts.**
 
     *Related links:*
@@ -845,6 +850,7 @@
     *Related links:*
     - [Pull Request #338][pr-338]
 
+[pr-559]: https://github.com/pakyow/pakyow/pull/559
 [pr-558]: https://github.com/pakyow/pakyow/pull/558
 [pr-557]: https://github.com/pakyow/pakyow/pull/557
 [pr-556]: https://github.com/pakyow/pakyow/pull/556

--- a/core/lib/pakyow/verifier.rb
+++ b/core/lib/pakyow/verifier.rb
@@ -170,9 +170,9 @@ module Pakyow
       if !value.nil? && @allowable_keys.any?
         Array.ensure(value).each do |each_value|
           @allowable_keys.each do |allowable_key|
-            # Typecase the value for each key.
+            # Coerce the value for each key.
             #
-            if each_value.key?(allowable_key)
+            unless each_value[allowable_key].nil?
               value_for_key = each_value[allowable_key]
 
               if (type = @types[allowable_key])

--- a/core/spec/unit/verifier_spec.rb
+++ b/core/spec/unit/verifier_spec.rb
@@ -38,26 +38,57 @@ RSpec.describe Pakyow::Verifier do
     end
   end
 
-  describe "normalization" do
-    let :verifier do
-      described_class.new do
-        required :foo, :datetime
+  describe "coercion" do
+    context "type is defined for a required key" do
+      let :verifier do
+        described_class.new do
+          required :foo, :datetime
+        end
       end
-    end
 
-    let :values do
-      {
-        foo: "2019-06-14 09:15:39 -0700"
-      }
-    end
+      let :values do
+        {
+          foo: "2019-06-14 09:15:39 -0700"
+        }
+      end
 
-    context "type is defined for a key" do
-      it "typecasts the value" do
+      it "coerces the value" do
         expect(values[:foo]).to be_instance_of(Time)
       end
 
       it "represents the correct value" do
         expect(values[:foo].to_s).to eq("2019-06-14 09:15:39 -0700")
+      end
+    end
+
+    context "type is defined for an optional key" do
+      let :verifier do
+        described_class.new do
+          optional :foo, :decimal, default: 0
+        end
+      end
+
+      context "value is missing" do
+        let :values do
+          {
+          }
+        end
+
+        it "uses the default value" do
+          expect(values[:foo]).to eq(0)
+        end
+      end
+
+      context "value is nil" do
+        let :values do
+          {
+            foo: nil
+          }
+        end
+
+        it "uses the default value" do
+          expect(values[:foo]).to eq(0)
+        end
       end
     end
   end


### PR DESCRIPTION
This allows a fallback to a default value even if `nil` cannot be coerced into the defined type.