### PR TITLE
Return mounted app after environment setup

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.1.0 (unreleased)
 
+  * `fix` **Return mounted app after environment setup.**
+
+    *Related links:*
+    - [Pull Request #563][pr-563]
+
   * `fix` **Don't attempt to coerce nils in the verifier.**
 
     *Related links:*
@@ -850,6 +855,7 @@
     *Related links:*
     - [Pull Request #338][pr-338]
 
+[pr-563]: https://github.com/pakyow/pakyow/pull/563
 [pr-559]: https://github.com/pakyow/pakyow/pull/559
 [pr-558]: https://github.com/pakyow/pakyow/pull/558
 [pr-557]: https://github.com/pakyow/pakyow/pull/557

--- a/core/lib/pakyow/environment.rb
+++ b/core/lib/pakyow/environment.rb
@@ -552,7 +552,7 @@ module Pakyow
     def app(app_name, path: "/", without: [], only: nil, mount: true, &block)
       app_name = app_name.to_sym
 
-      if booted?
+      if setup?
         @apps.find { |app|
           app.config.name == app_name
         }

--- a/core/spec/unit/environment_spec.rb
+++ b/core/spec/unit/environment_spec.rb
@@ -694,13 +694,11 @@ RSpec.describe Pakyow do
       Pakyow.app :test_foo, path: "/foo"
       Pakyow.app :test_bar, path: "/bar"
       Pakyow.app :test_baz, path: "/baz"
-
-      Pakyow.boot
     end
 
-    context "environment has booted" do
+    context "environment has been setup" do
       before do
-        Pakyow.setup(env: :test).boot
+        Pakyow.setup(env: :test).setup
       end
 
       it "returns an app instance" do


### PR DESCRIPTION
Mounted apps are tracked after `setup`, so make them available at that point for lookups.